### PR TITLE
Add Function Calling to qwen3-next

### DIFF
--- a/Qwen/Qwen3-Next.md
+++ b/Qwen/Qwen3-Next.md
@@ -89,6 +89,14 @@ You should see the following information printed in the server log. This indicat
 
 vLLM supports multi-parallel groups. You can refer to [Data Parallel Deployment documentation](https://docs.vllm.ai/en/latest/serving/data_parallel_deployment.html) and try parallel combinations that are more suitable for this model.
 
+### Function calling
+
+vLLM also supports calling user-defined functions. Make sure to run your Qwen3-Next models with the following arguments.
+
+```bash
+vllm serve ... --tool-call-parser hermes --enable-auto-tool-choice
+```
+
 ### Known limitations
 
 - Qwen3-Next currently does not support automatic prefix caching.


### PR DESCRIPTION
Add Function Calling to qwen3-next


Test:

```
# VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct -tp 4  --max-model-len 26214 --enable-auto-tool-choice --tool-call-parser hermes

```

Use the official vLLM [example](https://github.com/vllm-project/vllm/blob/main/examples/online_serving/openai_chat_completion_client_with_tools.py).

```
# python openai_chat_completion_client_with_tools.py
....
...
tool_to_call result:  The weather in Dallas, Texas is 85 degrees fahrenheit. It is partly cloudly, with highs in the 90's.
...
```