### PR TITLE
[Prototype] Add interactive deployment config generator

### DIFF
--- a/Llama/Llama3.3-70B.md
+++ b/Llama/Llama3.3-70B.md
@@ -33,6 +33,82 @@ For Hopper, FP8 offers the best performance for most workloads. For Blackwell, N
 
 ## Deployment Steps
 
+### Interactive Command Generator
+
+Use the configuration selector below to automatically generate the appropriate deployment
+command for your hardware platform, quantization method, and parallelism settings.
+
+<div id="llama33-config"></div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var el = document.getElementById('llama33-config');
+  if (!el || !window.ConfigGenerator) return;
+
+  ConfigGenerator.create(el, {
+    options: {
+      hardware: {
+        name: 'hardware',
+        title: 'Hardware Platform',
+        items: [
+          { id: 'blackwell', label: 'Blackwell', subtitle: 'B200 / GB200', default: true },
+          { id: 'hopper', label: 'Hopper', subtitle: 'H100 / H200', default: false }
+        ]
+      },
+      quantization: {
+        name: 'quantization',
+        title: 'Quantization',
+        getDynamicItems: function(values) {
+          var isBlackwell = values.hardware === 'blackwell';
+          return [
+            { id: 'fp4', label: 'NVFP4', subtitle: 'Max Throughput', default: isBlackwell, disabled: !isBlackwell, disabledReason: 'NVFP4 requires Blackwell GPUs' },
+            { id: 'fp8', label: 'FP8', subtitle: 'High Quality', default: !isBlackwell }
+          ];
+        }
+      },
+      tp: {
+        name: 'tp',
+        title: 'Tensor Parallel',
+        items: [
+          { id: '1', label: 'TP=1', subtitle: 'Max Throughput/GPU', default: true },
+          { id: '2', label: 'TP=2', subtitle: 'Balanced', default: false },
+          { id: '4', label: 'TP=4', subtitle: 'Low Latency', default: false },
+          { id: '8', label: 'TP=8', subtitle: 'Min Latency', default: false }
+        ]
+      },
+      prefixCaching: {
+        name: 'prefixCaching',
+        title: 'Prefix Caching',
+        items: [
+          { id: 'enabled', label: 'Enabled', subtitle: 'Production', default: true },
+          { id: 'disabled', label: 'Disabled', subtitle: 'Benchmarking', default: false }
+        ]
+      }
+    },
+
+    generateCommand: function(values) {
+      var hw = values.hardware;
+      var quant = values.quantization;
+      var tp = values.tp;
+
+      var modelSuffix = quant === 'fp4' ? '-FP4' : '-FP8';
+      var model = 'nvidia/Llama-3.3-70B-Instruct' + modelSuffix;
+      var yamlConfig = hw === 'blackwell' ? 'Llama3.3_Blackwell.yaml' : 'Llama3.3_Hopper.yaml';
+
+      var cmd = 'vllm serve ' + model + ' \\\n';
+      cmd += '  --config ' + yamlConfig + ' \\\n';
+      cmd += '  --tensor-parallel-size ' + tp;
+
+      if (values.prefixCaching === 'disabled') {
+        cmd += ' \\\n  --no-enable-prefix-caching';
+      }
+
+      return cmd;
+    }
+  });
+});
+</script>
+
 ### Pull Docker Image
 
 Pull the vLLM v0.12.0 release docker image.

