### PR TITLE
AMD MI300X/MI325X/MI355X support for Qwen3.5 Model

### DIFF
--- a/Qwen/Qwen3.5.md
+++ b/Qwen/Qwen3.5.md
@@ -7,13 +7,15 @@
 You can either install vLLM from pip or use the pre-built Docker image.
 
 ### Pip Install
+
+#### NVIDIA 
 ```bash
 uv venv
 source .venv/bin/activate
 uv pip install -U vllm --torch-backend=auto
 ```
 
-### Pip Install (AMD ROCm)
+#### AMD 
 > Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described below. Supported GPUs: MI300X, MI325X, MI355X.
 ```bash
 uv venv --python 3.12
@@ -21,7 +23,10 @@ source .venv/bin/activate
 uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
 ```
 
-### Docker (NVIDIA)
+### Docker 
+
+#### NVIDIA
+
 ```bash
 docker run --gpus all \
   -p 8000:8000 \
@@ -36,7 +41,7 @@ docker run --gpus all \
 
 For Blackwell GPUs, use `vllm/vllm-openai:cu130-nightly`
 
-### Docker (AMD MI300X/MI325X/MI355X)
+#### AMD
 
 ```bash
 docker run --device=/dev/kfd --device=/dev/dri \


### PR DESCRIPTION
## Summary
Add comprehensive AMD MI300X/MI325X/MI355X GPU support for Qwen3.5 deployment, including installation methods, Docker setup, and deployment configurations.

## Changes

### Installation Instructions
- Added pip install method for AMD ROCm with Python 3.12, ROCm 7.0, and glibc requirements
- Provides clear guidance on environment prerequisites for AMD GPU users

### Docker Support
- Added AMD-specific Docker deployment instructions with proper device mapping and security settings
- Separated Docker sections by vendor (NVIDIA vs AMD) for better organization and clarity

### GPU Verification
- Updated documentation to note testing on 8x MI300X/MI355X GPUs
- Validates compatibility across both NVIDIA and AMD hardware platforms

### MI355X Deployment
- Added 2-GPU deployment configuration for MI355X nodes with distributed parallelism
- Enables efficient deployment on newer AMD GPU architecture

### AMD-specific Notes
- Added note that MTP-1 speculative decoding for AMD GPUs is under development

