### PR TITLE
Add AMD GPU (ROCm) support for MiniMax-M2 series

### DIFF
--- a/MiniMax/MiniMax-M2.md
+++ b/MiniMax/MiniMax-M2.md
@@ -37,11 +37,11 @@ The following are recommended configurations; actual requirements should be adju
 
 - **192G x2** AMD GPU (MI300X/MI325X): Supports a total KV Cache capacity of ~500K tokens.
 
-- **192G x4** AMD GPU (MI300X/MI325X): Supports a total KV Cache capacity of up to ~1.5M tokens.
+- **192G x4** AMD GPU (MI300X/MI325X): Supports a total KV Cache capacity of ~1.5M tokens.
 
-- **288G x2** AMD GPU (MI350X/MI355X): Supports a total KV Cache capacity of up to ~1.5M tokens.
+- **288G x2** AMD GPU (MI350X/MI355X): Supports a total KV Cache capacity of ~1.5M tokens.
 
-- **288G x4** AMD GPU (MI350X/MI355X): Supports a total KV Cache capacity of up to ~4M tokens.
+- **288G x4** AMD GPU (MI350X/MI355X): Supports a total KV Cache capacity of ~4M tokens.
 
 > **Note**: The values above represent the total aggregate hardware KV Cache capacity. The maximum context length per individual sequence remains **196K** tokens.
 


### PR DESCRIPTION
## Summary

Add installation and deployment instructions for AMD Instinct GPUs (MI300X, MI325X, MI350X, MI355X) with [AITER](https://github.com/ROCm/aiter) acceleration for MiniMax-M2 series models.

## Changes

Minimal additions to `MiniMax/MiniMax-M2.md` — no changes to existing NVIDIA GPU content:

1. **System Requirements**: Add AMD GPU recommended configurations with estimated KV cache capacity
   - 192G x2/x4 (MI300X/MI325X): ~500K / ~1.5M tokens
   - 288G x2/x4 (MI350X/MI355X): ~1.5M / ~4M tokens

2. **Installation**: Add ROCm wheel install instructions
   - `uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/`

3. **Launching**: Add AMD GPU section with TP2 and TP4 commands
   - `VLLM_ROCM_USE_AITER=1` for optimized AITER kernels (CK-based FP8 MoE, RMSNorm, etc.)
   - Note about first-launch JIT compilation time

## Testing

Verified on **2x AMD Instinct MI300X** with vLLM v0.17.1 ROCm wheel:
- Model loads successfully with TP=2 (109 GB VRAM, ~70s load time)
- AITER JIT-compiles 24 kernel modules on first launch
- KV cache: 497,600 tokens (2x MI300X)
- Chat completions working correctly with reasoning (`<think>` tags)
