### PR TITLE
AMD GPU support for Kimi-K2.5 Model

### DIFF
--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -46,12 +46,50 @@ docker run --gpus all \
     --trust-remote-code
 ```
 
+### AMD (ROCm)
+
+Verified on 8× MI300X/MI355X GPUs:
+
+```bash
+docker run --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  --group-add video \
+  --ipc=host \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm/vllm-openai-rocm:latest \
+  moonshotai/Kimi-K2.5 \
+    --tensor-parallel-size 8 \
+    --mm-encoder-tp-mode data \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --enable-prefix-caching \
+    --trust-remote-code
+```
+
 ## Installing vLLM
+
+You can either install vLLM from pip or use the pre-built Docker image.
+
+### Pip Install
+
+#### NVIDIA
 
 ```bash
 uv venv
 source .venv/bin/activate
 uv pip install vllm --torch-backend auto
+```
+
+#### AMD
+
+> Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described above. Supported GPUs: MI300X, MI325X, MI355X.
+
+```bash
+uv venv --python 3.12
+source .venv/bin/activate
+uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
 ```
 
 ## Running Kimi-K2.5 with vLLM
@@ -66,6 +104,18 @@ vllm serve moonshotai/Kimi-K2.5 -tp 8 \
     --trust-remote-code
 ```
 The `--reasoning-parser` flag specifies the reasoning parser to use for extracting reasoning content from the model output.
+
+### AMD
+
+The configuration below has been verified on 8x MI300X/MI355X GPUs.
+```bash
+vllm serve moonshotai/Kimi-K2.5 -tp 8 \
+    --mm-encoder-tp-mode data \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+```
 
 ### Configuration Tips
 - `--async-scheduling` has been turned on by default to improve the overall system performance by overlapping scheduling overhead with the decoding process. If you run into issue with this feature, please try turning off this feature and file a bug report to vLLM.

