### PR TITLE
Add AMD GPU support for Step-3.5-Flash

### DIFF
--- a/Ernie/Ernie4.5-VL.md
+++ b/Ernie/Ernie4.5-VL.md
@@ -16,7 +16,7 @@ uv pip install -U vllm --torch-backend auto
 ```bash
 uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
 ```
-⚠️ The vLLM wheel for ROCm is compatible with Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment is incompatible, please use docker flow in [vLLM](https://vllm.ai/) 
+⚠️ The vLLM wheel for ROCm is compatible with Python 3.12, ROCm 7.2.1, and glibc >= 2.35. If your environment is incompatible, please use docker flow in [vLLM](https://vllm.ai/) 
 
 ## Running Ernie4.5-VL
 

--- a/MiniMax/MiniMax-M2.md
+++ b/MiniMax/MiniMax-M2.md
@@ -63,7 +63,7 @@ docker run --gpus all \
 
 ### Installing vLLM for AMD GPU (ROCm)
 
-Install the vLLM ROCm wheel (requires Python 3.12 and ROCm 7.0+):
+Install the vLLM ROCm wheel (requires Python 3.12 and ROCm 7.2.1+):
 
 ```bash
 uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/

--- a/Qwen/Qwen3.5.md
+++ b/Qwen/Qwen3.5.md
@@ -16,7 +16,7 @@ uv pip install -U vllm --torch-backend=auto
 ```
 
 #### AMD 
-> Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described below. Supported GPUs: MI300X, MI325X, MI355X.
+> Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.2.1, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup as described below. Supported GPUs: MI300X, MI325X, MI355X.
 ```bash
 uv venv --python 3.12
 source .venv/bin/activate

--- a/StepFun/Step-3.5-Flash.md
+++ b/StepFun/Step-3.5-Flash.md
@@ -128,7 +128,7 @@ vllm serve stepfun-ai/Step-3.5-Flash-FP8 \
   --trust-remote-code
 ```
 
-- BF16 (4x MI300X/MI325X/MI350X/MI355X)
+- BF16
 ```bash
 VLLM_USE_TRITON_FLASH_ATTN=0 \
 VLLM_ROCM_USE_AITER=1 \

--- a/StepFun/Step-3.5-Flash.md
+++ b/StepFun/Step-3.5-Flash.md
@@ -17,7 +17,7 @@ uv pip install vllm --torch-backend auto
 
 ### Installing vLLM for AMD GPU (ROCm)
 
-Install the vLLM ROCm wheel (requires Python 3.12 and ROCm 7.0+):
+Install the vLLM ROCm wheel (requires Python 3.12 and ROCm 7.2.1+):
 
 ```bash
 uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
@@ -30,7 +30,7 @@ Supported AMD GPUs: MI300X, MI325X, MI350X, MI355X.
 Use the latest ROCm image:
 
 ```bash
-docker pull vllm/vllm-openai-rocm:v0.17.1
+docker pull vllm/vllm-openai-rocm:latest
 ```
 
 ## Serving with vLLM
@@ -116,7 +116,6 @@ You can use 4x MI300X/MI325X/MI350X/MI355X GPUs to launch Step-3.5-Flash on AMD 
 
 - FP8 (4x MI300X/MI325X/MI350X/MI355X)
 ```bash
-VLLM_USE_TRITON_FLASH_ATTN=0 \
 VLLM_ROCM_USE_AITER=1 \
 VLLM_ROCM_USE_AITER_MOE=0 \
 vllm serve stepfun-ai/Step-3.5-Flash-FP8 \
@@ -130,7 +129,6 @@ vllm serve stepfun-ai/Step-3.5-Flash-FP8 \
 
 - BF16
 ```bash
-VLLM_USE_TRITON_FLASH_ATTN=0 \
 VLLM_ROCM_USE_AITER=1 \
 VLLM_ROCM_USE_AITER_MOE=0 \
 vllm serve stepfun-ai/Step-3.5-Flash \

--- a/StepFun/Step-3.5-Flash.md
+++ b/StepFun/Step-3.5-Flash.md
@@ -15,6 +15,24 @@ source .venv/bin/activate
 uv pip install vllm --torch-backend auto
 ```
 
+### Installing vLLM for AMD GPU (ROCm)
+
+Install the vLLM ROCm wheel (requires Python 3.12 and ROCm 7.0+):
+
+```bash
+uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+```
+
+Supported AMD GPUs: MI300X, MI325X, MI350X, MI355X.
+
+### Using Docker on AMD GPU (ROCm)
+
+Use the latest ROCm image:
+
+```bash
+docker pull vllm/vllm-openai-rocm:v0.17.1
+```
+
 ## Serving with vLLM
 
 
@@ -29,7 +47,6 @@ uv pip install vllm --torch-backend auto
 
 
 ### Running Step-3.5-Flash on 4xH200/H20/B200
-
 
 There are two ways to parallelize the model over multiple GPUs: (1) Tensor-parallel or (2) Data-parallel. Each one has its own advantages, where tensor-parallel is usually more beneficial for low-latency / low-load scenarios and data-parallel works better for cases where there is a lot of data with heavy-loads.
 
@@ -93,6 +110,43 @@ vllm serve stepfun-ai/Step-3.5-Flash \
 ```
 </details>
 
+### AMD GPU (ROCm)
+
+You can use 4x MI300X/MI325X/MI350X/MI355X GPUs to launch Step-3.5-Flash on AMD ROCm with [AITER](https://github.com/ROCm/aiter) acceleration enabled for attention kernels:
+
+- FP8 (4x MI300X/MI325X/MI350X/MI355X)
+```bash
+VLLM_USE_TRITON_FLASH_ATTN=0 \
+VLLM_ROCM_USE_AITER=1 \
+VLLM_ROCM_USE_AITER_MOE=0 \
+vllm serve stepfun-ai/Step-3.5-Flash-FP8 \
+  --tensor-parallel-size 4 \
+  --enable-expert-parallel \
+  --reasoning-parser step3p5 \
+  --tool-call-parser step3p5 \
+  --enable-auto-tool-choice \
+  --trust-remote-code
+```
+
+- BF16 (4x MI300X/MI325X/MI350X/MI355X)
+```bash
+VLLM_USE_TRITON_FLASH_ATTN=0 \
+VLLM_ROCM_USE_AITER=1 \
+VLLM_ROCM_USE_AITER_MOE=0 \
+vllm serve stepfun-ai/Step-3.5-Flash \
+  --tensor-parallel-size 4 \
+  --enable-expert-parallel \
+  --reasoning-parser step3p5 \
+  --tool-call-parser step3p5 \
+  --enable-auto-tool-choice \
+  --trust-remote-code
+```
+
+> **Note**: Step-3.5-Flash uses a custom MoE activation (`SWIGLUSTEP`). In vLLM v0.17.1, AITER attention kernels work on AMD, but AITER MoE kernels do not yet support this activation. Keep `VLLM_ROCM_USE_AITER=1` and set `VLLM_ROCM_USE_AITER_MOE=0` to use AITER for attention while falling back to the non-AITER MoE backend.
+
+> **Note**: Use `--enable-expert-parallel` together with `--tensor-parallel-size 4` on AMD for the 288-expert MoE architecture.
+
+> **Note**: The first launch with AITER may take several minutes as AITER JIT-compiles optimized kernels. Subsequent launches will use cached kernels.
 
 ## Benchmark 
 


### PR DESCRIPTION
Add AMD MI300X/MI325X/MI350X/MI355X GPU support for Step-3.5-Flash.

## Changes
- Add ROCm wheel and Docker (`vllm/vllm-openai-rocm:v0.17.1`) installation notes
- Add AMD serving recipes for both FP8 and BF16 models with TP=4 + Expert Parallelism
- Enable AITER for attention; disable AITER MoE due to `SWIGLUSTEP` activation incompatibility
- Add notes on AITER JIT compilation and expert parallelism requirements

## Testing
Verified on 4x MI300X (192 GB each) with vLLM v0.17.1 ROCm:
- `Step-3.5-Flash-FP8`: TP=4 EP ✅
- `Step-3.5-Flash` (BF16): TP=4 EP ✅

## Notes
- Existing NVIDIA content is unchanged
- No benchmark data included

Signed-off-by: Andy Luo <andy.linluo@gmail.com>