### PR TITLE
Update GLM-4.5.md

### DIFF
--- a/GLM/GLM-4.5.md
+++ b/GLM/GLM-4.5.md
@@ -24,8 +24,8 @@ run tensor-parallel like this:
 # Start server with FP8 model on 4 GPUs. the model can also changed to BF16 as zai-org/GLM-4.5-Air
 vllm serve zai-org/GLM-4.5-Air-FP8 \
      --tensor-parallel-size 8 \
-     --tool-call-parser glm45 \
-     --reasoning-parser glm45 \
+     --tool-call-parser glm4_moe \
+     --reasoning-parser glm4_moe \
      --enable-auto-tool-choice
 ```
 


### PR DESCRIPTION
the value for the tool and reasoning arguments changed in mainline vllm from glm45 to glm4_moe. Otherwise you get:

vllm serve: error: argument --tool-call-parser: invalid choice: 'glm45' (choose from deepseek_v3, glm4_moe, granite-20b-fc, granite, hermes, hunyuan_a13b, internlm, jamba, kimi_k2, llama4_pythonic, llama4_json, llama3_json, minimax, mistral, phi4_mini_json, pythonic, qwen3_coder, xlam)