### PR TITLE
Add trust remote code for Kimi-K2-Thinking

### DIFF
--- a/moonshotai/Kimi-K2-Think.md
+++ b/moonshotai/Kimi-K2-Think.md
@@ -28,6 +28,7 @@ run tensor-parallel like this:
 
 ```bash
 vllm serve moonshotai/Kimi-K2-Thinking \
+  --trust-remote-code \
   --tensor-parallel-size 8 \
   --enable-auto-tool-choice \
   --tool-call-parser kimi_k2 \
@@ -114,6 +115,7 @@ vLLM supports [Decode Context Parallel](https://docs.vllm.ai/en/latest/serving/c
 ```bash
 
 vllm serve moonshotai/Kimi-K2-Thinking \
+  --trust-remote-code \
   --tensor-parallel-size 8 \
   --decode-context-parallel-size 8 \
   --enable-auto-tool-choice \


### PR DESCRIPTION
Add trust remote code for Kimi-K2-Thinking

```
(APIServer pid=4) Traceback (most recent call last):
(APIServer pid=4)   File "/usr/local/bin/vllm", line 10, in <module>
(APIServer pid=4)     sys.exit(main())
(APIServer pid=4)              ^^^^^^
(APIServer pid=4)   File "/vllm/vllm/entrypoints/cli/main.py", line 73, in main
(APIServer pid=4)     args.dispatch_function(args)
(APIServer pid=4)   File "/vllm/vllm/entrypoints/cli/serve.py", line 59, in cmd
(APIServer pid=4)     uvloop.run(run_server(args))
(APIServer pid=4)   File "/usr/local/lib/python3.12/site-packages/uvloop/__init__.py", line 96, in run
(APIServer pid=4)     return __asyncio.run(
(APIServer pid=4)            ^^^^^^^^^^^^^^
(APIServer pid=4)   File "/usr/local/lib/python3.12/asyncio/runners.py", line 195, in run
(APIServer pid=4)     return runner.run(main)
(APIServer pid=4)            ^^^^^^^^^^^^^^^^
(APIServer pid=4)   File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
(APIServer pid=4)     return self._loop.run_until_complete(task)
(APIServer pid=4)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=4)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
(APIServer pid=4)   File "/usr/local/lib/python3.12/site-packages/uvloop/__init__.py", line 48, in wrapper
(APIServer pid=4)     return await main
(APIServer pid=4)            ^^^^^^^^^^
(APIServer pid=4)   File "/vllm/vllm/entrypoints/openai/api_server.py", line 2007, in run_server
(APIServer pid=4)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
(APIServer pid=4)   File "/vllm/vllm/entrypoints/openai/api_server.py", line 2026, in run_server_worker
(APIServer pid=4)     async with build_async_engine_client(
(APIServer pid=4)                ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=4)   File "/usr/local/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=4)     return await anext(self.gen)
(APIServer pid=4)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=4)   File "/vllm/vllm/entrypoints/openai/api_server.py", line 195, in build_async_engine_client
(APIServer pid=4)     async with build_async_engine_client_from_engine_args(
(APIServer pid=4)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=4)   File "/usr/local/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=4)     return await anext(self.gen)
(APIServer pid=4)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=4)   File "/vllm/vllm/entrypoints/openai/api_server.py", line 221, in build_async_engine_client_from_engine_args
(APIServer pid=4)     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
(APIServer pid=4)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=4)   File "/vllm/vllm/engine/arg_utils.py", line 1315, in create_engine_config
(APIServer pid=4)     model_config = self.create_model_config()
(APIServer pid=4)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=4)   File "/vllm/vllm/engine/arg_utils.py", line 1170, in create_model_config
(APIServer pid=4)     return ModelConfig(
(APIServer pid=4)            ^^^^^^^^^^^^
(APIServer pid=4)   File "/usr/local/lib/python3.12/site-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
(APIServer pid=4)     s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
(APIServer pid=4) pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
(APIServer pid=4)   Value error, The repository moonshotai/Kimi-K2-Thinking contains custom code which must be executed to correctly load the model. You can inspect the repository content at https://hf.co/moonshotai/Kimi-K2-Thinking .
(APIServer pid=4)  You can inspect the repository content at https://hf.co/moonshotai/Kimi-K2-Thinking.
(APIServer pid=4) Please pass the argument `trust_remote_code=True` to allow custom code to be run. [type=value_error, input_value=ArgsKwargs((), {'model': ...rocessor_plugin': None}), input_type=ArgsKwargs]
(APIServer pid=4)     For further information visit https://errors.pydantic.dev/2.12/v/value_error
```

cc @jeejeelee 