### PR TITLE
Add AMD ROCm (MI355X) deployment guide for Kimi-K2.5-MXFP4

### DIFF
--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -46,6 +46,67 @@ docker run --gpus all \
     --trust-remote-code
 ```
 
+### AMD ROCm (MI355X)
+
+For AMD Instinct MI355X GPUs, use the [MXFP4-quantized model](https://huggingface.co/amd/Kimi-K2.5-MXFP4) with the ROCm vLLM image:
+
+```bash
+docker pull vllm/vllm-openai-rocm:v0.16.0
+```
+
+Run with 4×MI355X GPUs (TP=4):
+
+```bash
+docker run \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  --shm-size=16G \
+  -p 8000:8000 \
+  -e VLLM_ROCM_USE_AITER=1 \
+  -e VLLM_ROCM_USE_AITER_MLA=1 \
+  -e VLLM_ROCM_USE_AITER_MOE=1 \
+  -e VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT8 \
+  -e VLLM_ROCM_USE_AITER_TRITON_ROPE=1 \
+  vllm/vllm-openai-rocm:v0.16.0 \
+  amd/Kimi-K2.5-MXFP4 \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.90 \
+    --block-size 1 \
+    --mm-encoder-tp-mode data \
+    --trust-remote-code
+```
+
+For 8×MI355X GPUs, you can enable Expert Parallelism (TP=4, EP=2) for higher throughput on long-output workloads:
+
+```bash
+docker run \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  --cap-add=SYS_PTRACE \
+  --security-opt seccomp=unconfined \
+  --shm-size=16G \
+  -p 8000:8000 \
+  -e VLLM_ROCM_USE_AITER=1 \
+  -e VLLM_ROCM_USE_AITER_MLA=1 \
+  -e VLLM_ROCM_USE_AITER_MOE=1 \
+  -e VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT8 \
+  -e VLLM_ROCM_USE_AITER_TRITON_ROPE=1 \
+  vllm/vllm-openai-rocm:v0.16.0 \
+  amd/Kimi-K2.5-MXFP4 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --gpu-memory-utilization 0.90 \
+    --block-size 1 \
+    --mm-encoder-tp-mode data \
+    --trust-remote-code
+```
+
+> **Note:** On systems with MEC firmware older than version 177, set `HSA_NO_SCRATCH_RECLAIM=1` (via `-e HSA_NO_SCRATCH_RECLAIM=1`) to prevent RCCL memory reclaim crashes. Check your firmware version with `rocm-smi --showfw | grep MEC`.
+
 ## Installing vLLM
 
 ```bash
@@ -66,6 +127,44 @@ vllm serve moonshotai/Kimi-K2.5 -tp 8 \
     --trust-remote-code
 ```
 The `--reasoning-parser` flag specifies the reasoning parser to use for extracting reasoning content from the model output.
+
+### Running on AMD ROCm
+
+Deploy the MXFP4-quantized model on AMD MI355X GPUs with AITER acceleration:
+
+```bash
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MLA=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT8
+export VLLM_ROCM_USE_AITER_TRITON_ROPE=1
+
+vllm serve amd/Kimi-K2.5-MXFP4 -tp 4 \
+    --gpu-memory-utilization 0.90 \
+    --block-size 1 \
+    --mm-encoder-tp-mode data \
+    --trust-remote-code
+```
+
+To enable Expert Parallelism on 8 GPUs (TP=4, EP=2):
+
+```bash
+vllm serve amd/Kimi-K2.5-MXFP4 -tp 4 \
+    --enable-expert-parallel \
+    --gpu-memory-utilization 0.90 \
+    --block-size 1 \
+    --mm-encoder-tp-mode data \
+    --trust-remote-code
+```
+
+The AITER environment variables enable optimized AMD kernels:
+| Variable | Description |
+|----------|-------------|
+| `VLLM_ROCM_USE_AITER` | Enable AITER acceleration (general) |
+| `VLLM_ROCM_USE_AITER_MLA` | Enable AITER Multi-head Latent Attention kernels |
+| `VLLM_ROCM_USE_AITER_MOE` | Enable AITER Mixture-of-Experts kernels |
+| `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION` | Quantized AllReduce communication (INT8) |
+| `VLLM_ROCM_USE_AITER_TRITON_ROPE` | Enable Triton-based RoPE kernels |
 
 ### Configuration Tips
 - `--async-scheduling` has been turned on by default to improve the overall system performance by overlapping scheduling overhead with the decoding process. If you run into issue with this feature, please try turning off this feature and file a bug report to vLLM.

--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -3,11 +3,12 @@
 
 ## Use vLLM with Docker
 
-Pull the vLLM release image from [Docker Hub](https://hub.docker.com/r/vllm/vllm-openai/tags?name=17.0):
+Pull the vLLM release image from Docker Hub ([CUDA](https://hub.docker.com/r/vllm/vllm-openai/tags?name=17.0) | [ROCm](https://hub.docker.com/r/vllm/vllm-openai-rocm/tags)):
 
 ```bash
