### PR TITLE
Add AMD GPU support for DeepSeek-OCR (MI300X/MI325X/MI355X + AITER)

### DIFF
--- a/DeepSeek/DeepSeek-OCR.md
+++ b/DeepSeek/DeepSeek-OCR.md
@@ -126,3 +126,51 @@ print(f"Generated text: {response.choices[0].message.content}")
 - DeepSeek-OCR works better with plain prompts than instruction formats. Find [more example prompts for various OCR tasks](https://github.com/deepseek-ai/DeepSeek-OCR/blob/2ac6d64a00656693b79c4f759a5e62c1b78bbeb1/DeepSeek-OCR-master/DeepSeek-OCR-vllm/config.py#L27-L37) in the official DeepSeek-OCR repository.
 - Depending on your hardware capability, adjust `max_num_batched_tokens` for better throughput performance.
 - Check out [vLLM documentation](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html#offline-inference) for additional information on batch inference with multimodal inputs.
+
+
+## AMD GPU Support
+
+Recommended approaches by hardware type are:
+
+MI300X/MI325X/MI355X
+
+Please follow the steps here to install and run DeepSeek-OCR models on AMD MI300X/MI325X/MI355X GPU.
+
+### Step 1: Installing vLLM (AMD ROCm Backend: MI300X, MI325X, MI355X)
+
+> Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described in the [documentation](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/#pre-built-images).
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+```
+
+### Step 2: Start the vLLM server
+
+Run the following sample command to start the vLLM server:
+
+```bash
+SAFETENSORS_FAST_GPU=1 \
+VLLM_USE_TRITON_FLASH_ATTN=0 \
+VLLM_ROCM_USE_AITER=1 \
+vllm serve deepseek-ai/DeepSeek-OCR \
+  --logits_processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor \
+  --no-enable-prefix-caching \
+  --mm-processor-cache-gb 0
+```
+
+### Step 3: Run Benchmark
+
+Open a new terminal and run the following command to execute the benchmark script.
+
+```bash
+vllm bench serve \
+  --model deepseek-ai/DeepSeek-OCR \
+  --dataset-name random \
+  --random-input-len 4096 \
+  --random-output-len 512 \
+  --request-rate 1 \
+  --num-prompts 4 \
+  --ignore-eos
+```


### PR DESCRIPTION
## Summary

This PR adds AMD GPU support for [DeepSeek-OCR](https://huggingface.co/deepseek-ai/DeepSeek-OCR) on MI300X/MI325X/MI355X GPUs.

## Changes

- **Step 1**: uv-based vLLM ROCm installation guide
- **Step 2**: vLLM server launch command with AITER enabled (`VLLM_ROCM_USE_AITER=1`)
- **Step 3**: Benchmark script

## Hardware Tested

| Hardware | Status |
|----------|--------|
| 8x AMD MI300X + AITER | ✅ Verified |
| 8x AMD MI355X + AITER | ✅ Verified |

## Related

Closes the AMD GPU support gap originally started in #151.