### PR TITLE
chore: remove --compilation_config.pass_config.fuse_allreduce_rms from Kimi-K2.5 recipe

### DIFF
--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -21,7 +21,6 @@ docker run --gpus all \
   vllm/vllm-openai:v0.17.0-cu130 moonshotai/Kimi-K2.5 \
     --tensor-parallel-size 8 \
     --mm-encoder-tp-mode data \
-    --compilation_config.pass_config.fuse_allreduce_rms true \
     --tool-call-parser kimi_k2 \
     --reasoning-parser kimi_k2 \
     --enable-auto-tool-choice \
@@ -39,7 +38,6 @@ docker run --gpus all \
   vllm/vllm-openai:v0.17.0-aarch64-cu130 moonshotai/Kimi-K2.5 \
     --tensor-parallel-size 4 \
     --mm-encoder-tp-mode data \
-    --compilation_config.pass_config.fuse_allreduce_rms true \
     --tool-call-parser kimi_k2 \
     --reasoning-parser kimi_k2 \
     --enable-auto-tool-choice \
@@ -59,7 +57,6 @@ See the following command to deploy Kimi-K2.5 with the vLLM inference server. Th
 ```bash
 vllm serve moonshotai/Kimi-K2.5 -tp 8 \
     --mm-encoder-tp-mode data \
-    --compilation_config.pass_config.fuse_allreduce_rms true \
     --tool-call-parser kimi_k2 \
     --reasoning-parser kimi_k2 \
     --enable-auto-tool-choice \


### PR DESCRIPTION
## Summary

- Removes `--compilation_config.pass_config.fuse_allreduce_rms true` from all three command examples in the Kimi-K2.5 recipe (Hopper Docker, Blackwell Docker, and `vllm serve`)
- This flag is no longer needed as of vLLM v0.17 — it is now enabled by default for MoE models on Hopper hardware (confirmed by Hanjie Qiu and Wei Zhao)

Closes #324

## Test plan

- [ ] Verify commands run correctly on vLLM v0.17+ without the flag