-docker pull vllm/vllm-openai:v0.17.0-cu130 # CUDA 13.0
-docker pull vllm/vllm-openai:v0.17.0       # Other CUDA versions
+docker pull vllm/vllm-openai:v0.17.0-cu130       # CUDA 13.0
+docker pull vllm/vllm-openai:v0.17.0              # Other CUDA versions
+docker pull vllm/vllm-openai-rocm:v0.16.0         # ROCm (AMD)
 ```
 
 ### Hopper (x86_64)
@@ -50,10 +51,6 @@ docker run --gpus all \
 
 For AMD Instinct MI355X GPUs, use the [MXFP4-quantized model](https://huggingface.co/amd/Kimi-K2.5-MXFP4) with the ROCm vLLM image:
 
-```bash
-docker pull vllm/vllm-openai-rocm:v0.16.0
-```
-
 Run with 4×MI355X GPUs (TP=4):
 
 ```bash
@@ -76,6 +73,9 @@ docker run \
     --gpu-memory-utilization 0.90 \
     --block-size 1 \
     --mm-encoder-tp-mode data \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
     --trust-remote-code
 ```
 
@@ -102,6 +102,9 @@ docker run \
     --gpu-memory-utilization 0.90 \
     --block-size 1 \
     --mm-encoder-tp-mode data \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
     --trust-remote-code
 ```
 
@@ -116,6 +119,9 @@ uv pip install vllm --torch-backend auto
 ```
 
 ## Running Kimi-K2.5 with vLLM
+
+### Running on NVIDIA
+
 See the following command to deploy Kimi-K2.5 with the vLLM inference server. The configuration below has been verified on 8xH200 GPUs.
 ```bash
 vllm serve moonshotai/Kimi-K2.5 -tp 8 \
@@ -143,6 +149,9 @@ vllm serve amd/Kimi-K2.5-MXFP4 -tp 4 \
     --gpu-memory-utilization 0.90 \
     --block-size 1 \
     --mm-encoder-tp-mode data \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
     --trust-remote-code
 ```
 
@@ -154,6 +163,9 @@ vllm serve amd/Kimi-K2.5-MXFP4 -tp 4 \
     --gpu-memory-utilization 0.90 \
     --block-size 1 \
     --mm-encoder-tp-mode data \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-auto-tool-choice \
     --trust-remote-code
 ```
 


### PR DESCRIPTION
## Summary

- Add AMD ROCm (MI355X) deployment instructions for Kimi-K2.5 using the [MXFP4-quantized model](https://huggingface.co/amd/Kimi-K2.5-MXFP4)
- Include Docker examples for both 4×MI355X (TP=4) and 8×MI355X (TP=4 + Expert Parallel) configurations
- Document AITER acceleration environment variables for optimized MLA, MoE, and RoPE kernels on ROCm
- Add non-Docker "Running on AMD ROCm" section with `vllm serve` commands and AITER env var reference table

Based on the optimized configurations from [InferenceX](https://github.com/SemiAnalysisAI/InferenceX/pull/922).

## Changes

The recipe previously only covered NVIDIA GPUs (Hopper H200, Blackwell GB200). This PR adds:

1. **Docker section: "AMD ROCm (MI355X)"** — `vllm/vllm-openai-rocm:v0.16.0` image with `amd/Kimi-K2.5-MXFP4`, AITER env vars, and ROCm-specific device flags
2. **"Running on AMD ROCm" section** — bare-metal `vllm serve` commands with TP=4 and TP=4+EP configurations
3. **AITER env var reference table** — documents `VLLM_ROCM_USE_AITER`, `VLLM_ROCM_USE_AITER_MLA`, `VLLM_ROCM_USE_AITER_MOE`, `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION`, `VLLM_ROCM_USE_AITER_TRITON_ROPE`
4. **MEC firmware compatibility note** — `HSA_NO_SCRATCH_RECLAIM=1` workaround for older AMD drivers

## Test Plan

- [ ] Verify 4×MI355X TP=4 deployment with `amd/Kimi-K2.5-MXFP4` using the documented Docker command
- [ ] Verify 8×MI355X TP=4+EP deployment with `--enable-expert-parallel`
- [ ] Confirm all AITER env vars are recognized by vLLM ROCm v0.16.0
