### PR TITLE
fix(docs): update DeepGEMM usage instructions for H100 GPUs and MiniMax-M2

### DIFF
--- a/MiniMax/MiniMax-M2.md
+++ b/MiniMax/MiniMax-M2.md
@@ -104,4 +104,4 @@ P99 ITL (ms):                            83.48
 
 ### DeepGEMM Usage
 
-vLLM has DeepGEMM enabled by default, follow the [setup instructions](https://github.com/vllm-project/vllm/blob/v0.11.0/benchmarks/kernels/deepgemm/README.md#setup) to install it. However, on H20 GPUs, we've found that disabling DeepGEMM yields better performance for this model. To disable `DeepGEMM`, set the environment variable `VLLM_USE_DEEP_GEMM=0`.
+vLLM has DeepGEMM enabled by default, follow the [setup instructions](https://github.com/vllm-project/vllm/blob/v0.11.0/benchmarks/kernels/deepgemm/README.md#setup) to install it. However, on H100 and H20 GPUs, we've found that disabling DeepGEMM yields better performance for this model. To disable `DeepGEMM`, set the environment variable `VLLM_USE_DEEP_GEMM=0`.


### PR DESCRIPTION
## Performance Improvements

Based on comprehensive benchmark testing with 100 requests at concurrency level 10, disabling DeepGEMM shows substantial performance gains:

### Key Metrics Comparison

| Metric | With DeepGEMM | Without DeepGEMM | Improvement |
|--------|---------------|------------------|-------------|
| **Output Token Throughput** | 288.31 tok/s | 566.84 tok/s | **+96.6%** |
| **Peak Output Throughput** | 320.00 tok/s | 650.00 tok/s | **+103.1%** |
| **Request Throughput** | 0.30 req/s | 0.60 req/s | **+100%** |
| **Total Token Throughput** | 907.58 tok/s | 1798.96 tok/s | **+98.2%** |
| **Benchmark Duration** | 330.71s | 166.22s | **-49.7%** |

### Latency Metrics

| Metric | With DeepGEMM | Without DeepGEMM | Improvement |
|--------|---------------|------------------|-------------|
| **Mean TPOT** | 32.21 ms | 16.39 ms | **-49.1%** |
| **Median TPOT** | 32.22 ms | 16.36 ms | **-49.2%** |
| **P99 TPOT** | 33.43 ms | 17.60 ms | **-47.4%** |
| **Mean ITL** | 32.15 ms | 16.35 ms | **-49.2%** |
| **Median ITL** | 31.87 ms | 15.90 ms | **-50.1%** |
| **P99 ITL** | 33.33 ms | 17.54 ms | **-47.4%** |

### TTFT (Time to First Token)

| Metric | With DeepGEMM | Without DeepGEMM |
|--------|---------------|------------------|
| **Mean TTFT** | 244.24 ms | 258.76 ms |
| **Median TTFT** | 216.79 ms | 161.44 ms |
| **P99 TTFT** | 639.05 ms | 1569.77 ms |

## Detailed Benchmark Results

### Configuration Without DeepGEMM (Recommended)

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             10
Benchmark duration (s):                  166.22
Total input tokens:                      204800
Total generated tokens:                  94218
Request throughput (req/s):              0.60
Output token throughput (tok/s):         566.84
Peak output token throughput (tok/s):    650.00
Peak concurrent requests:                20.00
Total Token throughput (tok/s):          1798.96

---------------Time to First Token----------------
Mean TTFT (ms):                          258.76
Median TTFT (ms):                        161.44
P99 TTFT (ms):                           1569.77

-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.39
Median TPOT (ms):                        16.36
P99 TPOT (ms):                           17.60

---------------Inter-token Latency----------------
Mean ITL (ms):                           16.35
Median ITL (ms):                         15.90
P99 ITL (ms):                            17.54
==================================================
```

### Configuration With DeepGEMM (Baseline)

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             10
Benchmark duration (s):                  330.71
Total input tokens:                      204800
Total generated tokens:                  95346
Request throughput (req/s):              0.30
Output token throughput (tok/s):         288.31
Peak output token throughput (tok/s):    320.00
Peak concurrent requests:                20.00
Total Token throughput (tok/s):          907.58

---------------Time to First Token----------------
Mean TTFT (ms):                          244.24
Median TTFT (ms):                        216.79
P99 TTFT (ms):                           639.05

-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          32.21
Median TPOT (ms):                        32.22
P99 TPOT (ms):                           33.43

---------------Inter-token Latency----------------
Mean ITL (ms):                           32.15
Median ITL (ms):                         31.87
P99 ITL (ms):                            33.33
==================================================
```

## Conclusion

The benchmark results clearly demonstrate that **disabling DeepGEMM on H100 GPUs provides nearly 2x performance improvement** across all key metrics:

-  **2x faster token generation** (TPOT reduced by ~50%)
-  **2x higher throughput** (both request and token throughput doubled)
-  **50% reduction in benchmark duration**
-  **Significantly lower inter-token latency**

While P99 TTFT shows some regression, the overall performance gains in throughput and latency make this change highly beneficial for production workloads on H100 hardware.
