### PR TITLE
update GLM-ASR-Nano-2512

### DIFF
--- a/GLM/GLM-ASR.md
+++ b/GLM/GLM-ASR.md
@@ -21,8 +21,7 @@ source .venv/bin/activate
 # Install transformers from source (required)
 uv pip install git+https://github.com/huggingface/transformers.git
 
-uv pip install -U vllm --torch-backend auto # vllm>=0.14.1 is required
-uv pip install vllm[audio]
+uv pip install -U "vllm[audio]" --torch-backend auto # vllm>=0.14.1 is required
 ```
 
 ## Running with vLLM


### PR DESCRIPTION
1. Change the version of vllm that GLM-ASR-Nano-2512 relies on (During the actual test, using vllm/vllm-openai:v0.13.0 did not work, but using v0.14.1 did work)
2. Modify the curl command of GLM-ASR-Nano-2512 to make it more readable