### PR TITLE
MiniMax-M2.5: update B200 FP8 serving config

### DIFF
--- a/MiniMax/MiniMax-M2.5.md
+++ b/MiniMax/MiniMax-M2.5.md
@@ -34,16 +34,21 @@ MiniMax-M2.5 can be run on different GPU configurations. The recommended setup u
 
 ### B200 (FP8)
 
+Recommended configuration uses 4 GPUs with tensor and expert parallelism. A 2-GPU configuration (`--tensor-parallel-size 2 --enable-expert-parallel`) is also supported.
+
 ```bash
 docker run --gpus all \
   -p 8000:8000 \
   --ipc=host \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
-  vllm/vllm-openai:nightly MiniMaxAI/MiniMax-M2.5 \
+  vllm/vllm-openai:latest MiniMaxAI/MiniMax-M2.5 \
       --tensor-parallel-size 4 \
-      --tool-call-parser minimax_m2 \
-      --reasoning-parser minimax_m2_append_think \
-      --enable-auto-tool-choice \
+      --enable-expert-parallel \
+      --gpu-memory-utilization 0.90 \
+      --block-size 32 \
+      --kv-cache-dtype fp8 \
+      --stream-interval 20 \
+      --no-enable-prefix-caching \
       --trust-remote-code
 ```
 


### PR DESCRIPTION
## Summary

- Add `--enable-expert-parallel` (tp:4/ep:4 validated; tp:2/ep:2 also noted)
- Add `--gpu-memory-utilization 0.90`
- Add `--block-size 32`
- Add `--kv-cache-dtype fp8`
- Add `--stream-interval 20`
- Add `--no-enable-prefix-caching`
- Switch image tag from `nightly` to `latest`

Based on SemiAnalysisAI/InferenceX#1010, which validated and widened the B200 FP8 search space for MiniMax-M2.5 (tp:4/ep:4 at conc 256–512, tp:2/ep:2 at conc 512).