--- a/assets/config-generator.css
+++ b/assets/config-generator.css
@@ -1,0 +1,167 @@
+/* vLLM Deployment Config Generator */
+.config-generator {
+  max-width: 900px;
+  margin: 1.5em 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.config-option {
+  background: var(--md-default-bg-color);
+  padding: 8px 12px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-left: 3px solid var(--md-primary-fg-color, #7C3AED);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.config-option-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--md-default-fg-color);
+  min-width: 140px;
+  flex-shrink: 0;
+}
+
+.config-option-items {
+  display: flex;
+  row-gap: 2px;
+  column-gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+  flex: 1;
+}
+
+.config-option-label {
+  padding: 4px 10px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 3px;
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  font-size: 13px;
+  transition: all 0.2s;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  user-select: none;
+  min-width: 45px;
+  text-align: center;
+  flex: 1;
+}
+
+.config-option-label:hover {
+  border-color: var(--md-primary-fg-color, #7C3AED);
+}
+
+.config-option-label.checked {
+  background: var(--md-primary-fg-color, #7C3AED);
+  color: var(--md-primary-bg-color, #fff);
+  border-color: var(--md-primary-fg-color, #7C3AED);
+}
+
+.config-option-label.disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.config-option-label.disabled:hover {
+  border-color: var(--md-default-fg-color--lightest);
+}
+
+.config-option-label input {
+  display: none;
+}
+
+.config-option-subtitle {
+  display: block;
+  font-size: 9px;
+  margin-top: 1px;
+  line-height: 1.1;
+  opacity: 0.7;
+}
+
+.config-option-label.checked .config-option-subtitle {
+  opacity: 0.85;
+}
+
+.config-command {
+  background: var(--md-default-bg-color);
+  padding: 8px 12px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-left: 3px solid var(--md-primary-fg-color, #7C3AED);
+  border-radius: 4px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.config-command-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--md-default-fg-color);
+  min-width: 140px;
+  flex-shrink: 0;
+  padding-top: 8px;
+}
+
+.config-command-display {
+  flex: 1;
+  padding: 8px 12px;
+  background: var(--md-code-bg-color);
+  border-radius: 3px;
+  font-family: var(--md-code-font-family, 'Roboto Mono', monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--md-code-fg-color);
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  margin: 0;
+  position: relative;
+}
+
+.config-command-copy {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: var(--md-default-fg-color--lightest);
+  border: none;
+  border-radius: 3px;
+  padding: 2px 6px;
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--md-default-fg-color--light);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.config-command-display:hover .config-command-copy {
+  opacity: 1;
+}
+
+.config-command-copy:hover {
+  background: var(--md-primary-fg-color, #7C3AED);
+  color: var(--md-primary-bg-color, #fff);
+}
+
+/* Responsive: stack on narrow screens */
+@media (max-width: 600px) {
+  .config-option,
+  .config-command {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
+
+  .config-option-title,
+  .config-command-title {
+    min-width: unset;
+  }
+}

--- a/assets/config-generator.js
+++ b/assets/config-generator.js
@@ -1,0 +1,171 @@
+/**
+ * vLLM Deployment Config Generator
+ *
+ * A vanilla JS interactive configuration selector for vLLM deployment recipes.
+ * Recipe authors define a config object and call ConfigGenerator.create(element, config).
+ *
+ * Config schema:
+ * {
+ *   options: {
+ *     optionKey: {
+ *       name: 'optionKey',
+ *       title: 'Display Title',
+ *       items: [{ id: 'val', label: 'Label', subtitle: '', default: true, disabled: false, disabledReason: '' }],
+ *       getDynamicItems: (values) => items[],    // optional: compute items from current state
+ *       condition: (values) => boolean,           // optional: show/hide this option
+ *       commandRule: (value) => string | null,    // optional: simple flag contribution
+ *     },
+ *     ...
+ *   },
+ *   generateCommand: function(values) { return 'shell command'; }
+ * }
+ */
+class ConfigGenerator {
+  constructor(container, config) {
+    this.container = container;
+    this.config = config;
+    this.values = this._getInitialState();
+    this._render();
+  }
+
+  static create(element, config) {
+    return new ConfigGenerator(element, config);
+  }
+
+  _getInitialState() {
+    const state = {};
+    for (const [key, option] of Object.entries(this.config.options)) {
+      let items = option.items;
+      if (option.getDynamicItems) {
+        // Bootstrap: build default values from static items first
+        const defaults = {};
+        for (const [k, opt] of Object.entries(this.config.options)) {
+          if (opt.items && opt.items.length > 0) {
+            const d = opt.items.find(i => i.default);
+            defaults[k] = d ? d.id : opt.items[0].id;
+          }
+        }
+        items = option.getDynamicItems(defaults);
+      }
+      const defaultItem = items && items.find(i => i.default);
+      state[key] = defaultItem ? defaultItem.id : (items && items[0] ? items[0].id : '');
+    }
+    return state;
+  }
+
+  _handleChange(optionName, value) {
+    this.values[optionName] = value;
+    this._render();
+  }
+
+  _render() {
+    this.container.innerHTML = '';
+    const wrapper = document.createElement('div');
+    wrapper.className = 'config-generator';
+
+    for (const [key, option] of Object.entries(this.config.options)) {
+      // Conditional visibility
+      if (option.condition && !option.condition(this.values)) {
+        continue;
+      }
+
+      const card = document.createElement('div');
+      card.className = 'config-option';
+
+      const title = document.createElement('div');
+      title.className = 'config-option-title';
+      title.textContent = option.title;
+      card.appendChild(title);
+
+      const items = document.createElement('div');
+      items.className = 'config-option-items';
+
+      const resolvedItems = option.getDynamicItems
+        ? option.getDynamicItems(this.values)
+        : option.items;
+
+      // If the current value is disabled or doesn't exist in resolved items, auto-select first enabled
+      const currentValid = resolvedItems.find(i => i.id === this.values[key] && !i.disabled);
+      if (!currentValid) {
+        const firstEnabled = resolvedItems.find(i => !i.disabled);
+        if (firstEnabled) {
+          this.values[key] = firstEnabled.id;
+        }
+      }
+
+      for (const item of resolvedItems) {
+        const label = document.createElement('label');
+        const isChecked = this.values[key] === item.id;
+        const isDisabled = item.disabled || false;
+
+        label.className = 'config-option-label'
+          + (isChecked ? ' checked' : '')
+          + (isDisabled ? ' disabled' : '');
+        if (item.disabledReason) {
+          label.title = item.disabledReason;
+        }
+
+        const input = document.createElement('input');
+        input.type = 'radio';
+        input.name = option.name;
+        input.value = item.id;
+        input.checked = isChecked;
+        input.disabled = isDisabled;
+        if (!isDisabled) {
+          input.addEventListener('change', () => this._handleChange(key, item.id));
+        }
+        label.appendChild(input);
+
+        label.appendChild(document.createTextNode(item.label));
+
+        if (item.subtitle) {
+          const sub = document.createElement('small');
+          sub.className = 'config-option-subtitle';
+          sub.textContent = item.subtitle;
+          label.appendChild(sub);
+        }
+
+        items.appendChild(label);
+      }
+
+      card.appendChild(items);
+      wrapper.appendChild(card);
+    }
+
+    // Command output
+    const cmdCard = document.createElement('div');
+    cmdCard.className = 'config-command';
+
+    const cmdTitle = document.createElement('div');
+    cmdTitle.className = 'config-command-title';
+    cmdTitle.textContent = 'Run this Command:';
+    cmdCard.appendChild(cmdTitle);
+
+    const cmdPre = document.createElement('pre');
+    cmdPre.className = 'config-command-display';
+    const command = this.config.generateCommand
+      ? this.config.generateCommand(this.values)
+      : '';
+    cmdPre.textContent = command;
+
+    // Copy button
+    const copyBtn = document.createElement('button');
+    copyBtn.className = 'config-command-copy';
+    copyBtn.textContent = 'Copy';
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(command).then(() => {
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
+      });
+    });
+    cmdPre.appendChild(copyBtn);
+
+    cmdCard.appendChild(cmdPre);
+    wrapper.appendChild(cmdCard);
+
+    this.container.appendChild(wrapper);
+  }
+}
+
+// Expose globally for use in markdown <script> blocks
+window.ConfigGenerator = ConfigGenerator;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,11 @@ markdown_extensions:
   - mdx_math:
       enable_dollar_delimiter: true
 
+extra_css:
+  - assets/config-generator.css
+
 extra_javascript:
   - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
+  - assets/config-generator.js
 
 use_directory_urls: false


### PR DESCRIPTION
## Summary

- Adds a reusable interactive configuration selector widget for vLLM deployment recipes, inspired by [SGLang Cookbook's ConfigGenerator](https://github.com/sgl-project/sgl-cookbook/blob/ff72b065c6e65afceb72ed6588a1adb93de22bae/src/components/base/ConfigGenerator/index.js#L12)
- Built with vanilla HTML/CSS/JS that works natively with MkDocs Material (no React or build step needed)
- Includes a proof-of-concept in the **Llama 3.3 70B recipe** with options for hardware platform, quantization, tensor parallelism, and prefix caching
- Supports light/dark mode via MkDocs Material CSS variables, dynamic option dependencies (e.g. NVFP4 auto-disabled on Hopper), and copy-to-clipboard

<img width="1410" height="827" alt="image" src="https://github.com/user-attachments/assets/5d2a99ed-b553-41f2-8eb3-5949dcf16758" />


### How to add to other recipes

Recipe authors just add a `<div>` and `<script>` block (~40 lines) defining model-specific options and a `generateCommand` function. The base component (`assets/config-generator.js` + `assets/config-generator.css`) handles all the rendering and state management.

## Test plan

- [x] Run `mkdocs serve` and verify the Llama 3.3 70B recipe shows the interactive selector
- [x] Click through hardware/quantization/TP options and verify the generated command updates correctly
- [x] Verify NVFP4 is disabled when Hopper is selected
- [ ] Verify dark mode styling works
- [ ] Verify copy button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)