### PR TITLE
Fix Qwen3-ASR recipe OpeanAI SDK example

### DIFF
--- a/Qwen/Qwen3-ASR.md
+++ b/Qwen/Qwen3-ASR.md
@@ -43,7 +43,7 @@ response = client.chat.completions.create(
                 {
                     "type": "audio_url",
                     "audio_url": {
-                        {"url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"}
+                        "url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"
                     }
                 }
             ]


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/mozf/develop-projects/vllm/qwen_asr_transcribe.py", line 20, in <module>
    "audio_url": {
                 ^
TypeError: unhashable type: 'dict
```