### PR TITLE
Optimize DeepGEMM Configuration for MiniMax-M2 on H100/H20 GPUs

### DIFF
--- a/MiniMax/MiniMax-M2.md
+++ b/MiniMax/MiniMax-M2.md
@@ -106,7 +106,7 @@ P99 ITL (ms):                            83.48
 
 vLLM has DeepGEMM enabled by default, follow the [setup instructions](https://github.com/vllm-project/vllm/blob/v0.11.0/benchmarks/kernels/deepgemm/README.md#setup) to install it.
 
-For optimal performance on H100 and H20 GPUs with this MoE model, we recommend **using DeepGEMM for linear layers while disabling it for MoE expert layers**. This is because DeepGEMM is faster for linear layers but slower for the grouped GEMM operations used in MoE experts.
+For optimal performance on H100 and H20 GPUs with this MoE model, we recommend **using DeepGEMM for linear layers while disabling it for MoE expert layers**. This is because DeepGEMM is faster for linear layers but slower for the grouped GEMM operations used in MoE experts. See detailed results in [PR #120](https://github.com/vllm-project/recipes/pull/120)
 
 To achieve this configuration, set the following environment variable:
 


### PR DESCRIPTION
## Summary

This PR updates the MiniMax-M2 documentation to recommend the optimal DeepGEMM configuration for H100 and H20 GPUs. Following the implementation of `VLLM_MOE_USE_DEEP_GEMM` in [vllm PR #28422](https://github.com/vllm-project/vllm/pull/28422), we've discovered that **using DeepGEMM for linear layers while disabling it for MoE expert layers** provides the best performance.

## Background

This is a follow-up to [PR #112](https://github.com/vllm-project/recipes/pull/112), where reviewers suggested investigating the new `VLLM_MOE_USE_DEEP_GEMM` environment variable introduced in vllm.

The key insight from vllm PR #28422:
- **DeepGEMM is faster for linear layers** but **slower for grouped GEMM operations** used in MoE experts
- The new `VLLM_MOE_USE_DEEP_GEMM` flag allows selective control: keep DeepGEMM for linear layers while using Cutlass BlockScaled GroupedGemm for MoE layers

## Performance Results

Comprehensive benchmark testing on **H100 and H20 GPUs** shows that the hybrid configuration delivers optimal performance across different hardware.

### H100 Performance (TP4, Concurrency 100)

| Configuration | Output Throughput | TPOT | Peak Throughput | Request Throughput |
|--------------|------------------|------|-----------------|-------------------|
| **DeepGEMM + VLLM_MOE_USE_DEEP_GEMM=0**  | **2272.83 tok/s** | **35.67 ms** | **3300 tok/s** | **2.22 req/s** |
| Disable DeepGEMM Completely | 2154.92 tok/s | 37.47 ms | 3200 tok/s | 2.10 req/s |
| DeepGEMM Enabled (Default) | 1448.46 tok/s | 51.10 ms | 2197 tok/s | 1.41 req/s |

### H20 Performance (TP4, Concurrency 100)

Results from [@jeejeelee's testing](https://github.com/vllm-project/recipes/pull/112#issuecomment-2469969653):

| Configuration | Output Throughput | TPOT | Peak Throughput | Request Throughput |
|--------------|------------------|------|-----------------|-------------------|
| **DeepGEMM + VLLM_MOE_USE_DEEP_GEMM=0**  | **1820.68 tok/s** | **49.70 ms** | **2200 tok/s** | **1.78 req/s** |
| Disable DeepGEMM Completely | 1714.18 tok/s | 53.02 ms | 2100 tok/s | 1.67 req/s |
| DeepGEMM Enabled (Default) | 1011.44 tok/s | 92.66 ms | 1200 tok/s | 0.99 req/s |

### Performance Improvements Summary

**On H100 GPUs**, compared to the default DeepGEMM configuration:
-  **+56.9% output token throughput** (1448.46 → 2272.83 tok/s)
-  **-30.2% TPOT latency** (51.10 → 35.67 ms)
-  **+50.2% peak throughput** (2197 → 3300 tok/s)
-  **+57.4% request throughput** (1.41 → 2.22 req/s)
-  **-36.3% benchmark duration** (70.70 → 45.05 seconds)

**On H100 GPUs**, compared to completely disabling DeepGEMM:
-  **+5.5% output token throughput** (2154.92 → 2272.83 tok/s)
-  **-4.8% TPOT latency** (37.47 → 35.67 ms)
-  **+3.1% peak throughput** (3200 → 3300 tok/s)
-  **+5.7% request throughput** (2.10 → 2.22 req/s)

**On H20 GPUs**, compared to the default DeepGEMM configuration:
-  **+80.0% output token throughput** (1011.44 → 1820.68 tok/s)
-  **-46.4% TPOT latency** (92.66 → 49.70 ms)
-  **+83.3% peak throughput** (1200 → 2200 tok/s)
-  **+79.8% request throughput** (0.99 → 1.78 req/s)

**On H20 GPUs**, compared to completely disabling DeepGEMM:
-  **+6.2% output token throughput** (1714.18 → 1820.68 tok/s)
-  **-6.3% TPOT latency** (53.02 → 49.70 ms)
-  **+4.8% peak throughput** (2100 → 2200 tok/s)
-  **+6.6% request throughput** (1.67 → 1.78 req/s)

## Detailed Benchmark Results on H100
- serve script
```
vllm serve MiniMax/MiniMax-M2 -tp 4 -dp 1 --max-num-seqs 128 --served-model-name minimax-m2 --tool-call-parser minimax_m2 --reasoning-parser minimax_m2_append_think --enable-auto-tool-choice --no-enable-prefix-caching
```

- command
```
vllm bench serve \
  --backend vllm \
  --model MiniMaxAI/MiniMax-M2 \
  --endpoint /v1/completions \
  --dataset-name random \
  --random-input 2048 \
  --random-output 1024 \
  --max-concurrency 100 \
  --num-prompt 100 
```

### Configuration 1: DeepGEMM + VLLM_MOE_USE_DEEP_GEMM=0 (Recommended) 

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             100
Benchmark duration (s):                  45.05
Total input tokens:                      204800
Total generated tokens:                  102400
Request throughput (req/s):              2.22
Output token throughput (tok/s):         2272.83
Peak output token throughput (tok/s):    3300.00
Peak concurrent requests:                100.00
Total Token throughput (tok/s):          6818.50

---------------Time to First Token----------------
Mean TTFT (ms):                          2941.62
Median TTFT (ms):                        2890.46
P99 TTFT (ms):                           6198.51

-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.67
Median TPOT (ms):                        35.74
P99 TPOT (ms):                           37.70

---------------Inter-token Latency----------------
Mean ITL (ms):                           35.68
Median ITL (ms):                         30.76
P99 ITL (ms):                            194.79
==================================================
```

### Configuration 2: Disable DeepGEMM Completely

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             100
Benchmark duration (s):                  47.52
Total input tokens:                      204800
Total generated tokens:                  102400
Request throughput (req/s):              2.10
Output token throughput (tok/s):         2154.92
Peak output token throughput (tok/s):    3200.00
Peak concurrent requests:                100.00
Total Token throughput (tok/s):          6464.77

---------------Time to First Token----------------
Mean TTFT (ms):                          3066.76
Median TTFT (ms):                        3013.18
P99 TTFT (ms):                           6406.99

-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          37.47
Median TPOT (ms):                        37.63
P99 TPOT (ms):                           39.80

---------------Inter-token Latency----------------
Mean ITL (ms):                           37.48
Median ITL (ms):                         31.81
P99 ITL (ms):                            200.67
==================================================
```

### Configuration 3: DeepGEMM Enabled (Default)

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             100
Benchmark duration (s):                  70.70
Total input tokens:                      204800
Total generated tokens:                  102400
Request throughput (req/s):              1.41
Output token throughput (tok/s):         1448.46
Peak output token throughput (tok/s):    2197.00
Peak concurrent requests:                100.00
Total Token throughput (tok/s):          4345.37

---------------Time to First Token----------------
Mean TTFT (ms):                          2842.41
Median TTFT (ms):                        2816.71
P99 TTFT (ms):                           5111.35

-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.10
Median TPOT (ms):                        50.24
P99 TPOT (ms):                           63.20

---------------Inter-token Latency----------------
Mean ITL (ms):                           51.10
Median ITL (ms):                         47.16
P99 ITL (ms):                            186.91
==================================================
```
## References

- Follow-up to: [vllm-project/recipes#112](https://github.com/vllm-project/recipes/pull/112)
- Based on: [vllm-project/vllm#28422](https://github.com/vllm-project/vllm/pull/28422)
