### PR TITLE
[AMD/ROCM] gptoss rocm (bugfix)

### DIFF
--- a/OpenAI/GPT-OSS.md
+++ b/OpenAI/GPT-OSS.md
@@ -96,7 +96,7 @@ export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
 export VLLM_ROCM_USE_AITER_MHA=0
 
-vllm serve openai/gpt-oss-120b --tensor-parallel-size=8 --gpu-memory-utilization 0.95 --compilation-config  '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' --block-size=64 --disable-log-request --async-scheduling 
+vllm serve openai/gpt-oss-120b --tensor-parallel-size=8 --gpu-memory-utilization 0.95 --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' --block-size=64 --disable-log-request --async-scheduling
 ```
 
 #### Known Issues


### PR DESCRIPTION
@Isotr0py @jeejeelee

I put incompatible aiter env vars for vllm v0.14.1. And this needs to be updated to be compatible to the below v0.14.1 env vars. 

https://github.com/vllm-project/vllm/blob/d7de043d55d1dd629554467e23874097e1c48993/vllm/envs.py#L124

Can you please merge this change ? 

Validated on MI355X. 

Regards,
Seungrok