### PR TITLE
[gpt-oss] Structure output is supported in chat completion API

### DIFF
--- a/OpenAI/GPT-OSS.md
+++ b/OpenAI/GPT-OSS.md
@@ -262,8 +262,8 @@ Meaning:
 | Response API | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Response API with Background Mode | ✅ | ✅ | ✅ | ❌ | ✅ |
 | Response API with Streaming | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Chat Completion API | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Chat Completion API with Streaming | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Chat Completion API | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Chat Completion API with Streaming | ✅ | ✅ | ❌ | ❌ | ❌ |
 
 
 If you want to use offline inference, you can treat vLLM as a token-in-token-out service and pass in tokens that are already formatted with Harmony.


### PR DESCRIPTION
I think structure output is supported in gpt-oss chat completion API. I ran `examples/online_serving/structured_outputs/structured_outputs.py` and it works.