### PR TITLE
Add AMD GPU support for DeepSeek-V3.2-Exp (MI300X/MI325X/MI355X + AITER)

### DIFF
--- a/DeepSeek/DeepSeek-V3_2-Exp.md
+++ b/DeepSeek/DeepSeek-V3_2-Exp.md
@@ -83,3 +83,55 @@ For other usage tips, such as enabling or disabling thinking mode, please refer 
 ## Additional Resources
 
 - [An end-to-end tutorial (Jupyter Notebook)](https://github.com/vllm-project/recipes/blob/main/DeepSeek/DeepSeek_v3_2_vLLM_getting_started_guide.ipynb)
+
+
+## AMD GPU Support
+
+Recommended approaches by hardware type are:
+
+MI300X/MI325X/MI355X
+
+Please follow the steps here to install and run DeepSeek-V3.2-Exp models on AMD MI300X/MI325X/MI355X GPU.
+
+### Step 1: Installing vLLM (AMD ROCm Backend: MI300X, MI325X, MI355X)
+
+> Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described in the [documentation](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/#pre-built-images).
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+```
+
+### Step 2: Start the vLLM server
+
+Run the following sample command to start the vLLM server:
+
+```bash
+SAFETENSORS_FAST_GPU=1 \
+VLLM_ROCM_USE_AITER=1 \
+VLLM_ROCM_USE_AITER_MOE=1 \
+VLLM_RPC_TIMEOUT=18000000 \
+vllm serve deepseek-ai/DeepSeek-V3.2-Exp \
+  --tensor-parallel-size 8 \
+  --max-num-batched-tokens 32768 \
+  --trust-remote-code \
+  --no-enable-prefix-caching \
+  --kv-cache-dtype bfloat16 \
+  --block-size 1
+```
+
+### Step 3: Run Benchmark
+
+Open a new terminal and run the following command to execute the benchmark script.
+
+```bash
+vllm bench serve \
+  --model deepseek-ai/DeepSeek-V3.2-Exp \
+  --dataset-name random \
+  --random-input-len 1000 \
+  --random-output-len 200 \
+  --request-rate 1 \
+  --num-prompts 4 \
+  --ignore-eos
+```


### PR DESCRIPTION
## Summary

This PR adds AMD GPU support for [DeepSeek-V3.2-Exp](https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp) on MI300X/MI325X/MI355X GPUs.

## Changes

- **Step 1**: uv-based vLLM ROCm installation guide
- **Step 2**: vLLM server launch command with AITER and AITER_MOE enabled
  - `--block-size 1` required for ROCm Sparse MLA attention
  - `--kv-cache-dtype bfloat16` for better latency on short requests
  - `--max-num-batched-tokens 32768` for throughput optimization
- **Step 3**: Benchmark script

## Hardware Tested

| Hardware | Status |
|----------|--------|
| 8x AMD MI300X + AITER | ✅ Verified |
| 8x AMD MI355X + AITER | ✅ Verified |

## Related

Closes the AMD GPU support gap originally started in #143.