### PR TITLE
fix(docs): correct DeepSeek-OCR logits_processors example command

### DIFF
--- a/DeepSeek/DeepSeek-OCR.md
+++ b/DeepSeek/DeepSeek-OCR.md
@@ -69,7 +69,7 @@ for output in model_outputs:
 In this guide, we demonstrate how to set up DeepSeek-OCR for online OCR serving with OpenAI compatible API server.
 
 ```bash
-vllm serve deepseek-ai/DeepSeek-OCR --logits_processors vllm.model_executor.models.deepseek_ocr.NGramPerReqLogitsProcessor --no-enable-prefix-caching --mm-processor-cache-gb 0
+vllm serve deepseek-ai/DeepSeek-OCR --logits_processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor --no-enable-prefix-caching --mm-processor-cache-gb 0
 ```
 
 ```python3


### PR DESCRIPTION
📝 Summary

This PR fixes an incorrect command example for serving DeepSeek-OCR using vllm.

🔧 Changes

Corrected the --logits_processors import path

Replaced . with : in the processor reference

Ensured consistency with other model examples in documentation

❌ Before
vllm serve deepseek-ai/DeepSeek-OCR \
  --logits_processors vllm.model_executor.models.deepseek_ocr.NGramPerReqLogitsProcessor \
  --no-enable-prefix-caching \
  --mm-processor-cache-gb 0

✅ After
vllm serve deepseek-ai/DeepSeek-OCR \
  --logits_processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor \
  --no-enable-prefix-caching \
  --mm-processor-cache-gb 0

📚 Reason

The --logits_processors argument requires a colon (:) to separate the module and class name.
Using a dot (.) results in an invalid import path.

✅ Checklist

 Fixed incorrect syntax

 Verified corrected command locally

 Matches style and format of other documentation examples

🧩 Related

No issue link, minor documentation correction.