### PR TITLE
Add Open Graph meta tags for link previews

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: vLLM Recipes
 site_url: !ENV READTHEDOCS_CANONICAL_URL
+site_description: A collection of recipes and guides for using vLLM with a variety of models.
 repo_url: https://github.com/vllm-project/recipes
 edit_uri: edit/main/
 docs_dir: .
@@ -7,6 +8,7 @@ strict: true
 
 theme:
   name: material
+  custom_dir: overrides
   logo: https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-only-light.ico
   favicon: https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-only-light.ico
   palette:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
+  {{ super() }}
   {% if page %}
   <meta property="og:type" content="article">
   <meta property="og:title" content="{{ page.meta.title or page.title }}">
@@ -8,7 +9,7 @@
   <meta property="og:url" content="{{ page.canonical_url }}">
   <meta property="og:site_name" content="{{ config.site_name }}">
   <meta property="og:image" content="https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-text-light.png">
-  <meta name="twitter:card" content="summary">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="{{ page.meta.title or page.title }}">
   <meta name="twitter:description" content="{{ page.meta.description or config.site_description or page.title }}">
   <meta name="twitter:image" content="https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-text-light.png">

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="{{ page.meta.title or page.title }}">
+  <meta property="og:description" content="{{ page.meta.description or config.site_description or page.title }}">
+  <meta property="og:url" content="{{ page.canonical_url }}">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:image" content="https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-text-light.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ page.meta.title or page.title }}">
+  <meta name="twitter:description" content="{{ page.meta.description or config.site_description or page.title }}">
+  <meta name="twitter:image" content="https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-text-light.png">
+{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
+  {% if page %}
   <meta property="og:type" content="article">
   <meta property="og:title" content="{{ page.meta.title or page.title }}">
   <meta property="og:description" content="{{ page.meta.description or config.site_description or page.title }}">
@@ -11,4 +12,5 @@
   <meta name="twitter:title" content="{{ page.meta.title or page.title }}">
   <meta name="twitter:description" content="{{ page.meta.description or config.site_description or page.title }}">
   <meta name="twitter:image" content="https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-text-light.png">
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Adds a MkDocs Material template override (`overrides/main.html`) that injects Open Graph and Twitter Card meta tags into every page's `<head>`
- Enables link previews when recipe URLs are shared on Slack, Discord, Twitter, etc.
- Uses the vLLM logo as the `og:image` thumbnail
- Adds `site_description` to `mkdocs.yml` as a fallback description for pages without explicit descriptions

## Details
Currently, sharing a link like `https://docs.vllm.ai/projects/recipes/en/latest/Google/Gemma4.html` on platforms like Slack or Discord shows no preview because the pages lack Open Graph meta tags. This PR fixes that by adding:

- `og:title`, `og:description`, `og:url`, `og:site_name`, `og:type`, `og:image`
- `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`

Individual pages can set a custom description via markdown frontmatter:
```yaml
---
description: "Guide for running Google's Gemma 4 model with vLLM"
---
```

## Test plan
- [x] Deploy to ReadTheDocs preview and verify `<meta property="og:...">` tags appear in page source
- [x] Test a preview link using https://www.opengraph.xyz/ or similar validator
- [ ] Verify the vLLM logo image loads correctly in previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)