### PR TITLE
Fixed a typo in vLLM command argument

### DIFF
--- a/Qwen/Qwen3-VL.md
+++ b/Qwen/Qwen3-VL.md
@@ -48,7 +48,7 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
 ```bash
 vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
   --tensor-parallel-size 4 \
-  ----limit-mm-per-prompt.video 0 \
+  --limit-mm-per-prompt.video 0 \
   --async-scheduling \
   --gpu-memory-utilization 0.95 \
   --max-num-seqs 128


### PR DESCRIPTION
Hi, the `--limit-mm-per-prompt.video` flag was incorrectly prefixed with `----` instead of `--`.