### PR TITLE
Minor corrections to deepseek-v3 recipe

### DIFF
--- a/DeepSeek/DeepSeek-V3.md
+++ b/DeepSeek/DeepSeek-V3.md
@@ -18,7 +18,7 @@ uv pip install -U vllm --torch-backend auto
 vllm serve deepseek-ai/DeepSeek-R1-0528 \
   --trust-remote-code \
   --tensor-parallel-size 8 \
-  --enable_expert_parallel
+  --enable-expert-parallel
 ```
 
 Additional flags:
@@ -39,8 +39,8 @@ export VLLM_USE_FLASHINFER_MOE_FP4=1
 # The model is runnable on 4 or 8 GPUs, here we show usage of 4.
 CUDA_VISIBLE_DEVICES=0,1,2,3 vllm serve nvidia/DeepSeek-R1-FP4 \
   --trust-remote-code \
-  --tensor-parallel-size 4
-  --enable_expert_parallel
+  --tensor-parallel-size 4 \
+  --enable-expert-parallel
 ```
 
 ## Benchmarking


### PR DESCRIPTION
This cleans up a couple minor things with the DS-v3 recipe:

1. Corrects `-` instead of `_` for command line argument
2. Adds missing line continuation in command line example