### PR TITLE
[ROCm] add Qwen3 235B recipe 

### DIFF
--- a/Qwen/Qwen3-235B-A22B-ROCm.md
+++ b/Qwen/Qwen3-235B-A22B-ROCm.md
@@ -89,17 +89,6 @@ lm_eval \
 --batch_size 100 
 ```
 
-## More to update
-
-### Optimizations on the way
-1. https://github.com/vllm-project/vllm/pull/28500 enables **q_norm + k_norm + rope fusion** on ROCm platforms, which was initially implemented for cuda in https://github.com/vllm-project/vllm/pull/27165.
-2. https://github.com/vllm-project/vllm/pull/25693 added new fusion passes to enable **rms_norm + fp8_block_quant** and **silu + fp8_block_quant**, which depends on the triton fused kernel in https://github.com/ROCm/aiter/tree/dev/perf_fused_rms_fp8_group_quant. Need to check if this triton kernel merged into AITER main.
-3. **Sequence parallel** code ready in https://github.com/ROCm/vllm/pull/790. But seems poor performance due to the pynccl comm op.
-4. **All-reduce + rms_norm** fusion WIP in https://github.com/ROCm/vllm/pull/803.
-5. FP8 block GEMM is not efficient enough, i.e., up to 1.2p ~ 1.4p flops even after tuning.
-
-### Other parallelism
-1. Try other parallel strategies for best performance across different scenarios. 
 
 
 


### PR DESCRIPTION
This pr adds a recipe for Qwen3-235B-A22B running on ROCm platforms.

The recipe is subject to changes as some optimizations are still on the way:
- [x]  **q_norm + k_norm + rope fusion** fusion: https://github.com/vllm-project/vllm/pull/28500 enables q_norm + k_norm + rope fusion on ROCm platforms, which was initially implemented for cuda in https://github.com/vllm-project/vllm/pull/27165. **PR already merged to vLLM main!**
- [ ]  **rms_norm + fp8_block_quant** fusion: https://github.com/vllm-project/vllm/pull/25693 added new fusion passes to enable rms_norm + fp8_block_quant and silu + fp8_block_quant, which depends on the triton fused kernel in https://github.com/ROCm/aiter/tree/dev/perf_fused_rms_fp8_group_quant. Need to check if this triton kernel merged into AITER main. **triton kernel already merged to AITER main! vLLM pr still under review**
- [ ] **Sequence parallel**: code ready in https://github.com/ROCm/vllm/pull/790. Need pr to upstream as well. But seems poor performance due to the pynccl comm op for now.
- [ ]  **All-reduce + rms_norm** fusion:  WIP in https://github.com/ROCm/vllm/pull/803.
- [ ]  FP8 block GEMM is not efficient enough, i.e., up to 1.2p ~ 1.4p flops even after tuning. Refer to https://github.com/ROCm/aiter/pull/1378 for the tuning pr. **Optimization WIP, just need to upgrade AITER when it's done.**

The current recipe only provides TP8+EP8 deployment as an example. We will try other parallel strategies for best performance across different scenarios. 