### PR TITLE
docs: Add missing `--enable-expert-parallel` flag for Qwen3-Coder BF16

### DIFF
--- a/Qwen/Qwen3-Coder-480B-A35B.md
+++ b/Qwen/Qwen3-Coder-480B-A35B.md
@@ -18,8 +18,9 @@ uv pip install -U vllm --torch-backend auto
 
 ```bash
 vllm serve Qwen/Qwen3-Coder-480B-A35B-Instruct \
-  --tensor-parallel-size 8 \
   --max-model-len 32000 \
+  --enable-expert-parallel \
+  --tensor-parallel-size 8 \
   --enable-auto-tool-choice \
   --tool-call-parser qwen3_coder
 ```


### PR DESCRIPTION
Hey there,

I noticed a couple of small inconsistencies in the Qwen3-Coder launch commands and unified them.

- The `--enable-expert-parallel` flag was missing from the BF16 example, so I added it.
- The argument order was different between the BF16 and FP8 commands, so I aligned them for better readability.

This looks like a simple oversight, so I've added it to the BF16 command for consistency and to make sure users don't miss this optimization.

If this was left out on purpose for some reason, just let me know! Happy to close this or change it to an explanatory note.

Thanks!

https://github.com/vllm-project/recipes/blob/c1755cd8df689927364264fa8a7eed57d062e43b/Qwen/Qwen3-Coder-480B-A35B.md?plain=1#L17-L25

https://github.com/vllm-project/recipes/blob/c1755cd8df689927364264fa8a7eed57d062e43b/Qwen/Qwen3-Coder-480B-A35B.md?plain=1#L27-L32