### PR TITLE
Add function calling support to DeepSeek-V3.1 usage guide.

### DIFF
--- a/DeepSeek/DeepSeek-V3_1.md
+++ b/DeepSeek/DeepSeek-V3_1.md
@@ -28,7 +28,7 @@ vllm serve deepseek-ai/DeepSeek-V3.1 \
 
 ### Function calling
 
-vLLM also supports calling user-defined functions. Make sure to run your DeepSeek-V3.1 models with the following arguments.
+vLLM also supports calling user-defined functions. Make sure to run your DeepSeek-V3.1 models with the following arguments. The example file is included in the official container and can be downloaded [here](https://github.com/vllm-project/vllm/blob/main/examples/tool_chat_template_deepseekv31.jinja)
 
 ```bash
 vllm serve ... 


### PR DESCRIPTION
This pull request updates the documentation for running DeepSeek-V3.1 models with vLLM, specifically adding instructions for enabling function calling support. The main change is a new section describing how to configure vLLM to support user-defined functions.

Function calling support:

* Added a "Function calling" section to `DeepSeek/DeepSeek-V3_1.md` with instructions for enabling function calling in vLLM using DeepSeek-V3.1 models, including the necessary command-line arguments (`--enable-auto-tool-choice`, `--tool-call-parser deepseek_v31`, and `--chat-template /models/DeepSeek-V3.1/assets/chat_template.jinja`).

This is based on this [PR](https://github.com/vllm-project/vllm/pull/23454).