### PR TITLE
Fix a typo for the Qwen3 model on AMD 

### DIFF
--- a/Qwen/Qwen3.md
+++ b/Qwen/Qwen3.md
@@ -16,7 +16,7 @@ Recommended approaches by hardware type are:
 
 MI300X/MI325X/MI355X 
 
-Please follow the steps here to install and run Qwen3-Next models on AMD MI300X/MI325X/MI355X GPU.
+Please follow the steps here to install and run Qwen3 models on AMD MI300X/MI325X/MI355X GPU.
 
 ### Step 1: Installing vLLM (AMD ROCm Backend: MI300X, MI325X, MI355X) 
  > Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described in the [documentation](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/#pre-built-images).  


### PR DESCRIPTION
FIx a typo here: Please follow the steps here to install and run Qwen3 models on AMD MI300X/MI325X/MI355X GPU.