--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -1,73 +1,6 @@
 # moonshotai/Kimi-K2.5 Usage Guide
 [Kimi K2.5](https://huggingface.co/moonshotai/Kimi-K2.5) is an open-source, native multimodal agentic model built through continual pretraining on approximately 15 trillion mixed visual and text tokens atop Kimi-K2-Base. It seamlessly integrates vision and language understanding with advanced agentic capabilities, instant and thinking modes, as well as conversational and agentic paradigms.
 
-## Use vLLM with Docker
-
-Pull the vLLM release image from [Docker Hub](https://hub.docker.com/r/vllm/vllm-openai/tags?name=17.0):
-
-```bash
-docker pull vllm/vllm-openai:v0.17.0-cu130 # CUDA 13.0
-docker pull vllm/vllm-openai:v0.17.0       # Other CUDA versions
-```
-
-### Hopper (x86_64)
-
-Verified on 8×H200 GPUs:
-
-```bash
-docker run --gpus all \
-  -p 8000:8000 \
-  --ipc=host \
-  vllm/vllm-openai:v0.17.0-cu130 moonshotai/Kimi-K2.5 \
-    --tensor-parallel-size 8 \
-    --mm-encoder-tp-mode data \
-    --compilation_config.pass_config.fuse_allreduce_rms true \
-    --tool-call-parser kimi_k2 \
-    --reasoning-parser kimi_k2 \
-    --enable-auto-tool-choice \
-    --trust-remote-code
-```
-
-### Blackwell (aarch64)
-
-NVIDIA Blackwell (e.g., GB200) is also supported via the aarch64 image:
-
-```bash
-docker run --gpus all \
-  -p 8000:8000 \
-  --ipc=host \
-  vllm/vllm-openai:v0.17.0-aarch64-cu130 moonshotai/Kimi-K2.5 \
-    --tensor-parallel-size 4 \
-    --mm-encoder-tp-mode data \
-    --compilation_config.pass_config.fuse_allreduce_rms true \
-    --tool-call-parser kimi_k2 \
-    --reasoning-parser kimi_k2 \
-    --enable-auto-tool-choice \
-    --trust-remote-code
-```
-
-### AMD (ROCm)
-
-Verified on 8× MI300X/MI355X GPUs:
-
-```bash
-docker run --device=/dev/kfd --device=/dev/dri \
-  --security-opt seccomp=unconfined \
-  --group-add video \
-  --ipc=host \
-  -p 8000:8000 \
-  -v ~/.cache/huggingface:/root/.cache/huggingface \
-  vllm/vllm-openai-rocm:latest \
-  moonshotai/Kimi-K2.5 \
-    --tensor-parallel-size 8 \
-    --mm-encoder-tp-mode data \
-    --tool-call-parser kimi_k2 \
-    --reasoning-parser kimi_k2 \
-    --enable-auto-tool-choice \
-    --enable-prefix-caching \
-    --trust-remote-code
-```
-
 ## Installing vLLM
 
 You can either install vLLM from pip or use the pre-built Docker image.
@@ -92,8 +25,82 @@ source .venv/bin/activate
 uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
 ```
 
+### Use vLLM with Docker
+
+#### NVIDIA 
+
+Pull the vLLM release image from [Docker Hub](https://hub.docker.com/r/vllm/vllm-openai/tags?name=17.0):
+
+```bash
+docker pull vllm/vllm-openai:v0.17.0-cu130 # CUDA 13.0
+docker pull vllm/vllm-openai:v0.17.0       # Other CUDA versions
+```
+
+##### Hopper (x86_64)
+
+Verified on 8×H200 GPUs:
+
+```bash
+docker run --gpus all \
+  -p 8000:8000 \
+  --ipc=host \
+  vllm/vllm-openai:v0.17.0-cu130 moonshotai/Kimi-K2.5 \
+    --tensor-parallel-size 8 \
+    --mm-encoder-tp-mode data \
+    --compilation_config.pass_config.fuse_allreduce_rms true \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+```
+
+##### Blackwell (aarch64)
+
+NVIDIA Blackwell (e.g., GB200) is also supported via the aarch64 image:
+
+```bash
+docker run --gpus all \
+  -p 8000:8000 \
+  --ipc=host \
+  vllm/vllm-openai:v0.17.0-aarch64-cu130 moonshotai/Kimi-K2.5 \
+    --tensor-parallel-size 4 \
+    --mm-encoder-tp-mode data \
+    --compilation_config.pass_config.fuse_allreduce_rms true \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+```
+
+#### AMD (ROCm)
+
+Verified on 8× MI300X/MI355X GPUs:
+
+```bash
+docker run --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined \
+  --group-add video \
+  --ipc=host \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm/vllm-openai-rocm:latest \
+  moonshotai/Kimi-K2.5 \
+    --tensor-parallel-size 8 \
+    --mm-encoder-tp-mode data \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --enable-prefix-caching \
+    --trust-remote-code
+```
+
 ## Running Kimi-K2.5 with vLLM
-See the following command to deploy Kimi-K2.5 with the vLLM inference server. The configuration below has been verified on 8xH200 GPUs.
+
+See the following command to deploy Kimi-K2.5 with the vLLM inference server. 
+
+### NVIDIA
+
+The configuration below has been verified on 8xH200 GPUs.
 ```bash
 vllm serve moonshotai/Kimi-K2.5 -tp 8 \
     --mm-encoder-tp-mode data \
@@ -147,7 +154,8 @@ vllm bench serve \
   --dataset-name hf \
   --dataset-path lmarena-ai/VisionArena-Chat \
   --num-prompts 1000 \
-  --request-rate 20
+  --request-rate 20 \
+  --trust-remote-code
 ```
 
 ### Consume the OpenAI API Compatible Server

--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -82,6 +82,9 @@ docker run --device=/dev/kfd --device=/dev/dri \
   --group-add video \
   --ipc=host \
   -p 8000:8000 \
+  -e VLLM_ROCM_USE_AITER=1 \
+  -e VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
+  -e VLLM_ROCM_USE_AITER_RMSNORM=0 \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
   vllm/vllm-openai-rocm:latest \
   moonshotai/Kimi-K2.5 \
@@ -112,15 +115,21 @@ vllm serve moonshotai/Kimi-K2.5 -tp 8 \
 ```
 The `--reasoning-parser` flag specifies the reasoning parser to use for extracting reasoning content from the model output.
 
-### AMD
+### AMD (ROCm)
 
 The configuration below has been verified on 8x MI300X/MI355X GPUs.
 ```bash
+export VLLM_ROCM_USE_AITER=1  # Enable AITER optimization for attention and tensor operations
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4  # Use INT4 quantization for faster all-reduce operations
+export VLLM_ROCM_USE_AITER_RMSNORM=0  # Disable AITER for RMSNorm layers
+
 vllm serve moonshotai/Kimi-K2.5 -tp 8 \
     --mm-encoder-tp-mode data \
     --tool-call-parser kimi_k2 \
     --reasoning-parser kimi_k2 \
     --enable-auto-tool-choice \
+    --block-size=1 \
+    --mm-encoder-tp-mode data \
     --trust-remote-code
 ```
 

--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -90,6 +90,7 @@ docker run --device=/dev/kfd --device=/dev/dri \
   moonshotai/Kimi-K2.5 \
     --tensor-parallel-size 8 \
     --mm-encoder-tp-mode data \
+    --block-size=1 \
     --tool-call-parser kimi_k2 \
     --reasoning-parser kimi_k2 \
     --enable-auto-tool-choice \

--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -17,7 +17,7 @@ uv pip install vllm --torch-backend auto
 
 #### AMD
 
-> Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described above. Supported GPUs: MI300X, MI325X, MI355X.
+> Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.2.1, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described above. Supported GPUs: MI300X, MI325X, MI355X.
 
 ```bash
 uv venv --python 3.12


### PR DESCRIPTION
## Summary
Add comprehensive AMD MI300X/MI325X/MI355X GPU support for Kimi-K2.5 deployment, including installation methods, Docker setup, and deployment configurations.

## Changes

### Installation Instructions
- Added pip install method for AMD ROCm 
- Reorganized installation section to separate NVIDIA and AMD methods
- Provides clear guidance on environment prerequisites for AMD GPU users

### Docker Support
- Added AMD-specific Docker deployment instructions 
- Configured for 8-GPU tensor parallelism with reasoning parser support
- Separated Docker sections by vendor (NVIDIA vs AMD) for better organization and clarity. 
- Structure Reference : [Qwen3.5 User Guide](https://docs.vllm.ai/projects/recipes/en/latest/Qwen/Qwen3.5.html)

### AMD-specific Deployment
- Updated documentation to note testing on 8x MI300X/MI355X GPUs
- Added 8-GPU deployment configuration for MI300X/MI355X nodes with tensor parallelism
- Removed AMD-incompatible flag (`--compilation_config.pass_config.fuse_allreduce_rms`) from AMD deployment

### Minor Fixes
- Added missing `--trust-remote-code` flag to benchmark command 
- Improved consistency in deployment command formatting

---

This PR enables AMD GPU users to deploy Kimi-K2.5 with the same capabilities as NVIDIA deployments, following the established pattern in the recipes repository.
