### PR TITLE
update glm-5.1 deployment command

### DIFF
--- a/GLM/GLM5.md
+++ b/GLM/GLM5.md
@@ -53,7 +53,7 @@ vllm serve zai-org/GLM-5.1-FP8 \
      --tool-call-parser glm47 \
      --reasoning-parser glm45 \
      --enable-auto-tool-choice \
-    --chat-template-content-format=string \
+     --chat-template-content-format=string \
      --served-model-name glm-5.1-fp8
 ```
 

--- a/GLM/GLM5.md
+++ b/GLM/GLM5.md
@@ -18,10 +18,12 @@ docker run --gpus all \
     --tool-call-parser glm47 \
     --reasoning-parser glm45 \
     --enable-auto-tool-choice \
+    --chat-template-content-format=string \
     --served-model-name glm-5.1-fp8
 ```
 
 Please use the `vllm/vllm-openai:glm51-cu130` Docker image if your CUDA version is 13 or higher.
+>Note: When encounter Tool Call Parse issue with MTP enabled, please turn to vllm main branch to serve GLM-5.1.
 
 ### Installing vLLM from source
 
@@ -51,6 +53,7 @@ vllm serve zai-org/GLM-5.1-FP8 \
      --tool-call-parser glm47 \
      --reasoning-parser glm45 \
      --enable-auto-tool-choice \
+    --chat-template-content-format=string \
      --served-model-name glm-5.1-fp8
 ```
 
@@ -205,6 +208,3 @@ Per-position acceptance (%):
   Position 2:                            7.00      
 ==================================================
 ```
-
-
-

--- a/GLM/GLM5.md
+++ b/GLM/GLM5.md
@@ -23,7 +23,8 @@ docker run --gpus all \
 ```
 
 Please use the `vllm/vllm-openai:glm51-cu130` Docker image if your CUDA version is 13 or higher.
->Note: When encounter Tool Call Parse issue with MTP enabled, please turn to vllm main branch to serve GLM-5.1.
+!!! Note
+    Please use the latest main branch of vLLM to serve GLM-5.1 if you intend to use tool calling together with MTP enabled.
 
 ### Installing vLLM from source
 


### PR DESCRIPTION
add `--chat-completion-content-format=string` to avoid `chat-template` related `tool_response` issue.
see (https://github.com/vllm-project/vllm/pull/39253#issuecomment-4211850796)