### PR TITLE
Add FP8 B200 best config to MiniMax-M2.5 recipe

### DIFF
--- a/MiniMax/MiniMax-M2.md
+++ b/MiniMax/MiniMax-M2.md
@@ -120,7 +120,7 @@ vllm serve MiniMaxAI/MiniMax-M2.5 \
   --enable-auto-tool-choice
 ```
 
-For 4x H200/H20 or 4x A100/A800, run like this
+For 4x H200/H20 or 4x A100/A800: Standard serving configuration
 
 ```bash
 vllm serve MiniMaxAI/MiniMax-M2.5 \


### PR DESCRIPTION
## Summary
Adds FP8 serving config fo B200 GPUs to the MiniMax-M2.5 recipe

Reference: https://github.com/SemiAnalysisAI/InferenceX/pull/757