### PR TITLE
Refactor recipes into YAML schema + Next.js interactive site

### DIFF
--- a/.claude/skills/add-recipe/SKILL.md
+++ b/.claude/skills/add-recipe/SKILL.md
@@ -35,6 +35,17 @@ meta:
     - text
   performance_headline: "..."     # optional pithy line for cards
   related_recipes: []             # optional list of "<org>/<repo>" ids
+  # Optional. Per-GPU support level renders as a colored dot on the hardware pill:
+  #   verified  = author has actually tested this hardware end-to-end (green)
+  #   supported = author claims it works, not verified in this repo (blue)
+  # GPUs omitted → treated as "untested", hardware pill shows a hollow grey dot.
+  # Default: seed any GPU whose `hardware_overrides.<gen>` block exists as
+  # `supported`; promote to `verified` only when the upstream README/benchmark
+  # explicitly verifies it.
+  hardware:
+    h200: verified
+    b200: supported
+    mi300x: supported
 
 model:
   model_id: "<hf_org>/<hf_repo>"  # MUST match the filename path

--- a/.claude/skills/add-recipe/SKILL.md
+++ b/.claude/skills/add-recipe/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: add-recipe
+description: Use when the user asks to add, contribute, or create a new vLLM recipe in this repo (e.g. "add a recipe for Qwen/Qwen3-XYZ", "create a recipe for huggingface.co/org/model"). Walks through fetching HF metadata, authoring the YAML at models/<hf_org>/<hf_repo>.yaml, picking variants/strategies, validating, and committing.
+---
+
+# Add a new vLLM recipe
+
+Recipes are YAML files at `models/<hf_org>/<hf_repo>.yaml`. The path mirrors HuggingFace (`huggingface.co/<hf_org>/<hf_repo>`), and the site/API are generated at build time from these files + `taxonomy.yaml` + `strategies/*.yaml`.
+
+## End-to-end steps
+
+1. **Confirm the HF id.** You need the exact `<org>/<repo>` string. If the user gave a URL, strip the `https://huggingface.co/` prefix.
+2. **Fetch model metadata.** Run `bash scripts/hf-info.sh <org>/<repo>` to pull `config.json` / `params.json`. Extract:
+   - `architecture`: `moe` if `num_experts`, `num_local_experts`, `moe.num_experts`, or a `*MoE*` architecture name is present. Otherwise `dense`.
+   - `parameter_count`: total params (e.g. `"671B"`, `"70B"`). Use HF model card or the sum of shard sizes.
+   - `active_parameters`: for MoE, the activated-per-token count (e.g. `"37B"` on DeepSeek-V3.2). For dense, equal to `parameter_count`.
+   - `context_length`: `max_position_embeddings` from `config.json` (for VL models, from `text_config.max_position_embeddings`).
+   - `min_vllm_version`: the earliest vllm that supports the architecture — check the model card or vLLM release notes. Err on the side of `0.11.0` or newer unless the card specifies.
+3. **Create the YAML.** Write `models/<hf_org>/<hf_repo>.yaml` following the schema below. Only include sections the model needs; leave `features: {}`, `opt_in_features: []`, `hardware_overrides: {}`, `strategy_overrides: {}` empty if not applicable.
+4. **Register the provider (if new).** If `<hf_org>` isn't already in `src/lib/providers.js`, add an entry with `display_name` and the logo path `/providers/<hf_org>.png` (or `.jpeg`). Logos get downloaded by `scripts/fetch-provider-logos.mjs` on the next build.
+5. **Validate.** Run `node scripts/build-recipes-api.mjs`. It must print `✓ JSON API: N models, 7 strategies` with no errors.
+6. **Commit.** Follow the user's earlier feedback (no kill-and-rebuild of dev server; syntax-check only).
+
+## YAML schema (top-level fields, in order)
+
+```yaml
+meta:
+  title: "..."                    # display name (e.g. "DeepSeek-V3.2")
+  slug: "..."                     # lowercase-kebab (legacy, keep consistent with title)
+  provider: "..."                 # human-readable org label (e.g. "DeepSeek")
+  description: "..."              # one-sentence summary
+  date_updated: YYYY-MM-DD        # today's date, or the date the recipe was authored
+  difficulty: beginner|intermediate|advanced
+  tasks:                          # one or more of: text, multimodal, omni, embedding
+    - text
+  performance_headline: "..."     # optional pithy line for cards
+  related_recipes: []             # optional list of "<org>/<repo>" ids
+
+model:
+  model_id: "<hf_org>/<hf_repo>"  # MUST match the filename path
+  min_vllm_version: "0.11.0"      # string, e.g. "0.12.0"
+  architecture: dense|moe
+  parameter_count: "30B"          # string with suffix (B or T)
+  active_parameters: "30B"        # same as parameter_count for dense models
+  context_length: 131072          # integer (tokens)
+  base_args: []                   # flags always needed (trust-remote-code, etc.)
+  base_env: {}                    # env vars always needed
+
+# Optional — only if the recipe needs extra pip installs beyond `uv pip install -U vllm`.
+# Rendered as an "extra install" block above the vllm serve command.
+dependencies:
+  - note: "Why you need it (one line)"
+    command: 'uv pip install -U "vllm[audio]"'
+    optional: false               # omit or false for required; true to mark optional
+
+features:
+  tool_calling:                   # flip any of these pills; recipe chooses naming
+    description: "..."
+    args: ["--enable-auto-tool-choice", "--tool-call-parser", "<name>"]
+  reasoning:
+    description: "..."
+    args: ["--reasoning-parser", "<name>"]
+  spec_decoding:                  # USE spec_decoding, NOT mtp — unified key for
+    description: "..."            # MTP / Eagle3 / ERNIE-MTP / etc.
+    args: ["--speculative-config", '{"method":"mtp","num_speculative_tokens":1}']
+
+opt_in_features:                  # features that default OFF (users tick them on)
+  - spec_decoding                 # spec decoding is opt-in unless the model docs insist
+
+variants:
+  default:                        # ALWAYS include a `default` variant
+    precision: bf16|fp8|nvfp4|fp4|int4|int8|awq|gptq|mxfp4
+    vram_minimum_gb: <integer>    # params × bytes × 1.2 (see formula below)
+    description: "..."
+  fp8:                            # optional extra variants
+    model_id: "<optional override>"   # only if the quantized variant is a different HF repo
+    precision: fp8
+    vram_minimum_gb: <integer>
+    description: "..."
+    extra_args: []
+    extra_env: {}
+
+compatible_strategies:            # subset of the 7 in strategies/*.yaml
+  - single_node_tp                # always include this as a baseline
+  - single_node_tep               # for MoE
+  - single_node_dep               # for MoE
+  - multi_node_tp
+  - multi_node_dep                # for MoE
+  - multi_node_tep                # for MoE
+  - pd_cluster                    # only if the recipe documents PD
+
+hardware_overrides:               # optional per-generation flags
+  hopper:    { extra_args: [], extra_env: {} }
+  blackwell: { extra_args: [], extra_env: {} }
+  amd:       { extra_args: [], extra_env: {} }
+
+strategy_overrides: {}            # optional per-strategy tweaks
+
+guide: |                          # markdown, rendered as the Guide accordion
+  ## Overview
+  ...
+  ## Prerequisites
+  ...
+  ## Launch command
+  ...
+  ## Benchmarking
+  ...
+  ## References
+  - [Model card](https://huggingface.co/<hf_org>/<hf_repo>)
+```
+
+## VRAM formula
+
+`vram_minimum_gb = ceil(params × bytes_per_param × 1.2)` where params is the **total** parameter count (MoE includes inactive experts — they still live in VRAM).
+
+| Precision | Bytes/param |
+|-----------|-------------|
+| bf16, fp16 | 2 |
+| fp8, int8, awq, gptq (8-bit) | 1 |
+| int4, nvfp4, fp4, mxfp4 (4-bit) | 0.5 |
+
+Example: a 70B BF16 model → `70 × 2 × 1.2 = 168 GB`. Round up.
+
+If the variant is `model_id`-overridden and the override is a different base model with its own param count (e.g. a distilled FP4 checkpoint), use the override's parameter count — verify it via HF.
+
+## Naming and conventions
+
+- **Feature keys**: prefer `tool_calling`, `reasoning`, `spec_decoding`. Don't use `mtp` — it's been renamed across the repo.
+- **Strategy list**: MoE recipes usually support every strategy; dense recipes are limited to `single_node_tp` and `multi_node_tp` (TEP/DEP require MoE).
+- **Variants**: quantized variants reuse the base name (`fp8`, `nvfp4`, `int4`). If the quantized checkpoint is authored by someone else (e.g. `nvidia/*-NVFP4`), set `model_id:` inside the variant.
+- **Tasks**: `omni` means served via vLLM-Omni (offline Python, no `vllm serve`). The command builder hides the serve block for omni recipes — just put the Python usage in `guide:`.
+
+## Validation checklist
+
+Before committing:
+
+1. `node scripts/build-recipes-api.mjs` succeeds and the new recipe appears in the line count.
+2. `node -e "const d = require('./public/<hf_org>/<hf_repo>.json'); console.log(d.model.parameter_count, d.variants.default.vram_minimum_gb)"` prints sensible values.
+3. The YAML top-level key order matches the schema above — downstream tools don't care, but reviewers scan for it.
+
+## Commit
+
+Stage **only** the new recipe (and providers.js if edited):
+
+```bash
+git add models/<hf_org>/<hf_repo>.yaml src/lib/providers.js
+git commit -m "Add <hf_org>/<hf_repo> recipe"
+```
+
+Do not stage `public/` (it's generated) or the design docs.

--- a/.claude/skills/add-recipe/SKILL.md
+++ b/.claude/skills/add-recipe/SKILL.md
@@ -35,17 +35,12 @@ meta:
     - text
   performance_headline: "..."     # optional pithy line for cards
   related_recipes: []             # optional list of "<org>/<repo>" ids
-  # Optional. Per-GPU support level renders as a colored dot on the hardware pill:
-  #   verified  = author has actually tested this hardware end-to-end (green)
-  #   supported = author claims it works, not verified in this repo (blue)
-  # GPUs omitted → treated as "untested", hardware pill shows a hollow grey dot.
-  # Default: seed any GPU whose `hardware_overrides.<gen>` block exists as
-  # `supported`; promote to `verified` only when the upstream README/benchmark
-  # explicitly verifies it.
+  # Optional. Only `verified` is meaningful — GPUs you've actually run this
+  # recipe on end-to-end. Everything else is assumed to work silently (no
+  # "untested" warning). Only add an entry when you've truly tested it.
   hardware:
     h200: verified
-    b200: supported
-    mi300x: supported
+    mi355x: verified
 
 model:
   model_id: "<hf_org>/<hf_repo>"  # MUST match the filename path

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,14 @@
 venv
 site/
 .idea
+.next/
+out/
+node_modules/
+
+# Generated at pnpm build time (JSON API + provider logos)
+public/models.json
+public/strategies.json
+public/taxonomy.json
+public/strategies/
+public/providers/
+public/*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ taxonomy.yaml              ─┘       (SSG, no runtime DB)
 
 Top-level keys, in this order:
 
-- `meta` — title, slug, provider, description, date_updated, difficulty, tasks[], performance_headline, related_recipes[], optional `hardware: { gpu_id: verified|supported }` (omitted GPUs render as "untested" on the pill).
+- `meta` — title, slug, provider, description, date_updated, difficulty, tasks[], performance_headline, related_recipes[], optional `hardware: { gpu_id: verified }` (GPUs NOT listed are assumed to work silently — only `verified` carries a green ✓ badge; we don't flag "untested" because the common case is "works but nobody bothered to write it down").
 - `model` — `model_id`, `min_vllm_version`, `architecture` (`dense` or `moe`), `parameter_count`, `active_parameters`, `context_length`, `base_args[]`, `base_env{}`.
 - `dependencies` (optional) — list of `{ command, note?, optional? }`. Rendered as the "extra install" block above `vllm serve`. Use this for DeepGEMM pins, `vllm[audio]`, pinned transformers commits, vllm-omni source installs, etc.
 - `features` — map of `{feature_key: { description, args[] }}`. Naming convention: `tool_calling`, `reasoning`, `spec_decoding` (the unified key for MTP / Eagle3 / ERNIE-MTP — **don't use `mtp`**, it was renamed across all recipes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ taxonomy.yaml              ─┘       (SSG, no runtime DB)
 
 Top-level keys, in this order:
 
-- `meta` — title, slug, provider, description, date_updated, difficulty, tasks[], performance_headline, related_recipes[].
+- `meta` — title, slug, provider, description, date_updated, difficulty, tasks[], performance_headline, related_recipes[], optional `hardware: { gpu_id: verified|supported }` (omitted GPUs render as "untested" on the pill).
 - `model` — `model_id`, `min_vllm_version`, `architecture` (`dense` or `moe`), `parameter_count`, `active_parameters`, `context_length`, `base_args[]`, `base_env{}`.
 - `dependencies` (optional) — list of `{ command, note?, optional? }`. Rendered as the "extra install" block above `vllm serve`. Use this for DeepGEMM pins, `vllm[audio]`, pinned transformers commits, vllm-omni source installs, etc.
 - `features` — map of `{feature_key: { description, args[] }}`. Naming convention: `tool_calling`, `reasoning`, `spec_decoding` (the unified key for MTP / Eagle3 / ERNIE-MTP — **don't use `mtp`**, it was renamed across all recipes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+Two overlapping things live here:
+
+1. **A content repo** for vLLM recipes — structured YAML at `models/<hf_org>/<hf_repo>.yaml`, one per model. The path mirrors HuggingFace so the site URL `/<hf_org>/<hf_repo>` matches `huggingface.co/<hf_org>/<hf_repo>`.
+2. **A Next.js 15 site** (App Router, React 19, Tailwind v4) that renders those YAMLs as an interactive command builder + static JSON API under `public/`. The older top-level Markdown directories (`DeepSeek/`, `Qwen/`, etc.) and `mkdocs.yml` are the legacy MkDocs site, kept for reference during migration.
+
+The site is the canonical surface. New work goes into YAMLs + the Next.js app; the `.md` files are historical sources for the migrated YAMLs.
+
+## Commands
+
+```bash
+pnpm dev                                # Next dev server (do not kill or rebuild as part of a task)
+pnpm build                              # Regenerates JSON API + fetches logos/HF dates, then next build
+pnpm lint                               # next lint (ESLint)
+node scripts/build-recipes-api.mjs      # Rebuild the JSON API only — fastest validation that all YAMLs parse
+node scripts/fetch-provider-logos.mjs   # Re-download HF org avatars to public/providers/
+node scripts/fetch-hf-dates.mjs         # Refresh public/hf-dates.json (HF createdAt per model)
+bash scripts/hf-info.sh <org>/<repo>    # Pull config.json / params.json for a model (used when authoring recipes)
+```
+
+There is no unit-test suite. The build-recipes-api script is the de-facto validator: if it prints `✓ JSON API: N models, 7 strategies` the YAML set is internally consistent.
+
+**Dev-server convention:** don't kill or restart the dev server as part of a task, and don't run `pnpm build` for each change. Use `node scripts/build-recipes-api.mjs` for fast feedback on YAML edits; rely on Next's HMR for `src/` edits.
+
+## Architecture
+
+### Data pipeline
+
+```
+models/<org>/<repo>.yaml  ──┐
+strategies/*.yaml          ─┼──► src/lib/*.js  ─► Next.js pages + JSON API in public/
+taxonomy.yaml              ─┘       (SSG, no runtime DB)
+```
+
+- `taxonomy.yaml` — the controlled vocabulary: hardware profiles (GPUs/node + VRAM), tasks, strategy ids. Every recipe references ids from here.
+- `strategies/*.yaml` — 7 deployment strategies: `single_node_{tp,tep,dep}`, `multi_node_{tp,tep,dep}`, `pd_cluster`. Each defines the vLLM flags and env for that parallelism pattern.
+- `src/lib/recipes.js`, `strategies.js`, `taxonomy.js` — filesystem readers that parse YAML once per process.
+- `src/lib/command-synthesis.js` — **the core of the site**. Pure functions that take `(recipe, variantKey, strategyName, hwProfileId, features, strategies, taxonomy, advancedArgs, nodeCount)` and return either a single `vllm serve` command, a pair of head+worker commands (multi-node), or a prefill/decode pair (pd_cluster). All parallel flag decisions, per-generation hardware overrides, and multi-node mp args (`--nnodes`/`--node-rank`/`--master-addr` for TP, `--data-parallel-*` for DEP) live here.
+- `scripts/build-recipes-api.mjs` — writes `public/taxonomy.json`, `public/strategies/*.json`, and `public/<hf_org>/<hf_repo>.json` at build time so agents can consume recipes without the website.
+
+### Next.js App Router
+
+- `src/app/page.js` — homepage (provider grid, alphabetical).
+- `src/app/[org]/page.js` — org overview, task-grouped sections.
+- `src/app/[org]/[repo]/page.js` — **the recipe detail page**. SSG via `generateStaticParams` over all YAMLs. Renders header + `<CommandBuilder>` + guide markdown (via `react-markdown`, not MDX — MDX chokes on `<think>` and `<64K` literals in guide text).
+- `src/app/[org]/layout.js` — wraps every recipe/org page with the left `<ModelSidebar>`, sorted by HF release date desc.
+- `src/components/recipes/CommandBuilder.jsx` — the interactive piece. Client component. Holds state for `variant`, `hwId`, `strategyOverride`, `nodeCount`, `features`, `advanced`; syncs all of them to URL query params; renders Hardware / Variant / Strategy / Nodes / Features / Advanced rows + the sticky command block. Calls `resolveCommand` on every change.
+
+### Recipe YAML schema (authoritative)
+
+Top-level keys, in this order:
+
+- `meta` — title, slug, provider, description, date_updated, difficulty, tasks[], performance_headline, related_recipes[].
+- `model` — `model_id`, `min_vllm_version`, `architecture` (`dense` or `moe`), `parameter_count`, `active_parameters`, `context_length`, `base_args[]`, `base_env{}`.
+- `dependencies` (optional) — list of `{ command, note?, optional? }`. Rendered as the "extra install" block above `vllm serve`. Use this for DeepGEMM pins, `vllm[audio]`, pinned transformers commits, vllm-omni source installs, etc.
+- `features` — map of `{feature_key: { description, args[] }}`. Naming convention: `tool_calling`, `reasoning`, `spec_decoding` (the unified key for MTP / Eagle3 / ERNIE-MTP — **don't use `mtp`**, it was renamed across all recipes).
+- `opt_in_features[]` — subset of feature keys that default OFF; others default ON. Typically `spec_decoding` is opt-in.
+- `variants` — must include a `default` variant. Each has `precision`, `vram_minimum_gb`, optional `description`, optional `model_id` override (for quantized checkpoints shipped under a different HF repo, e.g. `nvidia/*-NVFP4`), optional `extra_args`/`extra_env`.
+- `compatible_strategies[]` — subset of the 7 strategy ids. Dense models typically only get `single_node_tp` + `multi_node_tp`; MoE models can have all seven.
+- `hardware_overrides` — optional per-generation tweaks keyed by `hopper`, `blackwell`, `amd`. Each: `{ extra_args[], extra_env{} }`.
+- `strategy_overrides` — optional per-strategy tweaks (rare).
+- `guide` — markdown string (`|`-block), rendered with `react-markdown` + `remark-gfm` + `rehype-slug`.
+
+**VRAM formula**: `vram_minimum_gb = ceil(params × bytes × 1.2)`. Bytes per param: bf16/fp16=2, fp8/int8/awq/gptq=1, int4/nvfp4/fp4/mxfp4=0.5. For MoE, use total params (inactive experts still live in VRAM).
+
+### Non-obvious design decisions
+
+- **Hardware is never blocked by VRAM.** Multi-node scales VRAM, so `command-synthesis.js` only uses VRAM as a display hint. Precision constraints (NVFP4/FP4 require Blackwell) are the only things that disable a hardware pill.
+- **Default hardware is always H200** (or B200 for Blackwell-constrained variants). `pickDefaultHardware` prefers NVIDIA over AMD; `loadPreferences` deliberately ignores AMD entries from localStorage so first-page-load is always H200.
+- **Omni recipes skip the command builder entirely** — `CommandBuilder` returns an "Served via vLLM-Omni" notice instead, because these models use offline Python scripts, not `vllm serve`. Detection: `meta.tasks` includes `omni`.
+- **Multi-node uses vLLM mp (multiprocessing) backend**, not Ray. For TP/TEP every node runs the same command varying `--node-rank`; rank>0 adds `--headless`. For DEP, Node N adds `--data-parallel-start-rank = N × gpus_per_node`. The UI shows exactly two tabs (Head + Node 1) as a 2-node example.
+- **Taxonomy hardware specs** follow [inferencex.semianalysis.com/gpu-specs](https://inferencex.semianalysis.com/gpu-specs): B200 SXM is 180 GB/GPU (not the nameplate 192, which is pre-ECC), GB200/GB300 are **4-GPU compute trays** (NVL4, the NVL72 rack unit), B300 is 268 GB/GPU.
+- **Legacy Markdown under `DeepSeek/`, `Qwen/` etc. is read-only reference.** When migrating or updating a recipe, read those to extract flags and env, but write the YAML; don't edit the Markdown.
+- **`public/` is generated** — don't commit it. `.gitignore` should cover it; if something slips through, leave it untracked.
+
+## Contributing a new recipe
+
+A dedicated skill lives at `.claude/skills/add-recipe/SKILL.md` and is auto-loaded when the user asks to add/create/contribute a recipe. It covers HF metadata extraction, the full schema, VRAM formula, provider-registry updates, and the validation/commit loop.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,264 @@
+# Contributing a new recipe
+
+This repo hosts structured YAML recipes for serving open-weight models with
+vLLM. Each recipe renders on [recipes.vllm.ai](https://recipes.vllm.ai/) as an
+interactive command builder (pick hardware, variant, strategy → copy the exact
+`vllm serve` command) and is exported as static JSON under `public/` for
+agents/tools to consume.
+
+One recipe = one YAML file at `models/<hf_org>/<hf_repo>.yaml`. The path
+mirrors HuggingFace so the site URL `/<hf_org>/<hf_repo>` matches
+`huggingface.co/<hf_org>/<hf_repo>` exactly.
+
+## Quick start
+
+1. Fork + clone the repo.
+2. Create `models/<hf_org>/<hf_repo>.yaml` using the schema below.
+3. Validate: `node scripts/build-recipes-api.mjs` — must print
+   `✓ JSON API: N models, 8 strategies` with no errors.
+4. Preview locally: `pnpm install && pnpm dev` → open
+   `http://localhost:3000/<hf_org>/<hf_repo>`.
+5. Open a PR.
+
+## Fetching HuggingFace metadata
+
+Before authoring, pull the model's HF config to get architecture, parameter
+count, and context length correct:
+
+```bash
+bash scripts/hf-info.sh <hf_org>/<hf_repo>
+```
+
+This dumps `config.json` / `params.json`. Look at:
+
+- **`architectures`** — names like `*MoE*`, `*Mixtral*`, presence of
+  `num_experts` / `num_local_experts` / `moe.num_experts` → set
+  `architecture: moe`. Otherwise `dense`.
+- **`max_position_embeddings`** (or `text_config.max_position_embeddings` for
+  VL models) → `context_length`.
+- **`torch_dtype` / `quantization_config`** → `precision` on the default
+  variant (bf16, fp16, fp8, nvfp4, int4, etc.).
+
+## YAML schema (authoritative)
+
+Top-level keys, in this order:
+
+```yaml
+meta:
+  title: "DeepSeek-V3.2"                          # display name
+  slug: "deepseek-v3.2"                           # kebab-case; keep consistent with title
+  provider: "DeepSeek"                            # human-readable label
+  description: "…"                                # one-sentence summary
+  date_updated: 2026-04-20                        # today's date (or last touch)
+  difficulty: intermediate                        # beginner | intermediate | advanced
+  tasks:
+    - text                                        # one or more of: text, multimodal, omni, embedding
+  performance_headline: "…"                       # optional pithy line for cards
+  related_recipes: ["deepseek-ai/DeepSeek-V3.1"]  # optional list of "<org>/<repo>" ids
+  # Optional — only add GPUs you've ACTUALLY tested end-to-end.
+  # Missing GPUs are assumed to work silently (we don't flag "untested").
+  hardware:
+    h200: verified
+    mi355x: verified
+
+model:
+  model_id: "deepseek-ai/DeepSeek-V3.2"           # MUST match the filename path
+  min_vllm_version: "0.18.0"                      # earliest vLLM release that supports this model
+  architecture: moe                               # dense | moe
+  parameter_count: "671B"                         # total params with B/T suffix
+  active_parameters: "37B"                        # same as parameter_count for dense models
+  context_length: 163840                          # integer (tokens)
+  supports_dcp: true                              # optional — MLA-attention models (DeepSeek, Kimi-K2 family)
+  base_args:                                      # flags always needed
+    - "--trust-remote-code"
+  base_env:                                       # env vars always needed
+    VLLM_USE_FLASHINFER_MOE_FP8: "1"
+
+# Optional — extra install steps beyond `uv pip install -U vllm`.
+# Rendered as a code block above the vllm serve command.
+dependencies:
+  - note: "DeepGEMM required for FP8 MoE kernels"
+    command: "uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation"
+  - note: "Set VLLM_USE_DEEP_GEMM=0 to skip DeepGEMM (recommended on H20)"
+    command: "export VLLM_USE_DEEP_GEMM=0"
+    optional: true
+
+features:
+  tool_calling:                                   # names are conventions, not required keys
+    description: "Enable …"
+    args: ["--enable-auto-tool-choice", "--tool-call-parser", "<name>"]
+  reasoning:
+    description: "…"
+    args: ["--reasoning-parser", "<name>"]
+  spec_decoding:                                  # USE spec_decoding, NOT mtp — unified key for MTP / Eagle3 / ERNIE-MTP
+    description: "…"
+    args: ["--speculative-config", '{"method":"mtp","num_speculative_tokens":1}']
+
+opt_in_features:                                  # features that default OFF (users tick them on)
+  - spec_decoding                                 # spec decoding is opt-in unless docs insist
+
+variants:
+  default:                                        # ALWAYS include a `default` variant
+    precision: fp8                                # bf16|fp8|nvfp4|fp4|int4|int8|awq|gptq|mxfp4
+    vram_minimum_gb: 805                          # params × bytes × 1.2 (see formula below)
+    description: "…"
+  nvfp4:                                          # optional additional variants
+    model_id: "nvidia/*-NVFP4"                    # only if the quantized checkpoint is a different HF repo
+    precision: nvfp4
+    vram_minimum_gb: 403
+    extra_args: ["--kv-cache-dtype", "fp8"]
+    extra_env: { VLLM_USE_FLASHINFER_MOE_FP4: "1" }
+
+compatible_strategies:                            # subset of the 8 strategy ids in strategies/*.yaml
+  - single_node_tp                                # always include as baseline
+  - single_node_tep                               # for MoE
+  - single_node_dep                               # for MoE
+  - multi_node_tp
+  - multi_node_tp_pp                              # TP within node + PP across — vLLM's recommended multi-node default
+  - multi_node_dep                                # for MoE
+  - multi_node_tep                                # for MoE
+  - pd_cluster                                    # only if the recipe documents PD
+
+# Optional per-generation tweaks.
+# Key by `hopper` / `blackwell` / `amd` for per-family overrides, OR use
+# `nvidia` as a brand-wide fallback that applies to every NVIDIA GPU when
+# no generation-specific block is present.
+hardware_overrides:
+  blackwell:
+    extra_args: ["--attention-backend", "FLASHINFER_MLA"]
+    extra_env: {}
+  amd:
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+# Optional per-strategy tweaks. Rare. PD recipes use this to pin per-role args.
+strategy_overrides:
+  pd_cluster:
+    prefill:
+      vllm_args: ["--enforce-eager"]
+      env: {}
+    decode:
+      vllm_args: ["--compilation-config", '{"cudagraph_mode":"FULL_DECODE_ONLY"}']
+      env: {}
+
+# Markdown guide. Rendered on the recipe page under the command builder.
+# Covers Overview, Prerequisites, Launch, Benchmarking, Troubleshooting, References.
+guide: |
+  ## Overview
+  ...
+
+  ## Prerequisites
+  - **Hardware**: 8x H200
+  - **vLLM**: >= 0.18.0
+
+  ## Launching the Server
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-V3.2 --tensor-parallel-size 8 ...
+  ```
+
+  ## References
+  - [Model card](https://huggingface.co/deepseek-ai/DeepSeek-V3.2)
+```
+
+## VRAM formula
+
+`vram_minimum_gb = ceil(params × bytes_per_param × 1.2)` — uses **total**
+params (MoE counts inactive experts; they still live in VRAM).
+
+| Precision | Bytes per param |
+|-----------|-----------------|
+| bf16, fp16 | 2 |
+| fp8, int8, awq, gptq | 1 |
+| int4, nvfp4, fp4, mxfp4 | 0.5 |
+
+Examples:
+- 70B BF16 → `70 × 2 × 1.2 = 168 GB`
+- 671B FP8 → `671 × 1 × 1.2 = 805 GB`
+- 235B NVFP4 → `235 × 0.5 × 1.2 = 141 GB`
+
+If a `model_id`-override variant points to a different base (e.g., a distilled
+FP4 checkpoint), use **that** model's parameter count, not the base.
+
+## Naming conventions
+
+- Use **`spec_decoding`** for any speculative decoding feature (MTP / Eagle3 /
+  ERNIE-MTP / qwen3_next_mtp / step3p5_mtp). Don't use `mtp` — the key was
+  renamed across all recipes.
+- Dense models typically only get `single_node_tp` + `multi_node_tp` +
+  `multi_node_tp_pp`. MoE models can have all 8 strategies.
+- Quantized variants reuse the precision name (`fp8`, `nvfp4`, `int4`). If the
+  checkpoint is authored by someone else (e.g. `nvidia/*-NVFP4`), set
+  `model_id:` inside the variant.
+- Tasks: `omni` means the model is served via vLLM-Omni (offline Python, not
+  `vllm serve`). The command builder hides the serve block for omni recipes
+  and just surfaces the guide.
+
+## Provider logo (new organizations only)
+
+If `<hf_org>` isn't already in `src/lib/providers.js`, add an entry:
+
+```js
+"my-new-org": { display_name: "My New Org", logo: "/providers/my-new-org.png" },
+```
+
+The build script fetches the logo automatically from the HuggingFace avatar at
+build time:
+
+```bash
+node scripts/fetch-provider-logos.mjs
+```
+
+## Hardware support levels
+
+Only **`verified`** is a meaningful signal — GPUs you've actually tested with
+this recipe end-to-end. The site renders a green ✓ on those pills and shows
+"Verified on NVIDIA H200" above the command block when one is selected.
+
+GPUs **not** in `meta.hardware` render silently with no badge — the common
+case is "should work but nobody's written it down", and we don't flag that as
+a warning. Just add the entry when you test. Don't fill the list with
+speculative guesses.
+
+## Testing your recipe
+
+After saving the YAML, run:
+
+```bash
+# Fast validation: all YAMLs parse + JSON API builds
+node scripts/build-recipes-api.mjs
+
+# Full preview
+pnpm install
+pnpm dev
+# Open http://localhost:3000/<hf_org>/<hf_repo>
+```
+
+Click through Hardware / Variant / Strategy / Nodes pills and confirm the
+generated `vllm serve` command matches what you'd expect. The Verify / Bench
+popovers should open without clipping.
+
+## Commit style
+
+Stage **only** the new recipe YAML (and `providers.js` if you added an org):
+
+```bash
+git add models/<hf_org>/<hf_repo>.yaml
+# plus src/lib/providers.js if you added a new provider
+git commit -m "Add <hf_org>/<hf_repo> recipe"
+```
+
+Do not stage:
+
+- `public/` — generated at build time
+- `node_modules/`
+- `site/` — the legacy MkDocs output
+
+## Questions
+
+- Open an issue at https://github.com/vllm-project/recipes/issues
+- Or start a discussion at https://github.com/vllm-project/recipes/discussions
+
+If you use Claude Code, the repo ships a skill at
+`.claude/skills/add-recipe/SKILL.md` that walks the same process
+interactively.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ meta:
 model:
   model_id: "deepseek-ai/DeepSeek-V3.2"           # MUST match the filename path
   min_vllm_version: "0.18.0"                      # earliest vLLM release that supports this model
+  docker_image: "vllm/vllm-openai:v0.18.0"        # optional — override the Docker image:tag shown in Install → Docker (defaults to vllm/vllm-openai or vllm/vllm-openai-rocm). Use when the model needs a pinned build before its support lands in :latest.
   architecture: moe                               # dense | moe
   parameter_count: "671B"                         # total params with B/T suffix
   active_parameters: "37B"                        # same as parameter_count for dense models

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,15 @@ model:
   model_id: "deepseek-ai/DeepSeek-V3.2"           # MUST match the filename path
   min_vllm_version: "0.18.0"                      # earliest vLLM release that supports this model
   docker_image: "vllm/vllm-openai:v0.18.0"        # optional — override the Docker image:tag shown in Install → Docker (defaults to vllm/vllm-openai or vllm/vllm-openai-rocm). Use when the model needs a pinned build before its support lands in :latest.
+  # Optional — control the Install block's pip/Docker tabs. Each key accepts
+  # either `false` (hide the tab entirely) or an object with { command?, note? }.
+  # Use `note` for a one-liner above the code block; use `command` to fully
+  # replace the generated install script (e.g. nightly wheel, pinned version).
+  install:
+    pip:
+      command: "uv pip install vllm --pre --index-url https://wheels.vllm.ai/nightly"
+      note: "nightly wheel required — stable release does not yet support this model"
+    docker: false                                 # e.g. no matching image published yet
   architecture: moe                               # dense | moe
   parameter_count: "671B"                         # total params with B/T suffix
   active_parameters: "37B"                        # same as parameter_count for dense models

--- a/MiniMax/MiniMax-M2.md
+++ b/MiniMax/MiniMax-M2.md
@@ -115,7 +115,7 @@ uv pip install vllm \
 
 ### NVIDIA GPU
 
-You can use 4x H200/H20/H100 or 4x A100/A800 or 4x B200 GPUs to launch this model.
+You can use 4x H200/H20/H100 or 4x A100/A800 GPUs to launch this model.
 
 run tensor-parallel like this:
 
@@ -128,8 +128,6 @@ vllm serve MiniMaxAI/MiniMax-M2.7 \
   --enable-auto-tool-choice \
   --trust-remote-code
 ```
-
-> **Note**: For improved performance, you may set `VLLM_FLOAT32_MATMUL_PRECISION="high"` to enable TF32 TensorCore acceleration for float32 matmuls. This deviates from the original implementation, which uses full FP32 precision for MoE gating, but evaluations show no observable differences on GSM8K, MMLU-Pro, and tool-calling benchmarks.
 
 Note that pure TP8 is not supported. To run the model with >4 GPUs, please use DP+EP or TP+EP:
 

--- a/README.md
+++ b/README.md
@@ -122,15 +122,25 @@ This repo intends to host community maintained common recipes to run vLLM answer
 
 ## Contributing
 
-Please feel free to contribute by adding a new recipe or improving an existing one, just send us a PR!
+New recipes live as structured YAML at `models/<hf_org>/<hf_repo>.yaml` and render on [recipes.vllm.ai](https://recipes.vllm.ai/). **See [CONTRIBUTING.md](CONTRIBUTING.md) for the full schema, VRAM formula, and validation steps.**
 
-While the repo is designed to be directly viewable in GitHub (Markdown files as first citizen), you can build the docs as web pages locally.
+Quick loop:
+
+```bash
+pnpm install
+pnpm dev                              # http://localhost:3000
+node scripts/build-recipes-api.mjs    # validates every YAML + rebuilds the JSON API
+```
+
+### Legacy MkDocs guides
+
+The top-level Markdown directories (`DeepSeek/`, `Qwen/`, etc.) are the historical MkDocs site, kept as a reference during the YAML migration. To preview them:
 
 ```bash
 uv venv
 source .venv/bin/activate
 uv pip install -r requirements.txt
-uv run mkdocs serve
+uv run mkdocs serve --dev-addr 127.0.0.1:8001
 ```
 
 ## License

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,41 @@ edit_uri: edit/main/
 docs_dir: .
 strict: true
 
+# Keep the legacy MkDocs site focused on the hand-written Markdown guides
+# under DeepSeek/, Qwen/, etc. Exclude the Next.js app + content YAMLs +
+# every vendor/build directory. Uses gitignore-style patterns.
+exclude_docs: |
+  # Next.js site
+  /src/
+  /public/
+  /.next/
+  /out/
+  /node_modules/
+  /next.config.mjs
+  /postcss.config.mjs
+  /package.json
+  /package-lock.json
+  /pnpm-lock.yaml
+  /jsconfig.json
+
+  # YAML recipe content + build artefacts
+  /models/
+  /strategies/
+  /scripts/
+  /taxonomy.yaml
+  /CLAUDE.md
+
+  # Python / uv virtualenv
+  /.venv/
+  /requirements.txt
+  /pyproject.toml
+  /uv.lock
+
+  # Editor / agent config
+  /.claude/
+  /.idea/
+  /.vscode/
+
 theme:
   name: material
   custom_dir: overrides
@@ -50,6 +85,13 @@ plugins:
   - glightbox
   - git-revision-date-localized:
       enable_creation_date: true
+      # Don't try to stat git history for untracked vendor/build trees.
+      exclude:
+        - node_modules/*
+        - .venv/*
+        - .next/*
+        - site/*
+        - public/*
 
 markdown_extensions:
   - attr_list

--- a/models/ByteDance-Seed/Seed-OSS-36B-Instruct.yaml
+++ b/models/ByteDance-Seed/Seed-OSS-36B-Instruct.yaml
@@ -8,6 +8,10 @@ meta:
   tasks:
     - text
   related_recipes: []
+  hardware:
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "ByteDance-Seed/Seed-OSS-36B-Instruct"

--- a/models/ByteDance-Seed/Seed-OSS-36B-Instruct.yaml
+++ b/models/ByteDance-Seed/Seed-OSS-36B-Instruct.yaml
@@ -1,0 +1,161 @@
+meta:
+  title: "Seed-OSS-36B"
+  slug: "seed-oss-36b"
+  provider: "Seed (ByteDance)"
+  description: "ByteDance Seed-OSS 36B dense model with unique 'thinking budget' control and 512K context support"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  related_recipes: []
+
+model:
+  model_id: "ByteDance-Seed/Seed-OSS-36B-Instruct"
+  min_vllm_version: "0.11.0"
+  architecture: dense
+  parameter_count: "36B"
+  active_parameters: "36B"
+  context_length: 524288
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Pinned transformers commit required for Seed-OSS tokenizer compatibility"
+    command: "uv pip install git+https://github.com/huggingface/transformers.git@56d68c6706ee052b445e1e476056ed92ac5eb383"
+
+features:
+  tool_calling:
+    description: "Seed-OSS tool-call parser with automatic tool choice"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "seed_oss"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 86
+    description: "Native BF16 weights on 8x GPU (TP=8)"
+    extra_args:
+      - "--tensor-parallel-size"
+      - "8"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  amd:
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Seed-OSS-36B is a dense language model from ByteDance Seed with a unique **thinking
+  budget** feature for controlled reasoning, and up to 512K context. Users can choose
+  tensor-parallel (low latency) or data-parallel (high throughput).
+
+  ## Prerequisites
+
+  - Hardware: 8x GPU recommended (TP=8); also runs on consumer hardware like RTX 3090
+  - vLLM >= 0.11.0 (support may require main branch)
+  - Latest transformers for compatibility
+
+  ### Install vLLM (NVIDIA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  uv pip install git+https://github.com/huggingface/transformers.git@56d68c6706ee052b445e1e476056ed92ac5eb383
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+
+  ## Launch commands
+
+  NVIDIA:
+
+  ```bash
+  vllm serve ByteDance-Seed/Seed-OSS-36B-Instruct \
+    --host localhost --port 8000 \
+    --tensor-parallel-size 8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser seed_oss
+  ```
+
+  AMD:
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve ByteDance-Seed/Seed-OSS-36B-Instruct \
+    --tensor-parallel-size 8 \
+    --enable-auto-tool-choice --tool-call-parser seed_oss \
+    --trust-remote-code
+  ```
+
+  Tuning:
+  - `--max-model-len=65536` works well; max is 512K.
+  - `--max-num-batched-tokens=32768` for prompt-heavy; reduce to 8K–16K for latency.
+  - `--gpu-memory-utilization=0.95` to maximize KV cache.
+
+  ## Thinking Budget
+
+  Control the model's chain-of-thought length via `chat_template_kwargs`. Recommended
+  values are multiples of 512 (512, 1K, 2K, 4K, 8K, 16K). Use `0` for direct answers.
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  model = client.models.list().data[0].id
+
+  response = client.chat.completions.create(
+      model=model,
+      messages=[
+          {"role": "system", "content": "You are a helpful assistant"},
+          {"role": "user", "content": "Janet's ducks lay 16 eggs per day..."},
+      ],
+      extra_body={"chat_template_kwargs": {"thinking_budget": 512}},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  curl:
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+      "messages": [{"role": "user", "content": "Explain quantum computing"}],
+      "chat_template_kwargs": {"thinking_budget": 512}
+    }'
+  ```
+
+  The model emits `<seed:think>` blocks with `<seed:cot_budget_reflect>` markers that
+  report token usage against the budget.
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --backend vllm --model ByteDance-Seed/Seed-OSS-36B-Instruct \
+    --endpoint /v1/completions --host localhost --port 8000 \
+    --dataset-name random --random-input 800 --random-output 100 \
+    --request-rate 2 --num-prompt 100
+  ```
+
+  ## References
+
+  - [Seed-OSS-36B-Instruct on Hugging Face](https://huggingface.co/ByteDance-Seed/Seed-OSS-36B-Instruct)

--- a/models/ByteDance-Seed/Seed-OSS-36B-Instruct.yaml
+++ b/models/ByteDance-Seed/Seed-OSS-36B-Instruct.yaml
@@ -8,10 +8,6 @@ meta:
   tasks:
     - text
   related_recipes: []
-  hardware:
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "ByteDance-Seed/Seed-OSS-36B-Instruct"

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -10,6 +10,16 @@ meta:
     - text
   performance_headline: "Unified multimodal model with structured thinking, function calling, dynamic vision resolution"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: supported
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "google/gemma-4-31B-it"
@@ -64,13 +74,7 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -12,11 +12,6 @@ meta:
   related_recipes: []
   hardware:
     h100: verified
-    h200: supported
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -19,6 +19,7 @@ meta:
 model:
   model_id: "google/gemma-4-31B-it"
   min_vllm_version: "0.12.0"
+  docker_image: "vllm/vllm-openai:gemma4"
   architecture: dense
   parameter_count: "31B"
   active_parameters: "31B"

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -1,0 +1,300 @@
+meta:
+  title: "Gemma 4 31B IT"
+  slug: "gemma-4-31b-it"
+  provider: "Google"
+  description: "Google's unified multimodal Gemma 4 dense model (31B) with native text, image, and audio, plus thinking mode and tool-use protocol."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+    - text
+  performance_headline: "Unified multimodal model with structured thinking, function calling, dynamic vision resolution"
+  related_recipes: []
+
+model:
+  model_id: "google/gemma-4-31B-it"
+  min_vllm_version: "0.12.0"
+  architecture: dense
+  parameter_count: "31B"
+  active_parameters: "31B"
+  context_length: 262144
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Gemma 4 requires transformers 5.5.0"
+    command: "uv pip install transformers==5.5.0"
+  - note: "Audio extras — only needed when serving the audio modality"
+    command: 'uv pip install "vllm[audio]"'
+    optional: true
+
+features:
+  tool_calling:
+    description: "Enable automatic tool choice with Gemma 4 parser and chat template"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "gemma4"
+      - "--chat-template"
+      - "examples/tool_chat_template_gemma4.jinja"
+  reasoning:
+    description: "Enable structured thinking/reasoning output"
+    args:
+      - "--reasoning-parser"
+      - "gemma4"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 210
+    description: "Full BF16 — single 80 GB NVIDIA GPU or 1x MI300X/MI325X/MI350X/MI355X"
+  nvfp4:
+    model_id: "nvidia/gemma-4-31B-it-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 19
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Gemma 4](https://ai.google.dev/gemma/docs) is Google's most capable open model family, featuring a unified multimodal architecture that natively processes text, images, and audio. Gemma 4 models support structured thinking/reasoning, function calling with a custom tool-use protocol, and dynamic vision resolution — all available through vLLM's OpenAI-compatible API.
+
+  ### Key Features
+  - **Multimodal**: Text + images natively (video via custom frame-extraction pipeline). The smaller E2B and E4B models also support audio.
+  - **MoE variant**: 128 fine-grained experts with top-8 routing and custom GELU-activated FFN (Gemma 4 26B-A4B).
+  - **Dual Attention**: Alternating sliding-window (local) and global attention with different head dimensions.
+  - **Thinking Mode**: Structured reasoning via `<|channel>thought\n...<channel|>` delimiters.
+  - **Function Calling**: Custom tool-call protocol with dedicated special tokens.
+  - **Dynamic Vision Resolution**: Per-request configurable vision token budget (70, 140, 280, 560, 1120 tokens).
+
+  ### Supported Variants
+
+  Dense:
+  - `google/gemma-4-E2B-it` (effective 2B)
+  - `google/gemma-4-E4B-it` (effective 4B)
+  - `google/gemma-4-31B-it` (31B)
+
+  MoE:
+  - `google/gemma-4-26B-A4B-it` (26B total / 4B active)
+
+  TPU support is provided through [vLLM TPU](https://github.com/vllm-project/tpu-inference) with recipes for [Trillium](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Gemma4) and [Ironwood](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/inference/ironwood/vLLM/Gemma4/).
+
+  ## Prerequisites
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --pre \
+    --extra-index-url https://wheels.vllm.ai/nightly/cu129 \
+    --extra-index-url https://download.pytorch.org/whl/cu129 \
+    --index-strategy unsafe-best-match
+  uv pip install transformers==5.5.0
+  ```
+
+  ### pip (AMD ROCm: MI300X, MI325X, MI350X, MI355X)
+  Requires Python 3.12, ROCm 7.2.1, glibc >= 2.35 (Ubuntu 22.04+).
+  ```bash
+  uv venv --python 3.12
+  source .venv/bin/activate
+  uv pip install vllm --pre \
+    --extra-index-url https://wheels.vllm.ai/rocm/nightly/rocm721 --upgrade
+  uv pip install transformers==5.5.0
+  ```
+
+  ### Docker
+  ```bash
+  docker pull vllm/vllm-openai:gemma4        # CUDA 12.9
+  docker pull vllm/vllm-openai:gemma4-cu130  # CUDA 13.0
+  docker pull vllm/vllm-openai-rocm:gemma4   # AMD
+  docker pull vllm/vllm-tpu:gemma4           # Cloud TPUs
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU)
+  ```bash
+  vllm serve google/gemma-4-E4B-it \
+    --max-model-len <n_of_tokens>   # up to 131072
+  ```
+
+  ### 31B Dense on 2xA100/H100 (TP=2, BF16)
+  ```bash
+  vllm serve google/gemma-4-31B-it \
+    --tensor-parallel-size 2 \
+    --max-model-len 32768 \
+    --gpu-memory-utilization 0.90
+  ```
+
+  ### 26B MoE on 1xA100/H100 (BF16)
+  ```bash
+  vllm serve google/gemma-4-26B-A4B-it \
+    --max-model-len 32768 \
+    --gpu-memory-utilization 0.90
+  ```
+
+  ### Full-Featured Server Launch
+  Enables text, image, audio, thinking, and tool calling:
+  ```bash
+  vllm serve google/gemma-4-31B-it \
+    --tensor-parallel-size 2 \
+    --max-model-len 16384 \
+    --gpu-memory-utilization 0.90 \
+    --enable-auto-tool-choice \
+    --reasoning-parser gemma4 \
+    --tool-call-parser gemma4 \
+    --chat-template examples/tool_chat_template_gemma4.jinja \
+    --limit-mm-per-prompt image=4,audio=1 \
+    --async-scheduling \
+    --host 0.0.0.0 \
+    --port 8000
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name gemma4 \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:gemma4 \
+      --model google/gemma-4-31B-it \
+      --tensor-parallel-size 2 \
+      --max-model-len 32768 \
+      --gpu-memory-utilization 0.90 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ### Docker (AMD MI300X/MI325X/MI350X/MI355X)
+  ```bash
+  docker run -itd --name gemma4-rocm \
+    --ipc=host --network=host --privileged \
+    --cap-add=CAP_SYS_ADMIN --device=/dev/kfd --device=/dev/dri \
+    --group-add=video --cap-add=SYS_PTRACE \
+    --security-opt=seccomp=unconfined --shm-size 16G \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-rocm:gemma4 \
+      --model google/gemma-4-31B-it \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ### Docker (Cloud TPU)
+  ```bash
+  docker run -itd --name gemma4-tpu \
+    --privileged --network host --shm-size 16G \
+    -v /dev/shm:/dev/shm -e HF_TOKEN=$HF_TOKEN \
+    vllm/vllm-tpu:gemma4 \
+      --model google/gemma-4-31B-it \
+      --tensor-parallel-size 8 \
+      --max-model-len 16384 \
+      --disable_chunked_mm_input \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Text Generation
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="google/gemma-4-31B-it",
+      messages=[{"role": "user", "content": "Write a poem about the ocean."}],
+      max_tokens=512, temperature=0.7,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### Image Understanding
+  ```python
+  response = client.chat.completions.create(
+      model="google/gemma-4-31B-it",
+      messages=[{"role": "user", "content": [
+          {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg"}},
+          {"type": "text", "text": "Describe this image in detail."},
+      ]}],
+      max_tokens=1024,
+  )
+  ```
+
+  ### Dynamic Vision Resolution
+  Supported values: 70, 140, 280 (default), 560, 1120 tokens/image.
+  ```bash
+  vllm serve google/gemma-4-31B-it \
+    --mm-processor-kwargs '{"max_soft_tokens": 560}'
+  ```
+
+  ### Audio (E2B / E4B)
+  Requires `uv pip install "vllm[audio]"`.
+  ```bash
+  vllm serve google/gemma-4-E2B-it \
+    --max-model-len 8192 \
+    --limit-mm-per-prompt image=4,audio=1
+  ```
+
+  ### Thinking Mode
+  ```bash
+  vllm serve google/gemma-4-31B-it \
+    --max-model-len 16384 \
+    --enable-auto-tool-choice \
+    --reasoning-parser gemma4 \
+    --tool-call-parser gemma4 \
+    --chat-template examples/tool_chat_template_gemma4.jinja
+  ```
+  Enable thinking per-request via `extra_body={"chat_template_kwargs": {"enable_thinking": True}}`, or default-on with `--default-chat-template-kwargs '{"enable_thinking": true}'`.
+
+  ### Structured Outputs
+  vLLM guided decoding constrains output to a JSON schema. Include semantic instructions in the system prompt — the model does not see schema descriptions.
+
+  ## Configuration Tips
+
+  - Set `--max-model-len` to match your workload.
+  - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache.
+  - Image-only workloads: pass `--limit-mm-per-prompt audio=0`.
+  - Text-only workloads: pass `--limit-mm-per-prompt image=0,audio=0` to skip MM profiling.
+  - `--async-scheduling` improves throughput.
+  - FP8 KV cache (`--kv-cache-dtype fp8`) saves ~50% KV memory.
+
+  ## Throughput vs Latency
+
+  | Goal | TP | `--max-num-seqs` | Notes |
+  |------|----|------------------|-------|
+  | Max throughput | 1-2 | 256-512 | Best tok/s per GPU |
+  | Min latency   | 4-8 | 8-16   | Best TTFT/TPOT |
+  | Balanced      | 2   | 128    | Mixed workloads |
+
+  ## Deploy on Modal
+
+  Modal deployment script: `gemma4-modal.py` in the original recipe directory.
+  ```bash
+  pip install modal
+  modal setup
+  modal deploy gemma4-modal.py
+  modal run gemma4-modal.py
+  ```
+
+  ## References
+
+  - [Model card](https://huggingface.co/google/gemma-4-31B-it)
+  - [Gemma docs](https://ai.google.dev/gemma/docs)
+  - [vLLM Gemma 4 tool-call template](https://github.com/vllm-project/vllm/blob/main/examples/tool_chat_template_gemma4.jinja)
+  - [TPU recipes: Trillium](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Gemma4)
+  - [TPU recipes: Ironwood](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/inference/ironwood/vLLM/Gemma4/)

--- a/models/Google/translategemma-27b-it.yaml
+++ b/models/Google/translategemma-27b-it.yaml
@@ -13,6 +13,7 @@ meta:
 model:
   model_id: "google/translategemma-27b-it"
   min_vllm_version: "0.14.1"
+  docker_image: "vllm/vllm-openai:v0.14.1-cu130"
   architecture: dense
   parameter_count: "27B"
   active_parameters: "27B"

--- a/models/Google/translategemma-27b-it.yaml
+++ b/models/Google/translategemma-27b-it.yaml
@@ -1,0 +1,129 @@
+meta:
+  title: "TranslateGemma 27B IT"
+  slug: "translategemma-27b-it"
+  provider: "Google"
+  description: "Lightweight open translation model from Google (based on Gemma 3) supporting 55 languages. Served via the vLLM-optimized Infomaniak-AI checkpoint."
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "Deployable on laptops/desktops and cloud GPUs; vLLM-optimized checkpoint removes custom JSON inputs"
+  related_recipes: []
+
+model:
+  model_id: "google/translategemma-27b-it"
+  min_vllm_version: "0.14.1"
+  architecture: dense
+  parameter_count: "27B"
+  active_parameters: "27B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 65
+    description: "Original Google checkpoint in BF16 (has vLLM compatibility issues — prefer vllm-optimized variant)"
+  vllm_optimized:
+    model_id: "Infomaniak-AI/vllm-translategemma-27b-it"
+    precision: bf16
+    vram_minimum_gb: 65
+    description: "Infomaniak-AI vLLM-optimized checkpoint — recommended. Fixes RoPE config, EOS token, and replaces custom JSON inputs with string delimiters."
+  small_4b:
+    model_id: "google/translategemma-4b-it"
+    precision: bf16
+    vram_minimum_gb: 10
+    description: "4B variant for lower-resource deployments (prefer Infomaniak-AI/vllm-translategemma-4b-it)"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [TranslateGemma](https://huggingface.co/collections/google/translategemma) is a family of lightweight, state-of-the-art open translation models from Google, based on the Gemma 3 family. TranslateGemma models handle translation across 55 languages and are small enough to deploy on laptops, desktops, and modest cloud GPU environments.
+
+  ### Original Models
+  - [google/translategemma-27b-it](https://huggingface.co/google/translategemma-27b-it)
+  - [google/translategemma-4b-it](https://huggingface.co/google/translategemma-4b-it)
+
+  ### Optimized vLLM Models
+  - [Infomaniak-AI/vllm-translategemma-27b-it](https://huggingface.co/Infomaniak-AI/vllm-translategemma-27b-it)
+  - [Infomaniak-AI/vllm-translategemma-4b-it](https://huggingface.co/Infomaniak-AI/vllm-translategemma-4b-it)
+
+  ### Why use the vLLM-optimized models?
+
+  The original Google models have compatibility issues with standard inference engines like vLLM. The optimized versions from Infomaniak-AI ([detailed changes](https://huggingface.co/Infomaniak-AI/vllm-translategemma-27b-it#changes-from-original-model)):
+
+  - **vLLM Compatibility**: Originals require custom JSON parameters (`source_lang_code`/`target_lang_code`). The optimized version uses string delimiters.
+  - **RoPE Simplification**: Originals use a complex RoPE configuration for sliding attention. Optimized uses a standard linear RoPE format (`factor: 8.0`).
+  - **EOS Token Fix**: Corrects the EOS token from `<end_of_turn>` to `<eos>`.
+
+  ## Prerequisites
+
+  ### Docker
+  ```bash
+  docker pull vllm/vllm-openai:v0.14.1-cu130
+  ```
+
+  ## Deployment Configurations
+
+  Verified for both 4B and 27B:
+  ```bash
+  docker run -itd --name google-translategemma-27b-it \
+    --ipc=host \
+    --network host \
+    --shm-size 16G \
+    --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:v0.14.1-cu130 \
+      Infomaniak-AI/vllm-translategemma-27b-it \
+      --served-model-name translategemma-27b-it \
+      --gpu-memory-utilization 0.8 \
+      --host 0.0.0.0 \
+      --port 8000
+  ```
+
+  ## Client Usage
+
+  Tips:
+  - **Prompt Delimiters**: Encode language metadata directly in the content string:
+    `<<<source>>>{src_lang}<<<target>>>{tgt_lang}<<<text>>>{text}`
+  - **Language Codes**: ISO 639-1 Alpha-2 (e.g. `en`, `zh`) and regional variants (e.g. `en_US`, `zh_CN`).
+  - **Context Limit**: ~2K tokens.
+
+  ### cURL
+  ```bash
+  curl -X POST http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "translategemma-27b-it",
+      "messages": [{
+        "role": "user",
+        "content": "<<<source>>>en<<<target>>>zh<<<text>>>We distribute two models for language identification, which can recognize 176 languages."
+      }]
+    }'
+  ```
+
+  ## References
+
+  - [TranslateGemma collection](https://huggingface.co/collections/google/translategemma)
+  - [Infomaniak-AI optimized 27B](https://huggingface.co/Infomaniak-AI/vllm-translategemma-27b-it)
+  - [Infomaniak-AI optimized 4B](https://huggingface.co/Infomaniak-AI/vllm-translategemma-4b-it)

--- a/models/Google/translategemma-27b-it.yaml
+++ b/models/Google/translategemma-27b-it.yaml
@@ -45,13 +45,7 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.1.yaml
@@ -18,6 +18,7 @@ meta:
 model:
   model_id: "MiniMaxAI/MiniMax-M2.1"
   min_vllm_version: "0.11.0"
+  docker_image: "vllm/vllm-openai:minimax27"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"

--- a/models/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.1.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Updated M2 series MoE with strong SWE-Bench and Terminal-Bench performance, 196K context"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: supported
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2.1"
@@ -53,13 +63,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.1.yaml
@@ -1,0 +1,165 @@
+meta:
+  title: "MiniMax-M2.1"
+  slug: "minimax-m2.1"
+  provider: "MiniMax"
+  description: "MiniMax M2.1 MoE language model (230B total / 10B active) for coding, agent toolchains, and long-context reasoning — native FP8 checkpoint"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Updated M2 series MoE with strong SWE-Bench and Terminal-Bench performance, 196K context"
+  related_recipes: []
+
+model:
+  model_id: "MiniMaxAI/MiniMax-M2.1"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "230B"
+  active_parameters: "10B"
+  context_length: 196608
+  base_args:
+    - "--trust-remote-code"
+    - "--compilation-config"
+    - '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "MiniMax M2 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "minimax_m2"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "MiniMax M2 reasoning parser for chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "minimax_m2"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 276
+    description: "Native FP8 checkpoint — 4x H200/H20/H100 or 4x A100/A800 for weights, plus KV cache headroom"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [MiniMax-M2.1](https://huggingface.co/MiniMaxAI/MiniMax-M2.1) is part of the MiniMax
+  M2 series of advanced MoE language models. It retains the M2 architecture (10B active,
+  230B total) with improvements over the original M2 release. Supports 196K context per sequence.
+
+  ## Prerequisites
+
+  - **OS:** Linux
+  - **Python:** 3.10 - 3.13
+  - **NVIDIA:** compute capability >= 7.0; ~220 GB for weights + 240 GB per 1M context tokens
+  - **AMD:** MI300X / MI325X / MI350X / MI355X with ROCm 7.0+
+
+  ### Install vLLM (NVIDIA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Docker (dedicated M2-series image)
+
+  ```bash
+  docker run --gpus all \
+    -p 8000:8000 \
+    --ipc=host \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:minimax27 MiniMaxAI/MiniMax-M2.1 \
+        --tensor-parallel-size 4 \
+        --tool-call-parser minimax_m2 \
+        --reasoning-parser minimax_m2 \
+        --enable-auto-tool-choice \
+        --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+        --trust-remote-code
+  ```
+
+  ## Launching the Server
+
+  ### NVIDIA — TP4
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.1 \
+    --tensor-parallel-size 4 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  Pure TP8 is not supported. For >4 GPUs use DP+EP or TP+EP.
+
+  ### TP4+EP (recommended for H100)
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.1 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice
+  ```
+
+  ### AMD ROCm
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 vllm serve MiniMaxAI/MiniMax-M2.1 \
+    --tensor-parallel-size 4 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --backend vllm \
+    --model MiniMaxAI/MiniMax-M2.1 \
+    --endpoint /v1/completions \
+    --dataset-name random \
+    --random-input 2048 \
+    --random-output 1024 \
+    --max-concurrency 10 \
+    --num-prompt 100
+  ```
+
+  ## Troubleshooting
+
+  - See [MiniMax-M2](./MiniMax-M2.yaml) for shared troubleshooting notes
+    (`fuse_minimax_qk_norm`, nightly vs stable, DeepGEMM, AITER).
+
+  ## References
+
+  - [Model card](https://huggingface.co/MiniMaxAI/MiniMax-M2.1)
+  - [MiniMax](https://www.minimax.io/)

--- a/models/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.1.yaml
@@ -11,11 +11,6 @@ meta:
   related_recipes: []
   hardware:
     h100: verified
-    h200: supported
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -1,0 +1,175 @@
+meta:
+  title: "MiniMax-M2.5"
+  slug: "minimax-m2.5"
+  provider: "MiniMax"
+  description: "MiniMax M2.5 MoE language model (230B total / 10B active) for coding, agent toolchains, and long-context reasoning — native FP8 checkpoint"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Refreshed M2 series MoE with strong SWE-Bench and Terminal-Bench performance, 196K context"
+  related_recipes: []
+
+model:
+  model_id: "MiniMaxAI/MiniMax-M2.5"
+  min_vllm_version: "0.19.0"
+  architecture: moe
+  parameter_count: "230B"
+  active_parameters: "10B"
+  context_length: 196608
+  base_args:
+    - "--trust-remote-code"
+    - "--compilation-config"
+    - '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "MiniMax M2 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "minimax_m2"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "MiniMax M2 reasoning parser for chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "minimax_m2"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 276
+    description: "Native FP8 checkpoint — 4x H200/H20/H100 or 4x A100/A800 for weights, plus KV cache headroom"
+  nvfp4:
+    model_id: "nvidia/MiniMax-M2.5-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 138
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [MiniMax-M2.5](https://huggingface.co/MiniMaxAI/MiniMax-M2.5) is part of the MiniMax
+  M2 series of advanced MoE language models. It retains the M2 architecture (10B active,
+  230B total) and a 196K context per sequence.
+
+  ## Prerequisites
+
+  - **OS:** Linux
+  - **Python:** 3.10 - 3.13
+  - **NVIDIA:** compute capability >= 7.0; ~220 GB for weights + 240 GB per 1M context tokens
+  - **AMD:** MI300X / MI325X / MI350X / MI355X with ROCm 7.0+
+
+  ### Install vLLM (NVIDIA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Docker (dedicated M2-series image)
+
+  ```bash
+  docker run --gpus all \
+    -p 8000:8000 \
+    --ipc=host \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:minimax27 MiniMaxAI/MiniMax-M2.5 \
+        --tensor-parallel-size 4 \
+        --tool-call-parser minimax_m2 \
+        --reasoning-parser minimax_m2 \
+        --enable-auto-tool-choice \
+        --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+        --trust-remote-code
+  ```
+
+  ## Launching the Server
+
+  ### NVIDIA — TP4
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.5 \
+    --tensor-parallel-size 4 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  Pure TP8 is not supported. For >4 GPUs use DP+EP or TP+EP.
+
+  ### TP4+EP (recommended for H100)
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.5 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice
+  ```
+
+  ### AMD ROCm
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 vllm serve MiniMaxAI/MiniMax-M2.5 \
+    --tensor-parallel-size 4 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --backend vllm \
+    --model MiniMaxAI/MiniMax-M2.5 \
+    --endpoint /v1/completions \
+    --dataset-name random \
+    --random-input 2048 \
+    --random-output 1024 \
+    --max-concurrency 10 \
+    --num-prompt 100
+  ```
+
+  ## Troubleshooting
+
+  - See [MiniMax-M2](./MiniMax-M2.yaml) for shared troubleshooting notes
+    (`fuse_minimax_qk_norm`, nightly vs stable, DeepGEMM, AITER).
+
+  ## References
+
+  - [Model card](https://huggingface.co/MiniMaxAI/MiniMax-M2.5)
+  - [MiniMax](https://www.minimax.io/)

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Refreshed M2 series MoE with strong SWE-Bench and Terminal-Bench performance, 196K context"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: supported
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2.5"
@@ -63,13 +73,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -11,11 +11,6 @@ meta:
   related_recipes: []
   hardware:
     h100: verified
-    h200: supported
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -18,6 +18,7 @@ meta:
 model:
   model_id: "MiniMaxAI/MiniMax-M2.5"
   min_vllm_version: "0.19.0"
+  docker_image: "vllm/vllm-openai:minimax27"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Latest M2 series release; verified accuracy on AIME25, GPQA-D, GSM8K; 196K context"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2.7"
@@ -53,13 +63,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -1,0 +1,216 @@
+meta:
+  title: "MiniMax-M2.7"
+  slug: "minimax-m2.7"
+  provider: "MiniMax"
+  description: "MiniMax M2.7 MoE language model (230B total / 10B active) — latest M2 release for coding, agent toolchains, and long-context reasoning with native FP8"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Latest M2 series release; verified accuracy on AIME25, GPQA-D, GSM8K; 196K context"
+  related_recipes: []
+
+model:
+  model_id: "MiniMaxAI/MiniMax-M2.7"
+  min_vllm_version: "0.20.0"
+  architecture: moe
+  parameter_count: "230B"
+  active_parameters: "10B"
+  context_length: 196608
+  base_args:
+    - "--trust-remote-code"
+    - "--compilation-config"
+    - '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "MiniMax M2 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "minimax_m2"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "MiniMax M2 reasoning parser for chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "minimax_m2"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 276
+    description: "Native FP8 checkpoint — 4x H200/H20/H100 or 4x A100/A800 for weights, plus KV cache headroom"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [MiniMax-M2.7](https://huggingface.co/MiniMaxAI/MiniMax-M2.7) is the latest release
+  in the MiniMax M2 series. Like earlier M2 variants, it ships with 10B active
+  parameters out of 230B total, and supports a 196K context per sequence. MiniMax has
+  verified M2.7 accuracy on AIME25, GPQA-D, and GSM8K at vLLM commit
+  `0f3ce4c74b1875791d6604e006b6e905fde9f698`.
+
+  ## Prerequisites
+
+  - **OS:** Linux
+  - **Python:** 3.10 - 3.13
+  - **NVIDIA:** compute capability >= 7.0; ~220 GB for weights + 240 GB per 1M context tokens
+  - **AMD:** MI300X / MI325X / MI350X / MI355X with ROCm 7.0+
+
+  ### Install vLLM (NVIDIA, verified commit)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  export VLLM_COMMIT=0f3ce4c74b1875791d6604e006b6e905fde9f698
+  uv pip install vllm \
+      --torch-backend=auto \
+      --extra-index-url https://wheels.vllm.ai/${VLLM_COMMIT}
+  ```
+
+  ### Install vLLM (NVIDIA, nightly)
+
+  ```bash
+  uv pip install -U vllm --extra-index-url https://wheels.vllm.ai/nightly
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+
+  ### Docker (dedicated M2-series image)
+
+  ```bash
+  docker run --gpus all \
+    -p 8000:8000 \
+    --ipc=host \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:minimax27 MiniMaxAI/MiniMax-M2.7 \
+        --tensor-parallel-size 4 \
+        --tool-call-parser minimax_m2 \
+        --reasoning-parser minimax_m2 \
+        --enable-auto-tool-choice \
+        --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+        --trust-remote-code
+  ```
+
+  ## Launching the Server
+
+  ### NVIDIA — TP4 (4x H200/H20/H100 or 4x A100/A800)
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.7 \
+    --tensor-parallel-size 4 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  Pure TP8 is not supported. For >4 GPUs use DP+EP or TP+EP:
+
+  ### DP8+EP
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.7 \
+    --data-parallel-size 8 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice
+  ```
+
+  ### TP4+EP (recommended for H100)
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.7 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice
+  ```
+
+  ### TP8+EP
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.7 \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice
+  ```
+
+  ### AMD ROCm — TP2 or TP4
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
+    --tensor-parallel-size 4 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --backend vllm \
+    --model MiniMaxAI/MiniMax-M2.7 \
+    --endpoint /v1/completions \
+    --dataset-name random \
+    --random-input 2048 \
+    --random-output 1024 \
+    --max-concurrency 10 \
+    --num-prompt 100
+  ```
+
+  ## Troubleshooting
+
+  - **`fuse_minimax_qk_norm` not recognized:** This fusion was introduced in
+    [vLLM PR #37045](https://github.com/vllm-project/vllm/pull/37045); ensure your
+    vLLM build includes it.
+  - **Corrupted output on stable release:** Upgrade to a nightly after commit
+    `cf3eacfe58fa9e745c2854782ada884a9f992cf7`.
+  - **Verified accuracy:** Use the pinned commit
+    `0f3ce4c74b1875791d6604e006b6e905fde9f698` if reproducing MiniMax's reported results.
+  - **DeepGEMM:** vLLM uses DeepGEMM by default; install via
+    [install_deepgemm.sh](https://github.com/vllm-project/vllm/blob/main/tools/install_deepgemm.sh)
+    if missing.
+  - **AITER first launch:** Initial AMD launch JIT-compiles optimized kernels; subsequent launches reuse cached kernels.
+
+  ## References
+
+  - [Model card](https://huggingface.co/MiniMaxAI/MiniMax-M2.7)
+  - [MiniMax](https://www.minimax.io/)
+  - [vLLM PR #37045 (fuse_minimax_qk_norm)](https://github.com/vllm-project/vllm/pull/37045)

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -19,6 +19,7 @@ meta:
 model:
   model_id: "MiniMaxAI/MiniMax-M2.7"
   min_vllm_version: "0.20.0"
+  docker_image: "vllm/vllm-openai:minimax27"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -12,10 +12,6 @@ meta:
   hardware:
     h100: verified
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Open-source MoE with strong SWE-Bench and Terminal-Bench performance, 196K context"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2"
@@ -59,12 +69,6 @@ compatible_strategies:
   - multi_node_dep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     # First launch JIT-compiles AITER kernels (CK FP8 MoE, RMSNorm, activation);
     # expect a slow cold start on MI300X/MI325X/MI350X/MI355X.

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -1,0 +1,217 @@
+meta:
+  title: "MiniMax-M2"
+  slug: "minimax-m2"
+  provider: "MiniMax"
+  description: "MiniMax M2 MoE language model (230B total / 10B active) for coding, agent toolchains, and long-context reasoning — native FP8 checkpoint"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Open-source MoE with strong SWE-Bench and Terminal-Bench performance, 196K context"
+  related_recipes: []
+
+model:
+  model_id: "MiniMaxAI/MiniMax-M2"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "230B"
+  active_parameters: "10B"
+  context_length: 196608
+  base_args:
+    - "--trust-remote-code"
+    - "--compilation-config"
+    - '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
+  base_env: {}
+
+dependencies:
+  - note: "Optional: DeepGEMM FP8 MoE kernels for throughput (skip on B200 — known FlashInfer FP8 MoE error)"
+    command: "export VLLM_USE_DEEP_GEMM=1"
+    optional: true
+
+features:
+  tool_calling:
+    description: "MiniMax M2 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "minimax_m2"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "MiniMax M2 reasoning parser for chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "minimax_m2"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 276
+    description: "Native FP8 checkpoint — 4x H200/H20/H100 or 4x A100/A800 for weights, plus KV cache headroom"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    # First launch JIT-compiles AITER kernels (CK FP8 MoE, RMSNorm, activation);
+    # expect a slow cold start on MI300X/MI325X/MI350X/MI355X.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2) is an advanced MoE language
+  model from [MiniMax](https://www.minimax.io/). Highlights:
+
+  - Superior intelligence — #1 among open-source models globally on math, science, coding, tool use
+  - Advanced coding — multi-file edits, run-fix loops, test-validated repairs (SWE-Bench, Terminal-Bench)
+  - Agent performance — plans and executes complex toolchains across shell, browser, and code
+  - Efficient design — 10B active / 230B total for low latency and high throughput
+  - 196K context length per sequence
+
+  ## Prerequisites
+
+  - **OS:** Linux
+  - **Python:** 3.10 - 3.13
+  - **NVIDIA:** compute capability >= 7.0; ~220 GB for weights + 240 GB per 1M context tokens
+  - **AMD:** MI300X / MI325X / MI350X / MI355X with ROCm 7.0+
+
+  ### Install vLLM (NVIDIA, stable)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (NVIDIA, nightly)
+
+  If you hit corrupted output, upgrade to a nightly after commit
+  `cf3eacfe58fa9e745c2854782ada884a9f992cf7`:
+
+  ```bash
+  uv pip install -U vllm --extra-index-url https://wheels.vllm.ai/nightly
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+
+  ### Docker (NVIDIA, dedicated M2 image)
+
+  ```bash
+  docker run --gpus all \
+    -p 8000:8000 \
+    --ipc=host \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:minimax27 MiniMaxAI/MiniMax-M2 \
+        --tensor-parallel-size 4 \
+        --tool-call-parser minimax_m2 \
+        --reasoning-parser minimax_m2 \
+        --enable-auto-tool-choice \
+        --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+        --trust-remote-code
+  ```
+
+  ## Launching the Server
+
+  ### NVIDIA — TP4 (4x H200/H20/H100 or 4x A100/A800)
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2 \
+    --tensor-parallel-size 4 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  Pure TP8 is not supported. For >4 GPUs use DP+EP or TP+EP:
+
+  ### TP4+EP (recommended for H100)
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice
+  ```
+
+  ### DP8+EP
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2 \
+    --data-parallel-size 8 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice
+  ```
+
+  ### AMD ROCm — TP2 or TP4
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 vllm serve MiniMaxAI/MiniMax-M2 \
+    --tensor-parallel-size 4 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --backend vllm \
+    --model MiniMaxAI/MiniMax-M2 \
+    --endpoint /v1/completions \
+    --dataset-name random \
+    --random-input 2048 \
+    --random-output 1024 \
+    --max-concurrency 10 \
+    --num-prompt 100
+  ```
+
+  ## Troubleshooting
+
+  - **`fuse_minimax_qk_norm` not recognized:** This fusion was introduced in
+    [vLLM PR #37045](https://github.com/vllm-project/vllm/pull/37045); ensure your
+    vLLM build includes it.
+  - **Corrupted output on stable release:** Upgrade to a nightly after commit
+    `cf3eacfe58fa9e745c2854782ada884a9f992cf7`.
+  - **DeepGEMM:** vLLM uses DeepGEMM by default; install via
+    [install_deepgemm.sh](https://github.com/vllm-project/vllm/blob/main/tools/install_deepgemm.sh)
+    when missing.
+  - **AITER first launch:** AMD initial launch JIT-compiles CK-based FP8 MoE, RMSNorm,
+    and activation kernels. Subsequent launches use cached kernels.
+
+  ## References
+
+  - [Model card](https://huggingface.co/MiniMaxAI/MiniMax-M2)
+  - [MiniMax](https://www.minimax.io/)
+  - [vLLM PR #37045 (fuse_minimax_qk_norm)](https://github.com/vllm-project/vllm/pull/37045)

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -19,6 +19,7 @@ meta:
 model:
   model_id: "MiniMaxAI/MiniMax-M2"
   min_vllm_version: "0.11.0"
+  docker_image: "vllm/vllm-openai:minimax27"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -12,10 +12,6 @@ meta:
   hardware:
     h100: verified
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/OpenGVLab/InternVL3_5-8B.yaml
+++ b/models/OpenGVLab/InternVL3_5-8B.yaml
@@ -9,6 +9,16 @@ meta:
     - multimodal
   related_recipes:
     - internlm/Intern-S1
+  hardware:
+    h100: verified
+    h200: supported
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "OpenGVLab/InternVL3_5-8B"

--- a/models/OpenGVLab/InternVL3_5-8B.yaml
+++ b/models/OpenGVLab/InternVL3_5-8B.yaml
@@ -11,11 +11,6 @@ meta:
     - internlm/Intern-S1
   hardware:
     h100: verified
-    h200: supported
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/OpenGVLab/InternVL3_5-8B.yaml
+++ b/models/OpenGVLab/InternVL3_5-8B.yaml
@@ -1,0 +1,124 @@
+meta:
+  title: "InternVL3.5"
+  slug: "internvl3.5"
+  provider: "InternVL (OpenGVLab)"
+  description: "InternVL 3.5 vision-language models from Shanghai AI Lab with thinking-mode prompting"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - multimodal
+  related_recipes:
+    - internlm/Intern-S1
+
+model:
+  model_id: "OpenGVLab/InternVL3_5-8B"
+  min_vllm_version: "0.10.0"
+  architecture: dense
+  parameter_count: "8B"
+  active_parameters: "8B"
+  context_length: 40960
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 19
+    description: "BF16 weights for the 8B variant"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [InternVL3.5](https://github.com/OpenGVLab/InternVL) is a vision-language model developed
+  by Shanghai AI Laboratory. It supports single-image and multi-image prompts, plus an
+  optional "thinking mode" via a custom system prompt.
+
+  ## Prerequisites
+
+  - Hardware: 1x GPU with >=20 GB VRAM (A100, L40S, H100, etc.)
+  - vLLM >= 0.10.0
+
+  ### Install vLLM (CUDA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (AMD ROCm MI300X/MI325X/MI355X)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700
+  ```
+
+  ## Launch command
+
+  ```bash
+  vllm serve OpenGVLab/InternVL3_5-8B --trust-remote-code
+  ```
+
+  On AMD:
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve OpenGVLab/InternVL3_5-8B --trust-remote-code
+  ```
+
+  ## Client Usage
+
+  Single image:
+
+  ```python
+  from openai import OpenAI
+  client = OpenAI(api_key="", base_url="http://0.0.0.0:8000/v1")
+  model_name = client.models.list().data[0].id
+
+  response = client.chat.completions.create(
+      model=model_name,
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "text", "text": "Describe the image."},
+              {"type": "image_url", "image_url": {"url": "https://raw.githubusercontent.com/open-mmlab/mmdeploy/main/tests/data/tiger.jpeg"}},
+          ],
+      }],
+      temperature=0.0,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Thinking Mode
+
+  Set a thinking system prompt and use `temperature=0.6` to mitigate repetition:
+
+  ```python
+  THINKING_SYSTEM_PROMPT = """
+  You are an AI assistant that rigorously follows this response protocol:
+
+  1. First, conduct a detailed analysis of the question. Consider different angles, potential
+  solutions, and reason through the problem step-by-step. Enclose this entire thinking process
+  within <think> and </think> tags.
+
+  2. After the thinking section, provide a clear, concise, and direct answer to the user's
+  question. Separate the answer from the think section with a newline.
+  """.strip()
+  ```
+
+  ## References
+
+  - [InternVL3.5-8B](https://huggingface.co/OpenGVLab/InternVL3_5-8B)
+  - [InternVL GitHub](https://github.com/OpenGVLab/InternVL)

--- a/models/PaddlePaddle/PaddleOCR-VL.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL.yaml
@@ -8,6 +8,10 @@ meta:
   tasks:
     - multimodal
   related_recipes: []
+  hardware:
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "PaddlePaddle/PaddleOCR-VL"

--- a/models/PaddlePaddle/PaddleOCR-VL.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL.yaml
@@ -8,10 +8,6 @@ meta:
   tasks:
     - multimodal
   related_recipes: []
-  hardware:
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "PaddlePaddle/PaddleOCR-VL"
@@ -56,7 +52,6 @@ hardware_overrides:
   amd:
     extra_args: []
     extra_env:
-      VLLM_USE_TRITON_FLASH_ATTN: "0"
       SAFETENSORS_FAST_GPU: "1"
 strategy_overrides: {}
 

--- a/models/PaddlePaddle/PaddleOCR-VL.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL.yaml
@@ -1,0 +1,156 @@
+meta:
+  title: "PaddleOCR-VL"
+  slug: "paddleocr-vl"
+  provider: "PaddlePaddle"
+  description: "PaddleOCR-VL (0.9B) — compact vision-language model for document parsing, OCR, tables, formulas, charts"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - multimodal
+  related_recipes: []
+
+model:
+  model_id: "PaddlePaddle/PaddleOCR-VL"
+  min_vllm_version: "0.11.1"
+  architecture: dense
+  parameter_count: "0.9B"
+  active_parameters: "0.9B"
+  context_length: 131072
+  base_args:
+    - "--trust-remote-code"
+    - "--max-num-batched-tokens"
+    - "16384"
+    - "--no-enable-prefix-caching"
+    - "--mm-processor-cache-gb"
+    - "0"
+  base_env: {}
+
+dependencies:
+  - note: "PaddlePaddle runtime (install in a separate venv from vllm to avoid conflicts)"
+    command: "uv pip install paddlepaddle-gpu==3.2.1 --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/"
+  - note: "PaddleOCR document-parsing helpers"
+    command: 'uv pip install -U "paddleocr[doc-parser]"'
+  - note: "Safetensors loader used by the doc-parser path"
+    command: "uv pip install safetensors"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 2
+    description: "BF16 weights — small footprint, runs on most GPUs"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  amd:
+    extra_args: []
+    extra_env:
+      VLLM_USE_TRITON_FLASH_ATTN: "0"
+      SAFETENSORS_FAST_GPU: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [PaddleOCR-VL](https://huggingface.co/PaddlePaddle/PaddleOCR-VL) is a SOTA resource-efficient
+  model for document parsing. Its core (PaddleOCR-VL-0.9B) combines a NaViT-style dynamic
+  resolution visual encoder with an ERNIE-4.5-0.3B language model, optimized for OCR,
+  tables, formulas, and chart recognition.
+
+  ## Prerequisites
+
+  - Hardware: 1x GPU (small VRAM footprint)
+  - vLLM >= 0.11.1 (nightly if not released yet)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --pre \
+    --extra-index-url https://wheels.vllm.ai/nightly \
+    --extra-index-url https://download.pytorch.org/whl/cu129 \
+    --index-strategy unsafe-best-match
+  ```
+
+  ## Launch command
+
+  ```bash
+  vllm serve PaddlePaddle/PaddleOCR-VL \
+    --trust-remote-code \
+    --max-num-batched-tokens 16384 \
+    --no-enable-prefix-caching \
+    --mm-processor-cache-gb 0
+  ```
+
+  Tip: OCR workloads don't benefit much from prefix caching or image reuse, so disable
+  those to avoid hashing/caching overhead.
+
+  ## Client Usage
+
+  Task-specific prompts:
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  TASKS = {
+      "ocr": "OCR:",
+      "table": "Table Recognition:",
+      "formula": "Formula Recognition:",
+      "chart": "Chart Recognition:",
+  }
+
+  response = client.chat.completions.create(
+      model="PaddlePaddle/PaddleOCR-VL",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://.../receipt.png"}},
+              {"type": "text", "text": TASKS["ocr"]},
+          ],
+      }],
+      temperature=0.0,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Offline Inference with PP-DocLayoutV2
+
+  Use separate venvs for `vllm` and `paddlepaddle` to avoid conflicts. If you see
+  "The model PaddleOCR-VL-0.9B does not exist.", add `--served-model-name PaddleOCR-VL-0.9B`.
+
+  ```bash
+  uv pip install paddlepaddle-gpu==3.2.1 --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/
+  uv pip install -U "paddleocr[doc-parser]"
+  uv pip install safetensors
+  ```
+
+  ```python
+  from paddleocr import PaddleOCRVL
+
+  pipeline = PaddleOCRVL(
+      vl_rec_backend="vllm-server",
+      vl_rec_server_url="http://localhost:8000/v1",
+      layout_detection_model_name="PP-DocLayoutV2",
+      layout_detection_model_dir="/path/to/your/PP-DocLayoutV2/",
+  )
+
+  output = pipeline.predict("https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/paddleocr_vl_demo.png")
+  for i, res in enumerate(output):
+      res.save_to_json(save_path=f"output_{i}.json")
+      res.save_to_markdown(save_path=f"output_{i}.md")
+  ```
+
+  ## References
+
+  - [PaddleOCR-VL on Hugging Face](https://huggingface.co/PaddlePaddle/PaddleOCR-VL)
+  - [PaddleOCR GitHub](https://github.com/PaddlePaddle/PaddleOCR)

--- a/models/Qwen/Qwen-Image.yaml
+++ b/models/Qwen/Qwen-Image.yaml
@@ -1,0 +1,207 @@
+meta:
+  title: "Qwen-Image"
+  slug: "qwen-image"
+  provider: "Qwen"
+  description: "Text-to-image diffusion model (20B parameters) from the Qwen-Image family, served via vLLM-Omni."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - omni
+  performance_headline: "Shared DiT core across T2I, image editing, and layered-image variants; accelerated via Cache-DiT, TeaCache, and sequence parallelism"
+  related_recipes: []
+
+model:
+  model_id: "Qwen/Qwen-Image"
+  min_vllm_version: "0.18.0"
+  architecture: dense
+  parameter_count: "20B"
+  active_parameters: "20B"
+  context_length: 0
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "vLLM-Omni must be installed from source and pins vllm==0.18.0 for diffusion support"
+    command: "git clone https://github.com/vllm-project/vllm-omni.git && cd vllm-omni && uv pip install -e . vllm==0.18.0"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 48
+    description: "Full precision BF16 — use CPU offload / layerwise offload for lower VRAM"
+  fp8:
+    precision: fp8
+    vram_minimum_gb: 24
+    description: "FP8 quantization (`--quantization fp8`). Recommended to pass `--ignored-layers \"img_mlp\"` for better quality."
+  int8:
+    precision: int8
+    vram_minimum_gb: 24
+    description: "INT8 quantization (`--quantization int8`)."
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Qwen-Image is a diffusion-based text-to-image model. This recipe documents the Qwen-Image family served via **vLLM-Omni**:
+
+  | Model | HuggingFace | Description |
+  |-------|-------------|-------------|
+  | **Qwen-Image** | [Qwen/Qwen-Image](https://huggingface.co/Qwen/Qwen-Image) | Text-to-image (20B, Aug 2025) |
+  | **Qwen-Image-2512** | [Qwen/Qwen-Image-2512](https://huggingface.co/Qwen/Qwen-Image-2512) | Updated T2I with enhanced realism (Dec 2025) |
+  | **Qwen-Image-Edit** | [Qwen/Qwen-Image-Edit](https://huggingface.co/Qwen/Qwen-Image-Edit) | Single-image editing (Aug 2025) |
+  | **Qwen-Image-Edit-2509** | [Qwen/Qwen-Image-Edit-2509](https://huggingface.co/Qwen/Qwen-Image-Edit-2509) | Multi-image editing (Sep 2025) |
+  | **Qwen-Image-Edit-2511** | [Qwen/Qwen-Image-Edit-2511](https://huggingface.co/Qwen/Qwen-Image-Edit-2511) | Enhanced consistency + built-in LoRA (Nov 2025) |
+  | **Qwen-Image-Layered** | [Qwen/Qwen-Image-Layered](https://huggingface.co/Qwen/Qwen-Image-Layered) | Decomposes input into RGBA layers (Dec 2025) |
+
+  All models share the same DiT transformer core — acceleration methods are applicable across the entire series.
+
+  ## Prerequisites
+
+  ```bash
+  git clone https://github.com/vllm-project/vllm-omni.git
+  cd vllm-omni
+  uv venv
+  source .venv/bin/activate
+  uv pip install -e . vllm==0.18.0
+  ```
+
+  ## Usage
+
+  ### Text-to-Image
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image \
+      --prompt "a cup of coffee on the table" \
+      --output output_qwen_image.png \
+      --num-inference-steps 50 \
+      --cfg-scale 4.0
+  ```
+
+  ### Image Editing (Qwen-Image-Edit)
+  ```bash
+  python3 ./examples/offline_inference/image_to_image/image_edit.py \
+      --model Qwen/Qwen-Image-Edit \
+      --image qwen_bear.png \
+      --prompt "Let this mascot dance under the moon, surrounded by floating stars" \
+      --output output_image_edit.png \
+      --num-inference-steps 50 \
+      --cfg-scale 4.0
+  ```
+
+  ### Layered RGBA Decomposition
+  ```bash
+  python3 ./examples/offline_inference/image_to_image/image_edit.py \
+      --model Qwen/Qwen-Image-Layered \
+      --image input.png \
+      --prompt "" \
+      --output layered \
+      --num-inference-steps 50 \
+      --cfg-scale 4.0 \
+      --layers 4 \
+      --color-format "RGBA"
+  ```
+
+  ## Acceleration
+
+  Pick one cache backend AND any supported parallel strategy.
+
+  ### Cache-DiT
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." --cache-backend cache_dit
+  ```
+
+  ### TeaCache
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." --cache-backend tea_cache
+  ```
+
+  ### Ulysses / Ring Sequence Parallelism
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." --ulysses-degree 4
+  ```
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." --ring-degree 4
+  ```
+
+  ### CFG Parallelism (2 GPUs, non-distilled models with `cfg-scale > 1`)
+  ```bash
+  python3 ./examples/offline_inference/image_to_image/image_edit.py \
+      --model Qwen/Qwen-Image-Edit --image qwen_bear.png --prompt "..." \
+      --cfg-parallel-size 2 --num-inference-steps 50 --cfg-scale 4.0
+  ```
+
+  ### Tensor Parallelism
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." --tensor-parallel-size 2
+  ```
+
+  ### CPU / Layerwise Offload (low VRAM)
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." --enable-cpu-offload
+  ```
+  ```bash
+  python3 ./examples/offline_inference/image_to_image/image_edit.py \
+      --model Qwen/Qwen-Image-Edit --image qwen_bear.png --prompt "..." \
+      --enable-layerwise-offload
+  ```
+
+  ### VAE Patch Parallelism
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." \
+      --height 1536 --width 1536 \
+      --ulysses-degree 2 --vae-patch-parallel-size 2
+  ```
+  Must be combined with another parallel method.
+
+  ### Quantization (Qwen-Image / Qwen-Image-2512 only)
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." --quantization fp8 \
+      --ignored-layers "img_mlp"
+  ```
+  ```bash
+  python3 ./examples/offline_inference/text_to_image/text_to_image.py \
+      --model Qwen/Qwen-Image --prompt "..." --quantization int8
+  ```
+
+  Qwen-Image-Edit variants do **not** support quantization.
+
+  ## Configuration Tips
+
+  - **Cache + SP** is the recommended combo for long-sequence generation.
+  - **Sequence parallelism** (Ulysses / Ring) beats TP for high-res / long-sequence.
+  - **Tensor parallelism** is most useful when model weights alone don't fit on one GPU.
+  - **CFG parallelism** targets non-distilled diffusion with full CFG (not for guidance-distilled models).
+  - To reduce peak VRAM, use CPU/layerwise offload and/or VAE patch parallelism.
+  - TeaCache and Cache-DiT cannot be used together.
+  - `--enforce-eager` disables torch.compile if needed.
+
+  See the [Feature Support Table](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/diffusion_features.md#supported-models) and [Feature Compatibility Guide](https://github.com/vllm-project/vllm-omni/blob/main/docs/user_guide/feature_compatibility.md) for combinations.
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen-Image)
+  - [vLLM-Omni](https://github.com/vllm-project/vllm-omni)

--- a/models/Qwen/Qwen-Image.yaml
+++ b/models/Qwen/Qwen-Image.yaml
@@ -45,13 +45,7 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
@@ -10,6 +10,16 @@ meta:
     - text
   performance_headline: "Verified on 4x A100 and 4x MI300X/MI325X/MI355X with BF16"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: supported
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "Qwen/Qwen2.5-VL-72B-Instruct"

--- a/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
@@ -11,12 +11,6 @@ meta:
   performance_headline: "Verified on 4x A100 and 4x MI300X/MI325X/MI355X with BF16"
   related_recipes: []
   hardware:
-    h100: supported
-    h200: supported
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
@@ -1,0 +1,177 @@
+meta:
+  title: "Qwen2.5-VL-72B-Instruct"
+  slug: "qwen2.5-vl-72b-instruct"
+  provider: "Qwen"
+  description: "Qwen2.5-VL dense vision-language model (72B) for high-quality image and video understanding."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+    - text
+  performance_headline: "Verified on 4x A100 and 4x MI300X/MI325X/MI355X with BF16"
+  related_recipes: []
+
+model:
+  model_id: "Qwen/Qwen2.5-VL-72B-Instruct"
+  min_vllm_version: "0.7.0"
+  architecture: dense
+  parameter_count: "72B"
+  active_parameters: "72B"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 173
+    description: "Full precision BF16 — 4x A100 80GB or 4x MI300X/MI325X/MI355X"
+  awq:
+    model_id: "Qwen/Qwen2.5-VL-72B-Instruct-AWQ"
+    precision: int4
+    vram_minimum_gb: 43
+    description: "AWQ 4-bit quantized weights"
+    extra_args:
+      - "--quantization"
+      - "awq"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args:
+      - "--mm-encoder-tp-mode"
+      - "data"
+    extra_env: {}
+  blackwell:
+    extra_args:
+      - "--mm-encoder-tp-mode"
+      - "data"
+    extra_env: {}
+  amd:
+    # PR #125 verified on MI300X only; TP=2 for throughput, TP=8 for latency.
+    extra_args:
+      - "--mm-encoder-tp-mode"
+      - "data"
+      - "--limit-mm-per-prompt"
+      - '{"image":2,"video":0}'
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  This guide describes how to run Qwen2.5-VL series on the targeted accelerated stack. Since BF16 is the commonly used precision for Qwen2.5-VL training, using BF16 in inference ensures the best accuracy.
+
+  ## Prerequisites
+
+  ### NVIDIA
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### AMD ROCm (MI300X, MI325X, MI355X)
+  > Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. Use the Docker flow if your environment is incompatible.
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  ### TPU Deployment
+  - [Qwen2.5-VL on Trillium (v6e)](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Qwen2.5-VL)
+
+  ## Deployment Configurations
+
+  ### 4xA100 (BF16, TP=4)
+  ```bash
+  export CUDA_VISIBLE_DEVICES=0,1,2,3
+  vllm serve Qwen/Qwen2.5-VL-72B-Instruct  \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tensor-parallel-size 4 \
+    --mm-encoder-tp-mode data \
+    --limit-mm-per-prompt '{"image":2,"video":0}'
+  ```
+
+  ### 4xMI300X/MI325X/MI355X (BF16, TP=4)
+  ```bash
+  export CUDA_VISIBLE_DEVICES=0,1,2,3
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve Qwen/Qwen2.5-VL-72B-Instruct  \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tensor-parallel-size 4 \
+    --mm-encoder-tp-mode data \
+    --limit-mm-per-prompt '{"image":2,"video":0}'
+  ```
+
+  ### Qwen2.5-VL-7B-Instruct (DP=4)
+  For medium-size 7B model, data parallelism works better.
+
+  ```bash
+  export CUDA_VISIBLE_DEVICES=0,1,2,3
+  vllm serve Qwen/Qwen2.5-VL-7B-Instruct  \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --data-parallel-size 4 \
+    --limit-mm-per-prompt '{"image":2,"video":0}'
+  ```
+
+  ## Configuration Tips
+
+  - `--max-model-len 65536` is usually good for most scenarios (native context is 128K).
+  - For A100-80GB devices, TP must be >= 2 to avoid OOM.
+  - `--limit-mm-per-prompt` caps incoming multimodal requests.
+  - `--mm-encoder-tp-mode data` deploys the small ViT encoder in DP fashion (ViT ≈ 675M vs 72B LM).
+  - vLLM uses 90% of GPU memory by default; set `--gpu-memory-utilization=0.95` to maximize KV cache.
+
+  ## Benchmarking
+
+  Launch the server with `--no-enable-prefix-caching` to get consistent measurements.
+
+  ### VisionArena-Chat
+  ```bash
+  vllm bench serve \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --backend openai-chat \
+    --endpoint /v1/chat/completions \
+    --model Qwen/Qwen2.5-VL-72B-Instruct \
+    --dataset-name hf \
+    --dataset-path lmarena-ai/VisionArena-Chat \
+    --num-prompts 128
+  ```
+
+  ### Random Synthetic
+  ```bash
+  vllm bench serve \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --model Qwen/Qwen2.5-VL-72B-Instruct \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --num-prompts 128
+  ```
+
+  Workload mixes:
+  - Prompt-heavy: 8000 in / 1000 out
+  - Decode-heavy: 1000 in / 8000 out
+  - Balanced: 1000 in / 1000 out
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen2.5-VL-72B-Instruct)
+  - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html)

--- a/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -10,12 +10,7 @@ meta:
   performance_headline: "Verified on 4x/8x H200, MI300X/MI325X/MI355X nodes (BF16 and FP8)"
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -1,0 +1,172 @@
+meta:
+  title: "Qwen3-235B-A22B-Instruct"
+  slug: "qwen3-235b-a22b-instruct-2507"
+  provider: "Qwen"
+  description: "Flagship Qwen3 MoE instruct model with 235B total and 22B active parameters, tuned for high-quality text generation."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Verified on 4x/8x H200, MI300X/MI325X/MI355X nodes (BF16 and FP8)"
+  related_recipes: []
+
+model:
+  model_id: "Qwen/Qwen3-235B-A22B-Instruct-2507"
+  min_vllm_version: "0.10.0"
+  architecture: moe
+  parameter_count: "235B"
+  active_parameters: "22B"
+  context_length: 262144
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Enable automatic tool choice with Hermes-compatible parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "hermes"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 564
+    description: "Full precision BF16 — requires 4x H200 or 8x MI300X/MI325X/MI355X"
+  fp8:
+    model_id: "Qwen/Qwen3-235B-A22B-FP8"
+    precision: fp8
+    vram_minimum_gb: 240
+    description: "Qwen official FP8 checkpoint for improved efficiency on SM90+"
+  nvfp4:
+    model_id: "nvidia/Qwen3-235B-A22B-Instruct-2507-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 141
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Qwen3](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507) is the flagship instruct MoE model in the Qwen3 series, with 235B total parameters and 22B active parameters. This guide covers deploying the model efficiently with vLLM on NVIDIA and AMD GPUs.
+
+  ## Prerequisites
+
+  ### NVIDIA CUDA (pip)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend=auto
+  ```
+
+  ### AMD ROCm (pip)
+  > Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. Use the Docker flow if your environment is incompatible.
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700
+  ```
+
+  ## Deployment Configurations
+
+  ### BF16 on MI300X/MI325X/MI355X (4 GPUs)
+
+  ```bash
+  HIP_VISIBLE_DEVICES="4,5,6,7" \
+  VLLM_USE_V1=1 \
+  VLLM_ROCM_USE_AITER=1 \
+  VLLM_ROCM_USE_AITER_MHA=0 \
+  VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 \
+  VLLM_USE_TRITON_FLASH_ATTN=0 \
+  SAFETENSORS_FAST_GPU=1 \
+  vllm serve Qwen/Qwen3-235B-A22B \
+    --trust-remote-code \
+    -tp 4 \
+    --disable-log-requests \
+    --swap-space 32 \
+    --distributed-executor-backend mp \
+    --max-num-batched-tokens 32768 \
+    --max-model-len 32768 \
+    --no-enable-prefix-caching \
+    --gpu-memory-utilization 0.8
+  ```
+
+  ### FP8 on MI300X/MI325X/MI355X (4 GPUs)
+
+  ```bash
+  HIP_VISIBLE_DEVICES="4,5,6,7" \
+  VLLM_USE_V1=1 \
+  VLLM_ROCM_USE_AITER=1 \
+  VLLM_ROCM_USE_AITER_MHA=0 \
+  VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 \
+  VLLM_USE_TRITON_FLASH_ATTN=0 \
+  SAFETENSORS_FAST_GPU=1 \
+  vllm serve Qwen/Qwen3-235B-A22B-FP8 \
+    --trust-remote-code \
+    -tp 4 \
+    --disable-log-requests \
+    --swap-space 16 \
+    --distributed-executor-backend mp \
+    --max-num-batched-tokens 32768 \
+    --max-model-len 32768 \
+    --no-enable-prefix-caching \
+    --gpu-memory-utilization 0.8
+  ```
+
+  ### TPU Deployment
+
+  - [Qwen3-32B on Trillium (v6e)](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Qwen3)
+  - [Qwen3-4B on Trillium (v6e)](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Qwen3)
+
+  ## Client Usage
+
+  ```bash
+  vllm bench serve \
+    --model "Qwen/Qwen3-235B-A22B-FP8" \
+    --dataset-name random \
+    --random-input-len 8192 \
+    --random-output-len 1024 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos \
+    --trust-remote-code
+  ```
+
+  ## Troubleshooting
+
+  - Use `--max-num-batched-tokens` and `--max-model-len` to fit memory constraints on smaller nodes.
+  - If OOM at startup, lower `--gpu-memory-utilization` (e.g. 0.8) and disable prefix caching.
+  - AMD builds require `VLLM_ROCM_USE_AITER=1` for best performance.
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507)
+  - [FP8 checkpoint](https://huggingface.co/Qwen/Qwen3-235B-A22B-FP8)
+  - [vLLM documentation](https://docs.vllm.ai/)

--- a/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Verified on 4x/8x H200, MI300X/MI325X/MI355X nodes (BF16 and FP8)"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "Qwen/Qwen3-235B-A22B-Instruct-2507"
@@ -62,13 +72,7 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/Qwen/Qwen3-ASR-1.7B.yaml
+++ b/models/Qwen/Qwen3-ASR-1.7B.yaml
@@ -1,0 +1,157 @@
+meta:
+  title: "Qwen3-ASR-1.7B"
+  slug: "qwen3-asr-1.7b"
+  provider: "Qwen"
+  description: "Speech-to-text model supporting 11 languages, multiple accents, and singing voice with customizable text-context prompting."
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - multimodal
+  performance_headline: "Accurate multilingual ASR, including singing voice; single-GPU serving"
+  related_recipes: []
+
+model:
+  model_id: "Qwen/Qwen3-ASR-1.7B"
+  min_vllm_version: "0.12.0"
+  architecture: dense
+  parameter_count: "2.3B"
+  active_parameters: "2.3B"
+  context_length: 65536
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Audio extras — required for ASR input pre-processing (librosa, soundfile)"
+    command: 'uv pip install -U "vllm[audio]"'
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 4
+    description: "Full precision BF16 — fits on a single mid-range GPU"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      SAFETENSORS_FAST_GPU: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Qwen3-ASR is a speech-to-text model that achieves accurate and robust recognition across 11 languages and multiple accents. It supports prompting the model with text context in any format to produce customized ASR results and performs well on singing-voice recognition. This guide demonstrates how to deploy Qwen3-ASR efficiently with vLLM.
+
+  ## Prerequisites
+
+  Install vLLM with audio dependencies:
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --pre \
+      --extra-index-url https://wheels.vllm.ai/nightly/cu129 \
+      --extra-index-url https://download.pytorch.org/whl/cu129 \
+      --index-strategy unsafe-best-match
+  uv pip install "vllm[audio]"
+  ```
+
+  ## Launching with vLLM
+
+  ```bash
+  vllm serve Qwen/Qwen3-ASR-1.7B
+  ```
+
+  ## Client Usage
+
+  ### Chat Completions (OpenAI SDK)
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+  response = client.chat.completions.create(
+      model="Qwen/Qwen3-ASR-1.7B",
+      messages=[{
+          "role": "user",
+          "content": [{
+              "type": "audio_url",
+              "audio_url": {"url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"},
+          }],
+      }],
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### Transcription API
+  ```python
+  import httpx
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  audio_url = "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"
+  audio_file = httpx.get(audio_url).content
+
+  transcription = client.audio.transcriptions.create(
+      model="Qwen/Qwen3-ASR-1.7B",
+      file=audio_file,
+  )
+  print(transcription.text)
+  ```
+
+  ### cURL
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "messages": [
+        {"role": "user", "content": [
+          {"type": "audio_url", "audio_url": {"url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav"}}
+        ]}
+      ]
+    }'
+  ```
+
+  ### Offline Inference
+  ```python
+  from vllm import LLM, SamplingParams
+  from vllm.assets.audio import AudioAsset
+
+  llm = LLM(model="Qwen/Qwen3-ASR-1.7B")
+  audio_asset = AudioAsset("winning_call")
+
+  conversation = [{
+      "role": "user",
+      "content": [{"type": "audio_url", "audio_url": {"url": audio_asset.url}}],
+  }]
+
+  sampling_params = SamplingParams(temperature=0.01, max_tokens=256)
+  outputs = llm.chat(conversation, sampling_params=sampling_params)
+  print(outputs[0].outputs[0].text)
+  ```
+
+  ## Troubleshooting
+
+  - Make sure `vllm[audio]` extras are installed or audio requests will fail.
+  - Use the nightly wheel until Qwen3-ASR support lands in the stable release.
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3-ASR-1.7B)
+  - [vLLM audio support](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html)

--- a/models/Qwen/Qwen3-ASR-1.7B.yaml
+++ b/models/Qwen/Qwen3-ASR-1.7B.yaml
@@ -9,10 +9,6 @@ meta:
     - multimodal
   performance_headline: "Accurate multilingual ASR, including singing voice; single-GPU serving"
   related_recipes: []
-  hardware:
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "Qwen/Qwen3-ASR-1.7B"

--- a/models/Qwen/Qwen3-ASR-1.7B.yaml
+++ b/models/Qwen/Qwen3-ASR-1.7B.yaml
@@ -9,6 +9,10 @@ meta:
     - multimodal
   performance_headline: "Accurate multilingual ASR, including singing voice; single-GPU serving"
   related_recipes: []
+  hardware:
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "Qwen/Qwen3-ASR-1.7B"
@@ -40,12 +44,6 @@ compatible_strategies:
   - multi_node_tp_pp
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     extra_args: []
     extra_env:

--- a/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "HumanEval 0.939, MBPP 0.918 (FP8). Recommended FP8 on 8x H200/H20 via DP=8"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
@@ -71,9 +81,6 @@ hardware_overrides:
     extra_args: []
     extra_env:
       VLLM_USE_DEEP_GEMM: "1"
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     # Verified on 8× MI300X / MI325X / MI355X (FP8 path uses --data-parallel-size 8
     # instead of TP8 — swap strategy to DP if deploying the FP8 checkpoint).

--- a/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -10,12 +10,7 @@ meta:
   performance_headline: "HumanEval 0.939, MBPP 0.918 (FP8). Recommended FP8 on 8x H200/H20 via DP=8"
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -1,0 +1,186 @@
+meta:
+  title: "Qwen3-Coder-480B-A35B-Instruct"
+  slug: "qwen3-coder-480b-a35b-instruct"
+  provider: "Qwen"
+  description: "Large coder MoE with 480B total / 35B active parameters, strong tool-use and code generation capabilities."
+  date_updated: 2026-04-17
+  difficulty: advanced
+  tasks:
+    - text
+  performance_headline: "HumanEval 0.939, MBPP 0.918 (FP8). Recommended FP8 on 8x H200/H20 via DP=8"
+  related_recipes: []
+
+model:
+  model_id: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
+  min_vllm_version: "0.10.0"
+  architecture: moe
+  parameter_count: "480B"
+  active_parameters: "35B"
+  context_length: 262144
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Optional: opt into DeepGEMM FP8 MoE kernels for extra throughput"
+    command: "export VLLM_USE_DEEP_GEMM=1"
+    optional: true
+
+features:
+  tool_calling:
+    description: "Enable automatic tool choice with Qwen3 Coder parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "qwen3_coder"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 1152
+    description: "Full BF16 — 8x H200/H20 (141GB × 8) recommended"
+  fp8:
+    model_id: "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8"
+    precision: fp8
+    vram_minimum_gb: 576
+    description: "Qwen official FP8 checkpoint — required for DP=8 serving"
+  nvfp4:
+    model_id: "nvidia/Qwen3-Coder-480B-A35B-Instruct-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 288
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env:
+      VLLM_USE_DEEP_GEMM: "1"
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    # Verified on 8× MI300X / MI325X / MI355X (FP8 path uses --data-parallel-size 8
+    # instead of TP8 — swap strategy to DP if deploying the FP8 checkpoint).
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Qwen3-Coder](https://github.com/QwenLM/Qwen3-Coder) is an advanced large language model created by the Qwen team. `Qwen3-Coder-480B-A35B-Instruct` is the flagship coder MoE with 480B total / 35B active parameters. vLLM supports it including tool calling; the guide below covers BF16 and FP8 serving on NVIDIA and AMD GPUs.
+
+  ## Prerequisites
+
+  ### CUDA
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### ROCm (MI300X, MI325X, MI355X)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+  The ROCm wheel requires Python 3.12, ROCm 7.0, and glibc >= 2.35.
+
+  ## Deployment Configurations
+
+  ### 8xH200 / 8xH20 BF16
+  ```bash
+  vllm serve Qwen/Qwen3-Coder-480B-A35B-Instruct \
+    --max-model-len 32000 \
+    --enable-expert-parallel \
+    --tensor-parallel-size 8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder
+  ```
+
+  ### 8xH200 / 8xH20 FP8 (DP=8, recommended)
+  ```bash
+  VLLM_USE_DEEP_GEMM=1 vllm serve Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 \
+    --max-model-len 131072 \
+    --enable-expert-parallel \
+    --data-parallel-size 8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder
+  ```
+
+  ### 8xMI300X/MI325X/MI355X BF16
+  ```bash
+  VLLM_ROCM_USE_AITER=1 vllm serve Qwen/Qwen3-Coder-480B-A35B-Instruct \
+    --max-model-len 32000 \
+    --enable-expert-parallel \
+    --tensor-parallel-size 8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder
+  ```
+
+  ### 8xMI300X/MI325X/MI355X FP8
+  ```bash
+  VLLM_ROCM_USE_AITER=1 vllm serve Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 \
+    --trust-remote-code \
+    --max-model-len 131072 \
+    --enable-expert-parallel \
+    --data-parallel-size 8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder
+  ```
+
+  ## Client Usage
+
+  ```bash
+  vllm bench serve \
+    --backend vllm \
+    --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 \
+    --endpoint /v1/completions \
+    --dataset-name random \
+    --random-input 2048 \
+    --random-output 1024 \
+    --max-concurrency 10 \
+    --num-prompt 100
+  ```
+
+  ## Troubleshooting
+
+  - **Context-length OOM**: A single H20 node cannot serve the native 262144 context. Reduce `--max-model-len` or raise `--gpu-memory-utilization`.
+  - **TP=8 failure on FP8**: Expect `ValueError: The output_size of gate's and up's weight = 320 is not divisible by weight quantization block_n = 128.` on FP8 with TP=8. Switch to `--data-parallel-size 8` instead.
+  - **DeepGEMM**: set `VLLM_USE_DEEP_GEMM=1` for faster FP8 matmul. Follow the [setup instructions](https://github.com/vllm-project/vllm/blob/main/benchmarks/kernels/deepgemm/README.md#setup) to install it.
+  - **Tool calling**: add `--tool-call-parser qwen3_coder` as shown above.
+
+  ## Evaluation
+
+  | Dataset    | Test Type          | Pass@1 Score |
+  |------------|--------------------|--------------|
+  | HumanEval  | Base tests         | 0.939        |
+  | HumanEval+ | Base + extra tests | 0.902        |
+  | MBPP       | Base tests         | 0.918        |
+  | MBPP+      | Base + extra tests | 0.794        |
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct)
+  - [FP8 checkpoint](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8)
+  - [Qwen3-Coder GitHub](https://github.com/QwenLM/Qwen3-Coder)
+  - [EvalPlus](https://github.com/evalplus/evalplus)

--- a/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Highly sparse MoE with MTP-accelerated decoding, runs on 4x H200/H20/A100/A800"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "Qwen/Qwen3-Next-80B-A3B-Instruct"
@@ -68,9 +78,6 @@ compatible_strategies:
   - multi_node_tep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
   blackwell:
     extra_args: []
     extra_env:

--- a/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -1,0 +1,187 @@
+meta:
+  title: "Qwen3-Next-80B-A3B-Instruct"
+  slug: "qwen3-next-80b-a3b-instruct"
+  provider: "Qwen"
+  description: "Advanced Qwen3-Next MoE model (80B total / 3B active) with hybrid attention, highly sparse experts, and multi-token prediction."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Highly sparse MoE with MTP-accelerated decoding, runs on 4x H200/H20/A100/A800"
+  related_recipes: []
+
+model:
+  model_id: "Qwen/Qwen3-Next-80B-A3B-Instruct"
+  min_vllm_version: "0.10.0"
+  architecture: moe
+  parameter_count: "80B"
+  active_parameters: "3B"
+  context_length: 262144
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Enable automatic tool choice with Hermes parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "hermes"
+  spec_decoding:
+    description: "Multi-token prediction speculative decoding for lower latency"
+    args:
+      - "--speculative-config"
+      - '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'
+      - "--no-enable-chunked-prefill"
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 192
+    description: "Full precision BF16 — fits on 4x H200/H20/A100/A800"
+  fp8:
+    model_id: "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
+    precision: fp8
+    vram_minimum_gb: 96
+    description: "Qwen official FP8 checkpoint — recommended on SM90/SM100"
+  nvfp4:
+    model_id: "nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 48
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP8: "1"
+      VLLM_FLASHINFER_MOE_BACKEND: "latency"
+      VLLM_USE_DEEP_GEMM: "0"
+      VLLM_USE_TRTLLM_ATTENTION: "0"
+      VLLM_ATTENTION_BACKEND: "FLASH_ATTN"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Qwen3-Next](https://qwen.ai/blog?id=4074cca80393150c248e508aa62983f9cb7d27cd&from=research.latest-advancements-list) is an advanced LLM from the Qwen team featuring:
+  - A hybrid attention mechanism
+  - A highly sparse Mixture-of-Experts (MoE) structure
+  - Training-stability-friendly optimizations
+  - A multi-token prediction mechanism for faster inference
+
+  ## Prerequisites
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  Launch on 4x H200/H20 or 4x A100/A800 GPUs.
+
+  ### Basic Multi-GPU (BF16)
+  ```bash
+  vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --tensor-parallel-size 4 \
+    --served-model-name qwen3-next \
+    --enable-prefix-caching
+  ```
+
+  If you hit `torch.AcceleratorError: CUDA error: an illegal memory access was encountered`, add `--compilation_config.cudagraph_mode=PIECEWISE`.
+
+  ### FP8 (SM90/SM100)
+  ```bash
+  vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
+    --tensor-parallel-size 4 \
+    --enable-prefix-caching
+  ```
+
+  On SM100, accelerate with the FP8 FlashInfer TRTLLM MoE kernel:
+  ```bash
+  VLLM_USE_FLASHINFER_MOE_FP8=1 \
+  VLLM_FLASHINFER_MOE_BACKEND=latency \
+  VLLM_USE_DEEP_GEMM=0 \
+  VLLM_USE_TRTLLM_ATTENTION=0 \
+  VLLM_ATTENTION_BACKEND=FLASH_ATTN \
+  vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
+    --tensor-parallel-size 4
+  ```
+
+  ### MTP (Multi-Token Prediction)
+  ```bash
+  vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --tokenizer-mode auto --gpu-memory-utilization 0.8 \
+    --speculative-config '{"method": "qwen3_next_mtp", "num_speculative_tokens": 2}' \
+    --tensor-parallel-size 4 --no-enable-chunked-prefill
+  ```
+
+  ### Tool / Function Calling
+  ```bash
+  vllm serve ... --tool-call-parser hermes --enable-auto-tool-choice
+  ```
+
+  ### AMD (MI300X/MI325X/MI355X)
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700
+  ```
+  ```bash
+  SAFETENSORS_FAST_GPU=1 \
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+  vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --tensor-parallel-size 4 \
+    --max-model-len 32768 \
+    --no-enable-prefix-caching \
+    --trust-remote-code
+  ```
+
+  ## Client Usage
+
+  Benchmark:
+  ```bash
+  vllm bench serve \
+    --backend vllm \
+    --model Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --served-model-name qwen3-next \
+    --endpoint /v1/completions \
+    --dataset-name random \
+    --random-input 2048 \
+    --random-output 1024 \
+    --max-concurrency 10 \
+    --num-prompt 100
+  ```
+
+  ## Troubleshooting
+
+  - **Sub-optimal MoE performance warning**: Tune the MoE Triton kernel with [benchmark_moe](https://github.com/vllm-project/vllm/blob/main/benchmarks/kernels/benchmark_moe.py), then set `VLLM_TUNED_CONFIG_FOLDER` to the directory containing the generated config.
+  - **IMA error in DP mode**: add `--compilation_config.cudagraph_mode=PIECEWISE`.
+  - For more parallel topologies, see the [Data Parallel Deployment docs](https://docs.vllm.ai/en/latest/serving/data_parallel_deployment.html).
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct)
+  - [FP8 checkpoint](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct-FP8)
+  - [Qwen3-Next blog](https://qwen.ai/blog?id=4074cca80393150c248e508aa62983f9cb7d27cd)

--- a/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -10,12 +10,7 @@ meta:
   performance_headline: "Highly sparse MoE with MTP-accelerated decoding, runs on 4x H200/H20/A100/A800"
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -1,0 +1,203 @@
+meta:
+  title: "Qwen3-VL-235B-A22B-Instruct"
+  slug: "qwen3-vl-235b-a22b-instruct"
+  provider: "Qwen"
+  description: "Qwen3-VL flagship MoE vision-language model with 235B total / 22B active parameters, supporting images, video, and long context."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+    - text
+  performance_headline: "Strong on images, video, and text — #1 open model on text on lmarena.ai at release"
+  related_recipes: []
+
+model:
+  model_id: "Qwen/Qwen3-VL-235B-A22B-Instruct"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "235B"
+  active_parameters: "22B"
+  context_length: 262144
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Recommended for offline multimodal inference (image/video pre-processing helpers)"
+    command: "uv pip install qwen-vl-utils==0.0.14"
+    optional: true
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 564
+    description: "Full BF16 — ideal on H200/B200 with 8 GPUs"
+  fp8:
+    model_id: "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8"
+    precision: fp8
+    vram_minimum_gb: 282
+    description: "Qwen official FP8 checkpoint for optimal H100 memory efficiency"
+  nvfp4:
+    model_id: "nvidia/Qwen3-VL-235B-A22B-Instruct-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 141
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args:
+      - "--mm-encoder-tp-mode"
+      - "data"
+      - "--async-scheduling"
+    extra_env: {}
+  blackwell:
+    extra_args:
+      - "--mm-encoder-tp-mode"
+      - "data"
+      - "--async-scheduling"
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Qwen3-VL](https://github.com/QwenLM/Qwen3-VL) is the most powerful vision-language model in the Qwen series, delivering upgrades to text understanding & generation, visual perception & reasoning, extended context, spatial/video dynamics, and agent interaction. The flagship `Qwen3-VL-235B-A22B-Instruct` is a MoE model that requires at least 8 GPUs with ≥80 GB memory each (A100/H100/H200 class).
+
+  ## Prerequisites
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+
+  # Install vLLM >= 0.11.0
+  uv pip install -U vllm
+
+  # Install Qwen-VL utility library (recommended for offline inference)
+  uv pip install qwen-vl-utils==0.0.14
+  ```
+
+  ## Deployment Configurations
+
+  ### H100 (Image + Video, FP8)
+  ```bash
+  vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
+    --tensor-parallel-size 8 \
+    --mm-encoder-tp-mode data \
+    --enable-expert-parallel \
+    --async-scheduling
+  ```
+
+  ### H100 (Image-Only, FP8, TP4)
+  ```bash
+  vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
+    --tensor-parallel-size 4 \
+    --limit-mm-per-prompt.video 0 \
+    --async-scheduling \
+    --gpu-memory-utilization 0.95 \
+    --max-num-seqs 128
+  ```
+
+  ### A100 & H100 (Image-Only, BF16)
+  ```bash
+  vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+    --tensor-parallel-size 8 \
+    --limit-mm-per-prompt.video 0 \
+    --async-scheduling
+  ```
+
+  ### A100 & H100 (Image + Video, BF16)
+  ```bash
+  vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+    --tensor-parallel-size 8 \
+    --max-model-len 128000 \
+    --async-scheduling
+  ```
+
+  ### H200 & B200
+  ```bash
+  vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+    --tensor-parallel-size 8 \
+    --mm-encoder-tp-mode data \
+    --async-scheduling
+  ```
+
+  ### MI300X/MI325X/MI355X (BF16)
+  ```bash
+  MIOPEN_USER_DB_PATH="$(pwd)/miopen" \
+  MIOPEN_FIND_MODE=FAST \
+  VLLM_ROCM_USE_AITER=1 \
+  SAFETENSORS_FAST_GPU=1 \
+  vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct \
+    --tensor-parallel 4 \
+    --mm-encoder-tp-mode data
+  ```
+
+  ## Configuration Tips
+
+  - Use `--limit-mm-per-prompt.video 0` if your server only serves image inputs to save memory.
+  - `OMP_NUM_THREADS=1` reduces CPU contention during preprocessing.
+  - The model's context length is 262K. Reduce `--max-model-len` (e.g. 128000) if you don't need the full range.
+  - `--async-scheduling` overlaps scheduling with decoding for better throughput.
+  - `--mm-encoder-tp-mode data` deploys the vision encoder in data-parallel fashion for better performance.
+  - If your inputs are mostly unique, pass `--mm-processor-cache-gb 0` to skip caching overhead.
+  - Extend context with YaRN:
+    `--rope-scaling '{"rope_type":"yarn","factor":3.0,"original_max_position_embeddings":262144,"mrope_section":[24,20,20],"mrope_interleaved":true}' --max-model-len 1000000`
+
+  Text-only mode: pass `--limit-mm-per-prompt.video 0 --limit-mm-per-prompt.image 0` to free memory for KV cache when serving text-only traffic.
+
+  ## Client Usage
+
+  ```python
+  import time
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  messages = [{
+      "role": "user",
+      "content": [
+          {"type": "image_url", "image_url": {"url": "https://ofasys-multimodal-wlcb-3-toshanghai.oss-accelerate.aliyuncs.com/wpf272043/keepme/image/receipt.png"}},
+          {"type": "text", "text": "Read all the text in the image."},
+      ],
+  }]
+
+  start = time.time()
+  response = client.chat.completions.create(
+      model="Qwen/Qwen3-VL-235B-A22B-Instruct",
+      messages=messages,
+      max_tokens=2048,
+  )
+  print(f"Response costs: {time.time() - start:.2f}s")
+  print(response.choices[0].message.content)
+  ```
+
+  ## Troubleshooting
+
+  - OOM on A100 / H100 BF16: reduce `--max-model-len`, drop to image-only, or switch to the FP8 checkpoint.
+  - If enabling `--mm-encoder-tp-mode data` raises memory pressure, lower `--gpu-memory-utilization`.
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct)
+  - [FP8 checkpoint](https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8)
+  - [Qwen3-VL GitHub](https://github.com/QwenLM/Qwen3-VL)
+  - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html)

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -10,6 +10,16 @@ meta:
     - text
   performance_headline: "Strong on images, video, and text — #1 open model on text on lmarena.ai at release"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: verified
+    b200: verified
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "Qwen/Qwen3-VL-235B-A22B-Instruct"

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -14,9 +14,6 @@ meta:
     h100: verified
     h200: verified
     b200: verified
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -10,6 +10,16 @@ meta:
   performance_headline: "Verified on 8x H200, 8x MI300X/MI355X, and GB200 nodes"
   related_recipes:
     - "Qwen/Qwen3.6-35B-A3B"
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: verified
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "Qwen/Qwen3.5-397B-A17B"
@@ -71,13 +81,7 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -11,12 +11,8 @@ meta:
   related_recipes:
     - "Qwen/Qwen3.6-35B-A3B"
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
     gb200: verified
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -1,0 +1,271 @@
+meta:
+  title: "Qwen3.5-397B"
+  slug: "qwen3.5-397b"
+  provider: "Qwen"
+  description: "Multimodal MoE model with gated delta networks architecture, 397B total / 17B active parameters, up to 262K context"
+  date_updated: 2026-04-16
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Verified on 8x H200, 8x MI300X/MI355X, and GB200 nodes"
+  related_recipes:
+    - "Qwen/Qwen3.6-35B-A3B"
+
+model:
+  model_id: "Qwen/Qwen3.5-397B-A17B"
+  min_vllm_version: "0.17.0"
+  architecture: moe
+  parameter_count: "397B"
+  active_parameters: "17B"
+  context_length: 262144
+  base_args:
+    - "--trust-remote-code"
+  base_env:
+    VLLM_DEEP_GEMM_WARMUP: "skip"
+    VLLM_USE_DEEP_GEMM: "0"
+    VLLM_FLASHINFER_MOE_BACKEND: "latency"
+
+features:
+  tool_calling:
+    description: "Enable automatic tool choice with Qwen3 Coder parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "qwen3_coder"
+  reasoning:
+    description: "Enable chain-of-thought reasoning with Qwen3 parser"
+    args:
+      - "--reasoning-parser"
+      - "qwen3"
+  spec_decoding:
+    description: "Multi-token prediction speculative decoding for lower latency"
+    args:
+      - "--speculative_config"
+      - '{"method":"mtp","num_speculative_tokens":3}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 953
+    description: "Full precision BF16 — requires 8x H200 or equivalent"
+  nvfp4:
+    model_id: "nvidia/Qwen3.5-397B-A17B-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 238
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Qwen3.5](https://huggingface.co/Qwen/Qwen3.5-397B-A17B) is a multimodal mixture-of-experts model featuring a gated delta networks architecture with 397B total parameters and 17B active parameters. This guide covers how to efficiently deploy and serve the model across different hardware configurations and workload profiles using vLLM.
+
+  ## Prerequisites
+
+  ### Pip Install
+
+  #### NVIDIA
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend=auto
+  ```
+
+  #### AMD
+  > Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35. If your environment does not meet these requirements, please use the Docker-based setup. Supported GPUs: MI300X, MI325X, MI355X.
+  ```bash
+  uv venv --python 3.12
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  ### Docker
+
+  #### NVIDIA
+  ```bash
+  docker run --gpus all \
+    -p 8000:8000 \
+    --ipc=host \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai Qwen/Qwen3.5-397B-A17B \
+      --tensor-parallel-size 8 \
+      --reasoning-parser qwen3 \
+      --enable-prefix-caching
+  ```
+  For Blackwell GPUs, use `vllm/vllm-openai:cu130-nightly`.
+
+  #### AMD
+  ```bash
+  docker run --device=/dev/kfd --device=/dev/dri \
+    --security-opt seccomp=unconfined \
+    --group-add video \
+    --ipc=host \
+    -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-rocm:latest \
+    Qwen/Qwen3.5-397B-A17B-FP8 \
+    --tensor-parallel-size 8 \
+    --reasoning-parser qwen3 \
+    --enable-prefix-caching
+  ```
+
+  ## Deployment Configurations
+
+  The configurations below have been verified on 8x H200 GPUs and 8x MI300X/MI355X GPUs. We recommend using the official FP8 checkpoint [Qwen/Qwen3.5-397B-A17B-FP8](https://huggingface.co/Qwen/Qwen3.5-397B-A17B-FP8) for optimal serving efficiency.
+
+  ### Throughput-Focused (Text-Only)
+
+  For maximum text throughput under high concurrency, use `--language-model-only` to skip loading the vision encoder and free up memory for KV cache, and enable Expert Parallelism.
+
+  ```bash
+  vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
+    -dp 8 \
+    --enable-expert-parallel \
+    --language-model-only \
+    --reasoning-parser qwen3 \
+    --enable-prefix-caching
+  ```
+
+  ### Throughput-Focused (Multimodal)
+
+  For multimodal workloads, use `--mm-encoder-tp-mode data` for data-parallel vision encoding and `--mm-processor-cache-type shm` for shared-memory caching of preprocessed multimodal inputs.
+
+  ```bash
+  vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
+    -dp 8 \
+    --enable-expert-parallel \
+    --mm-encoder-tp-mode data \
+    --mm-processor-cache-type shm \
+    --reasoning-parser qwen3 \
+    --enable-prefix-caching
+  ```
+
+  To enable tool calling, add `--enable-auto-tool-choice --tool-call-parser qwen3_coder` to the serve command.
+
+  ### Latency-Focused
+
+  For latency-sensitive workloads at low concurrency, enable MTP-1 speculative decoding and disable prefix caching. MTP-1 reduces time-per-output-token (TPOT) with a high acceptance rate, at the cost of lower throughput under load.
+
+  > Note: MTP-1 speculative decoding for AMD GPUs is under development.
+
+  ```bash
+  vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
+    --tensor-parallel-size 8 \
+    --speculative-config '{"method": "mtp", "num_speculative_tokens": 1}' \
+    --reasoning-parser qwen3
+  ```
+
+  ### GB200 Deployment
+
+  We recommend using the NVFP4 checkpoint [nvidia/Qwen3.5-397B-A17B-NVFP4](https://huggingface.co/nvidia/Qwen3.5-397B-A17B-NVFP4) for optimal serving efficiency on GB200 nodes.
+
+  ```bash
+  vllm serve nvidia/Qwen3.5-397B-A17B-NVFP4 \
+    -dp 4 \
+    --enable-expert-parallel \
+    --language-model-only \
+    --reasoning-parser qwen3 \
+    --enable-prefix-caching
+  ```
+
+  ### MI355X Deployment
+
+  ```bash
+  vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
+    -tp 2 \
+    --enable-expert-parallel \
+    --language-model-only \
+    --reasoning-parser qwen3 \
+    --enable-prefix-caching
+  ```
+
+  ## Client Usage
+
+  ```python
+  import time
+  from openai import OpenAI
+
+  client = OpenAI(
+      api_key="EMPTY",
+      base_url="http://localhost:8000/v1",
+      timeout=3600
+  )
+
+  messages = [
+      {
+          "role": "user",
+          "content": [
+              {
+                  "type": "image_url",
+                  "image_url": {
+                      "url": "https://ofasys-multimodal-wlcb-3-toshanghai.oss-accelerate.aliyuncs.com/wpf272043/keepme/image/receipt.png"
+                  }
+              },
+              {
+                  "type": "text",
+                  "text": "Read all the text in the image."
+              }
+          ]
+      }
+  ]
+
+  start = time.time()
+  response = client.chat.completions.create(
+      model="Qwen/Qwen3.5-397B-A17B",
+      messages=messages,
+      max_tokens=2048
+  )
+  print(f"Response costs: {time.time() - start:.2f}s")
+  print(f"Generated text: {response.choices[0].message.content}")
+  ```
+
+  ## Troubleshooting
+
+  **CUDA graph / Mamba cache size error**
+
+  You may encounter:
+  ```
+  assert num_cache_lines >= batch
+  ```
+  This occurs because the CUDA graph capture size is larger than the Mamba cache size. Reduce `--max-cudagraph-capture-size` (default is 512). See https://github.com/vllm-project/vllm/pull/34571 for details.
+
+  **Configuration tips**
+
+  - **Disable Reasoning**: Add `--reasoning-parser qwen3 --default-chat-template-kwargs '{"enable_thinking": false}'` to disable reasoning mode via command-line parameters.
+  - **Prefix Caching**: Prefix caching for Mamba cache "align" mode is currently experimental.
+  - **Multi-token Prediction**: MTP-1 reduces per-token latency but degrades throughput under high concurrency because speculative tokens consume KV cache capacity. Adjust `num_speculative_tokens` (1-5) based on your use case.
+  - **Encoder Data Parallelism**: `--mm-encoder-tp-mode data` deploys the vision encoder in a data-parallel fashion. This consumes additional memory and may require adjustment of `--gpu-memory-utilization`.
+  - **Ultra-Long Texts**: Qwen3.5 natively supports up to 262,144 tokens. For longer contexts, use RoPE scaling (YaRN). See the [HuggingFace model card](https://huggingface.co/Qwen/Qwen3.5-397B-A17B#processing-ultra-long-texts) for details.
+
+  ## References
+
+  - Model card: https://huggingface.co/Qwen/Qwen3.5-397B-A17B
+  - FP8 checkpoint: https://huggingface.co/Qwen/Qwen3.5-397B-A17B-FP8
+  - NVFP4 checkpoint: https://huggingface.co/nvidia/Qwen3.5-397B-A17B-NVFP4
+  - vLLM documentation: https://docs.vllm.ai/

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -10,6 +10,16 @@ meta:
   performance_headline: "Compact Qwen3.6 MoE with 3B active parameters — single-GPU FP8 or 2-4 GPU BF16 serving"
   related_recipes:
     - "Qwen/Qwen3.5-397B-A17B"
+  hardware:
+    h100: verified
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "Qwen/Qwen3.6-35B-A3B"
@@ -58,12 +68,6 @@ compatible_strategies:
   - multi_node_tep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     extra_args: []
     extra_env:

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -1,0 +1,159 @@
+meta:
+  title: "Qwen3.6-35B-A3B"
+  slug: "qwen3.6-35b-a3b"
+  provider: "Qwen"
+  description: "Smaller Qwen3.6 multimodal MoE model (35B total / 3B active) with 256 experts (8 routed + 1 shared), gated delta networks architecture, and 262K context"
+  date_updated: 2026-04-18
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "Compact Qwen3.6 MoE with 3B active parameters — single-GPU FP8 or 2-4 GPU BF16 serving"
+  related_recipes:
+    - "Qwen/Qwen3.5-397B-A17B"
+
+model:
+  model_id: "Qwen/Qwen3.6-35B-A3B"
+  min_vllm_version: "0.17.0"
+  architecture: moe
+  parameter_count: "35B"
+  active_parameters: "3B"
+  context_length: 262144
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features:
+  reasoning:
+    description: "Enable chain-of-thought reasoning with Qwen3 parser"
+    args:
+      - "--reasoning-parser"
+      - "qwen3"
+  spec_decoding:
+    description: "Multi-token prediction speculative decoding for lower latency"
+    args:
+      - "--speculative-config"
+      - '{"method":"mtp","num_speculative_tokens":2}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 84
+    description: "Full precision BF16 — fits on 1x H200 or 2x H100"
+  fp8:
+    model_id: "Qwen/Qwen3.6-35B-A3B-FP8"
+    precision: fp8
+    vram_minimum_gb: 42
+    description: "Qwen official FP8 checkpoint — single-GPU serving"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) is the smaller sibling
+  of Qwen3.5, sharing the same gated-delta-networks MoE architecture but with 35B total
+  parameters and 3B activated (256 experts, 8 routed + 1 shared). With FP8 weights it
+  fits comfortably on a single 80 GB GPU and supports the full 262K context.
+
+  ## Prerequisites
+
+  - **vLLM version:** >= 0.17.0
+  - **Hardware (BF16):** 1x H200 or 2x H100
+  - **Hardware (FP8):** single H100/H200 or 1x MI300X/MI325X/MI355X
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend=auto
+  ```
+
+  ## Launching the Server
+
+  ### Single-GPU FP8
+
+  ```bash
+  vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
+    --max-model-len 262144 \
+    --reasoning-parser qwen3
+  ```
+
+  ### BF16 on 2xH200 (TP2)
+
+  ```bash
+  vllm serve Qwen/Qwen3.6-35B-A3B \
+    --tensor-parallel-size 2 \
+    --max-model-len 262144 \
+    --reasoning-parser qwen3
+  ```
+
+  ### MTP speculative decoding
+
+  ```bash
+  vllm serve Qwen/Qwen3.6-35B-A3B \
+    --tensor-parallel-size 2 \
+    --max-model-len 262144 \
+    --reasoning-parser qwen3 \
+    --speculative-config '{"method": "mtp", "num_speculative_tokens": 2}'
+  ```
+
+  ### AMD (MI300X / MI325X / MI355X)
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
+    --max-model-len 262144 \
+    --reasoning-parser qwen3 \
+    --trust-remote-code
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  resp = client.chat.completions.create(
+      model="Qwen/Qwen3.6-35B-A3B",
+      messages=[{"role": "user", "content": "Explain gated delta networks in one paragraph."}],
+      max_tokens=512,
+  )
+  print(resp.choices[0].message.content)
+  ```
+
+  ## Troubleshooting
+
+  - **CUDA graph / Mamba cache size error:** reduce `--max-cudagraph-capture-size`
+    (default 512). See [vLLM PR #34571](https://github.com/vllm-project/vllm/pull/34571).
+  - **Reasoning disable:** add `--default-chat-template-kwargs '{"enable_thinking": false}'`.
+  - **Prefix Caching (Mamba):** currently experimental in "align" mode.
+
+  ## References
+
+  - [Qwen3.6-35B-A3B on Hugging Face](https://huggingface.co/Qwen/Qwen3.6-35B-A3B)
+  - [FP8 checkpoint](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8)
+  - [Qwen3.5 recipe (sibling 397B-A17B flagship)](../Qwen3.5-397B-A17B)

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -13,10 +13,6 @@ meta:
   hardware:
     h100: verified
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified
@@ -33,6 +29,12 @@ model:
   base_env: {}
 
 features:
+  tool_calling:
+    description: "Enable automatic tool choice with Qwen3 Coder parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "qwen3_coder"
   reasoning:
     description: "Enable chain-of-thought reasoning with Qwen3 parser"
     args:

--- a/models/Qwen/Qwen3Guard-Gen-8B.yaml
+++ b/models/Qwen/Qwen3Guard-Gen-8B.yaml
@@ -1,0 +1,138 @@
+meta:
+  title: "Qwen3Guard-Gen-8B"
+  slug: "qwen3guard-gen-8b"
+  provider: "Qwen"
+  description: "Lightweight text-only guardrail/safety classifier model in the Qwen3Guard family."
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "Runs on a single GPU; serves safety classifications over OpenAI-compatible API"
+  related_recipes: []
+
+model:
+  model_id: "Qwen/Qwen3Guard-Gen-8B"
+  min_vllm_version: "0.10.0"
+  architecture: dense
+  parameter_count: "8B"
+  active_parameters: "8B"
+  context_length: 32768
+  base_args: []
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 19
+    description: "Full precision BF16 — single GPU with >=20 GB VRAM"
+  small_4b:
+    model_id: "Qwen/Qwen3Guard-Gen-4B"
+    precision: bf16
+    vram_minimum_gb: 10
+    description: "4B variant for more constrained deployments"
+  tiny_0_6b:
+    model_id: "Qwen/Qwen3Guard-Gen-0.6B"
+    precision: bf16
+    vram_minimum_gb: 4
+    description: "0.6B variant for edge / ultra-low-cost serving"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  **Qwen3Guard-Gen** is a lightweight text-only guardrail model. This guide describes how to run the 8B variant — as well as the 4B and 0.6B variants — on GPU using vLLM.
+
+  ## Prerequisites
+
+  ### CUDA
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### ROCm
+  > Note: The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35.
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+
+  ## Deployment Configurations
+
+  ### Single GPU (CUDA)
+  ```bash
+  vllm serve Qwen/Qwen3Guard-Gen-8B \
+    --host 0.0.0.0 \
+    --max-model-len 32768
+  ```
+
+  ### Single GPU (ROCm)
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve Qwen/Qwen3Guard-Gen-8B \
+    --host 0.0.0.0 \
+    --max-model-len 32768
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  messages = [{"role": "user", "content": "Tell me how to make a bomb."}]
+
+  response = client.chat.completions.create(
+      model="Qwen/Qwen3Guard-Gen-8B",
+      messages=messages,
+      temperature=0.0,
+  )
+  print("Generated text:", response.choices[0].message.content)
+  # Safety: Unsafe
+  # Categories: Violent
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model Qwen/Qwen3Guard-Gen-8B \
+    --dataset-name random \
+    --random-input-len 2000 \
+    --random-output-len 512 \
+    --num-prompts 100
+  ```
+
+  ## Available Variants
+
+  The Qwen3Guard-Gen series includes multiple model sizes, all compatible with the same vLLM serving commands:
+  - **Qwen/Qwen3Guard-Gen-8B**
+  - **Qwen/Qwen3Guard-Gen-4B**
+  - **Qwen/Qwen3Guard-Gen-0.6B**
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3Guard-Gen-8B)
+  - [Qwen3Guard-Gen-4B](https://huggingface.co/Qwen/Qwen3Guard-Gen-4B)
+  - [Qwen3Guard-Gen-0.6B](https://huggingface.co/Qwen/Qwen3Guard-Gen-0.6B)

--- a/models/Qwen/Qwen3Guard-Gen-8B.yaml
+++ b/models/Qwen/Qwen3Guard-Gen-8B.yaml
@@ -45,13 +45,7 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers.yaml
+++ b/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers.yaml
@@ -1,0 +1,167 @@
+meta:
+  title: "Wan2.2"
+  slug: "wan2.2"
+  provider: "Wan AI"
+  description: "Wan2.2 video generation models — T2V/I2V MoE (14B active) and unified TI2V (5B dense), served via vLLM-Omni"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - omni
+  related_recipes: []
+
+model:
+  model_id: "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "28B"
+  active_parameters: "14B"
+  context_length: 0
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Pin vllm==0.12.0 for Wan2.2"
+    command: "uv pip install vllm==0.12.0"
+  - note: "vllm-omni pinned to a specific commit that includes Wan2.2 text-to-video support"
+    command: "uv pip install git+https://github.com/vllm-project/vllm-omni.git@ef01223c42be10ee260b9f6e5ec31894cd09d86e"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 152
+    description: "T2V MoE with 14B active parameters"
+
+  i2v:
+    model_id: "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+    precision: bf16
+    vram_minimum_gb: 40
+    description: "Image-to-Video MoE with 14B active parameters"
+
+  ti2v_5b:
+    model_id: "Wan-AI/Wan2.2-TI2V-5B-Diffusers"
+    precision: bf16
+    vram_minimum_gb: 20
+    description: "Unified Text-to-Video + Image-to-Video dense 5B"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Wan2.2 is a video generation family served via **vLLM-Omni** with optional **Cache-DiT**
+  acceleration:
+
+  - `Wan-AI/Wan2.2-T2V-A14B-Diffusers` — Text-to-Video (MoE, 14B active)
+  - `Wan-AI/Wan2.2-I2V-A14B-Diffusers` — Image-to-Video (MoE, 14B active)
+  - `Wan-AI/Wan2.2-TI2V-5B-Diffusers` — Unified Text+Image-to-Video (dense 5B)
+
+  ## Prerequisites
+
+  - vLLM-Omni on top of vLLM 0.12.0
+  - diffusers (bundled in vLLM-Omni CLI scripts)
+
+  ## Installation
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm==0.12.0
+  uv pip install git+https://github.com/vllm-project/vllm-omni.git@ef01223c42be10ee260b9f6e5ec31894cd09d86e
+  ```
+
+  ## Text-to-Video (T2V)
+
+  ```python
+  from vllm_omni.entrypoints.omni import Omni
+
+  omni = Omni(model="Wan-AI/Wan2.2-T2V-A14B-Diffusers")
+  frames = omni.generate(
+      "Two anthropomorphic cats in comfy boxing gear fight on a spotlighted stage.",
+      height=720, width=1280,
+      num_frames=81,
+      num_inference_steps=40,
+      guidance_scale=4.0,
+  )
+  ```
+
+  CLI:
+
+  ```bash
+  python examples/offline_inference/text_to_video/text_to_video.py \
+    --model Wan-AI/Wan2.2-T2V-A14B-Diffusers \
+    --prompt "A serene lakeside sunrise with mist over the water." \
+    --height 720 --width 1280 \
+    --num_frames 81 --num_inference_steps 40 \
+    --guidance_scale 4.0 --fps 24 \
+    --output t2v_output.mp4
+  ```
+
+  ## Image-to-Video (I2V)
+
+  ```python
+  import PIL.Image
+  from vllm_omni.entrypoints.omni import Omni
+
+  omni = Omni(model="Wan-AI/Wan2.2-I2V-A14B-Diffusers")
+  image = PIL.Image.open("input.jpg").convert("RGB")
+
+  frames = omni.generate(
+      "A cat playing with yarn",
+      pil_image=image,
+      height=480, width=832,
+      num_frames=81,
+      num_inference_steps=50,
+      guidance_scale=5.0,
+  )
+  ```
+
+  TI2V CLI:
+
+  ```bash
+  python examples/offline_inference/image_to_video/image_to_video.py \
+    --model Wan-AI/Wan2.2-TI2V-5B-Diffusers \
+    --image input.jpg --prompt "A cat playing with yarn" \
+    --num_frames 81 --num_inference_steps 50 \
+    --guidance_scale 5.0 --fps 16 --output ti2v_output.mp4
+  ```
+
+  ## Cache-DiT Acceleration
+
+  ```python
+  omni = Omni(
+      model="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+      cache_backend="cache_dit",
+      cache_config={
+          "Fn_compute_blocks": 8,
+          "Bn_compute_blocks": 0,
+          "max_warmup_steps": 4,
+          "residual_diff_threshold": 0.12,
+      },
+  )
+  ```
+
+  ## Key Parameters
+
+  | Parameter | Default | Description |
+  |-----------|---------|-------------|
+  | `height` | 720 (T2V) / auto (I2V) | Video height (multiples of 16) |
+  | `width` | 1280 (T2V) / auto (I2V) | Video width (multiples of 16) |
+  | `num_frames` | 81 | Frames to generate |
+  | `num_inference_steps` | 40–50 | Denoising steps |
+  | `guidance_scale` | 4.0–5.0 | Classifier-free guidance scale |
+  | `boundary_ratio` | 0.875 | MoE boundary split ratio |
+  | `flow_shift` | 5.0 (720p) / 12.0 (480p) | Scheduler flow shift |
+
+  ## References
+
+  - [Wan2.2-T2V-A14B](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers)
+  - [Wan2.2-I2V-A14B](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B-Diffusers)
+  - [Wan2.2-TI2V-5B](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B-Diffusers)
+  - [Cache-DiT Acceleration](https://github.com/vipshop/cache-dit)

--- a/models/XiaomiMiMo/MiMo-V2-Flash.yaml
+++ b/models/XiaomiMiMo/MiMo-V2-Flash.yaml
@@ -8,6 +8,16 @@ meta:
   tasks:
     - text
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "XiaomiMiMo/MiMo-V2-Flash"

--- a/models/XiaomiMiMo/MiMo-V2-Flash.yaml
+++ b/models/XiaomiMiMo/MiMo-V2-Flash.yaml
@@ -9,12 +9,7 @@ meta:
     - text
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/XiaomiMiMo/MiMo-V2-Flash.yaml
+++ b/models/XiaomiMiMo/MiMo-V2-Flash.yaml
@@ -1,0 +1,173 @@
+meta:
+  title: "MiMo-V2-Flash"
+  slug: "mimo-v2-flash"
+  provider: "Xiaomi MiMo"
+  description: "Xiaomi's MoE reasoning model (309B total / 15B active) with hybrid attention and MTP for fast agentic workflows"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  related_recipes: []
+
+model:
+  model_id: "XiaomiMiMo/MiMo-V2-Flash"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "309B"
+  active_parameters: "15B"
+  context_length: 262144
+  base_args:
+    - "--trust-remote-code"
+    - "--generation-config"
+    - "vllm"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Qwen3 XML tool-call parser"
+    args:
+      - "--tool-call-parser"
+      - "qwen3_xml"
+  reasoning:
+    description: "Qwen3 reasoning parser"
+    args:
+      - "--reasoning-parser"
+      - "qwen3"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 371
+    description: "Native FP8 weights; 4x H200 recommended with TP4"
+    extra_args:
+      - "--tensor-parallel-size"
+      - "4"
+      - "--gpu-memory-utilization"
+      - "0.9"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  amd:
+    # AITER is disabled for MiMo-V2-Flash (regression when enabled).
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "0"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [MiMo-V2-Flash](https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash) is a MoE language model
+  with 309B total parameters and 15B active. Designed for high-speed reasoning and agentic
+  workflows, it features hybrid attention and Multi-Token Prediction (MTP) to reduce
+  inference cost.
+
+  ## Prerequisites
+
+  - Hardware: 4x H200 (TP4) or equivalent aggregate VRAM (~320 GB with FP8)
+  - vLLM >= 0.11.0
+
+  ### Install vLLM (NVIDIA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (AMD ROCm MI300X/MI325X/MI355X)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+
+  ## Launch commands
+
+  Basic TP4:
+
+  ```bash
+  vllm serve XiaomiMiMo/MiMo-V2-Flash \
+    --host 0.0.0.0 --port 9001 --seed 1024 \
+    --served-model-name mimo_v2_flash \
+    --tensor-parallel-size 4 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.9 \
+    --generation-config vllm
+  ```
+
+  With tool calling + reasoning:
+
+  ```bash
+  vllm serve XiaomiMiMo/MiMo-V2-Flash \
+    --tensor-parallel-size 4 --trust-remote-code --gpu-memory-utilization 0.9 \
+    --tool-call-parser qwen3_xml \
+    --reasoning-parser qwen3 \
+    --generation-config vllm \
+    --served-model-name mimo_v2_flash
+  ```
+
+  DP + TP + EP:
+
+  ```bash
+  vllm serve XiaomiMiMo/MiMo-V2-Flash \
+    --data-parallel-size 2 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.9 \
+    --generation-config vllm \
+    --served-model-name mimo_v2_flash
+  ```
+
+  AMD:
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=0
+  vllm serve XiaomiMiMo/MiMo-V2-Flash --tensor-parallel-size 4 \
+    --trust-remote-code --gpu-memory-utilization 0.9 --generation-config vllm
+  ```
+
+  Tunable flags:
+  - `--max-model-len=65536` works well; max is 128K.
+  - `--max-num-batched-tokens=32768` for prompt-heavy; 16K/8K for lower latency.
+  - `--gpu-memory-utilization=0.95` to maximize KV cache.
+
+  ## Client Usage
+
+  ```bash
+  curl -X POST http://localhost:9001/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "mimo_v2_flash",
+      "messages": [{"role": "user", "content": "Hello MiMo!"}],
+      "chat_template_kwargs": {"enable_thinking": true}
+    }'
+  ```
+
+  Set `"enable_thinking": false` (or omit the kwargs) to disable thinking mode.
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model XiaomiMiMo/MiMo-V2-Flash \
+    --dataset-name random --random-input-len 8000 --random-output-len 1000 \
+    --request-rate 3 --num-prompts 1800 --ignore-eos
+  ```
+
+  ## Accuracy (GSM8K)
+
+  Reported 5-shot `exact_match`: flexible 0.9128, strict 0.9075.
+
+  ## References
+
+  - [MiMo-V2-Flash on Hugging Face](https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash)

--- a/models/arcee-ai/Trinity-Large-Thinking.yaml
+++ b/models/arcee-ai/Trinity-Large-Thinking.yaml
@@ -1,0 +1,176 @@
+meta:
+  title: "Trinity-Large-Thinking"
+  slug: "trinity-large-thinking"
+  provider: "Arcee AI"
+  description: "Arcee AI's reasoning-focused sparse MoE (AfmoeForCausalLM) with structured <think> traces and agentic tool use"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  related_recipes: []
+
+model:
+  model_id: "arcee-ai/Trinity-Large-Thinking"
+  min_vllm_version: "0.11.1"
+  architecture: moe
+  parameter_count: "398B"
+  active_parameters: "13B"
+  context_length: 262144
+  base_args:
+    - "--dtype"
+    - "bfloat16"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Qwen3 Coder tool-call parser with automatic tool choice"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "qwen3_coder"
+  reasoning:
+    description: "DeepSeek-R1 reasoning parser extracts <think>...</think> into message.reasoning"
+    args:
+      - "--reasoning-parser"
+      - "deepseek_r1"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 955
+    description: "Full precision BF16 on multi-GPU (sparse MoE — multi-GPU recommended)"
+  nvfp4:
+    model_id: "arcee-ai/Trinity-Large-Thinking-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 239
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Trinity-Large-Thinking](https://huggingface.co/arcee-ai/Trinity-Large-Thinking) is
+  Arcee AI's reasoning-focused Trinity Large checkpoint — a sparse MoE model designed for
+  long-horizon planning, tool use, and multi-step agent workflows. It uses the
+  `AfmoeForCausalLM` architecture and emits explicit reasoning traces inside `<think>...</think>`
+  blocks.
+
+  For multi-turn chat and agentic loops, reasoning tokens should be preserved across
+  turns as part of the working state.
+
+  ## Prerequisites
+
+  - vLLM >= 0.11.1
+  - Hardware: multi-GPU recommended for production deployments
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm openai --torch-backend auto
+  ```
+
+  ## Launch command
+
+  ```bash
+  vllm serve arcee-ai/Trinity-Large-Thinking \
+    --dtype bfloat16 \
+    --reasoning-parser deepseek_r1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder
+  ```
+
+  Why these flags:
+  - `--reasoning-parser deepseek_r1` extracts `<think>...</think>` into `message.reasoning`.
+  - `--enable-auto-tool-choice` lets the model decide when to call tools.
+  - `--tool-call-parser qwen3_coder` converts tool calls into OpenAI-style `tool_calls`.
+  - `--dtype bfloat16` matches the recommended serving dtype.
+
+  Add parallelism flags (`--tensor-parallel-size`, `--data-parallel-size`, or
+  `--enable-expert-parallel`) for your hardware. Lower `--max-model-len` if you don't
+  need the full long-context config.
+
+  ## Validation Request
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  model = client.models.list().data[0].id
+
+  tools = [{
+      "type": "function",
+      "function": {
+          "name": "get_weather",
+          "description": "Get the current weather for a location.",
+          "parameters": {
+              "type": "object",
+              "properties": {"location": {"type": "string"}},
+              "required": ["location"],
+          },
+      },
+  }]
+
+  response = client.chat.completions.create(
+      model=model,
+      messages=[{"role": "user", "content": "What is the weather in Paris right now?"}],
+      tools=tools, tool_choice="auto",
+  )
+
+  msg = response.choices[0].message
+  reasoning = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
+  print("reasoning:", reasoning)
+  print("content:", msg.content)
+  print("tool_calls:", msg.tool_calls)
+  ```
+
+  ## Preserving Reasoning Across Turns
+
+  Pass reasoning back as `reasoning` on assistant messages:
+
+  ```python
+  assistant_msg = {"role": "assistant", "content": msg.content or ""}
+  if reasoning:
+      assistant_msg["reasoning"] = reasoning
+  if msg.tool_calls:
+      assistant_msg["tool_calls"] = [
+          {"id": tc.id, "type": "function",
+           "function": {"name": tc.function.name, "arguments": tc.function.arguments}}
+          for tc in msg.tool_calls
+      ]
+  messages.append(assistant_msg)
+  ```
+
+  Rules:
+  - Pass reasoning back as `reasoning` (even if your client exposes it as `reasoning_content`).
+  - Keep `content` as an empty string (not `null`) on tool-only turns.
+  - Append the assistant message before tool-result messages.
+  - Use `/v1/chat/completions` for structured reasoning output.
+
+  ## Troubleshooting
+
+  - **No reasoning:** start server with `--reasoning-parser deepseek_r1`; use `/v1/chat/completions`.
+  - **Tool calls as plain text:** enable `--enable-auto-tool-choice` and `--tool-call-parser qwen3_coder`.
+  - **Loses coherence after tool turns:** preserve `reasoning` on each assistant turn; don't set content to `null`.
+  - **OOM:** lower `--max-model-len`; scale parallelism; use a local checkpoint path.
+
+  ## References
+
+  - [Trinity-Large-Thinking on Hugging Face](https://huggingface.co/arcee-ai/Trinity-Large-Thinking)

--- a/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
@@ -9,6 +9,10 @@ meta:
     - text
   related_recipes:
     - baidu/ERNIE-4.5-VL-28B-A3B-PT
+  hardware:
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "baidu/ERNIE-4.5-21B-A3B-PT"

--- a/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
@@ -9,10 +9,6 @@ meta:
     - text
   related_recipes:
     - baidu/ERNIE-4.5-VL-28B-A3B-PT
-  hardware:
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "baidu/ERNIE-4.5-21B-A3B-PT"

--- a/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
@@ -1,0 +1,145 @@
+meta:
+  title: "ERNIE-4.5"
+  slug: "ernie-4.5"
+  provider: "Ernie (Baidu)"
+  description: "Baidu ERNIE 4.5 MoE text models (21B-A3B, 300B-A47B) with BF16 and FP8 support plus ERNIE-MTP speculative decoding"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  related_recipes:
+    - baidu/ERNIE-4.5-VL-28B-A3B-PT
+
+model:
+  model_id: "baidu/ERNIE-4.5-21B-A3B-PT"
+  min_vllm_version: "0.10.1"
+  architecture: moe
+  parameter_count: "21B"
+  active_parameters: "3B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+features:
+  spec_decoding:
+    description: "ERNIE-MTP (multi-token prediction) speculative decoding"
+    args:
+      - "--speculative-config"
+      - '{"method":"ernie_mtp","model":"baidu/ERNIE-4.5-21B-A3B-PT","num_speculative_tokens":1}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 106
+    description: "BF16 weights; fits on 1x80GB GPU (21B variant)"
+
+  "300b":
+    model_id: "baidu/ERNIE-4.5-300B-A47B-PT"
+    precision: bf16
+    vram_minimum_gb: 640
+    description: "300B total / 47B active; 8x80GB with FP8 online, 16x80GB for BF16"
+    extra_args:
+      - "--tensor-parallel-size"
+      - "8"
+      - "--gpu-memory-utilization"
+      - "0.95"
+      - "--quantization"
+      - "fp8"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  amd:
+    extra_args:
+      - "--gpu-memory-utilization"
+      - "0.9"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      SAFETENSORS_FAST_GPU: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  ERNIE 4.5 is Baidu's MoE language model family. This recipe covers the text-only
+  variants:
+
+  - `baidu/ERNIE-4.5-21B-A3B-PT` — 21B total / 3B active (fits on 1x80GB)
+  - `baidu/ERNIE-4.5-300B-A47B-PT` — 300B total / 47B active (8x80GB FP8 or 16x80GB BF16)
+
+  Both support ERNIE-MTP speculative decoding via `--speculative-config`.
+
+  ## Prerequisites
+
+  - transformers >= 4.54.0
+  - vLLM >= 0.10.1
+  - Hardware depends on variant (see above)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv --python 3.12 --seed
+  source .venv/bin/activate
+  uv pip install vllm --torch-backend=auto
+  ```
+
+  ## Launch commands
+
+  21B on 1x80GB GPU:
+
+  ```bash
+  vllm serve baidu/ERNIE-4.5-21B-A3B-PT
+  ```
+
+  300B on 8x80GB with vLLM FP8 online quantization:
+
+  ```bash
+  vllm serve baidu/ERNIE-4.5-300B-A47B-PT \
+    --tensor-parallel-size 8 \
+    --gpu-memory-utilization 0.95 \
+    --quantization fp8
+  ```
+
+  300B on 16x80GB native BF16 (multi-node via Ray):
+
+  ```bash
+  vllm serve baidu/ERNIE-4.5-300B-A47B-PT --tensor-parallel-size 16
+  ```
+
+  ERNIE-MTP speculative decoding (21B example):
+
+  ```bash
+  vllm serve baidu/ERNIE-4.5-21B-A3B-PT \
+    --speculative-config '{"method":"ernie_mtp","model":"baidu/ERNIE-4.5-21B-A3B-PT","num_speculative_tokens":1}'
+  ```
+
+  ## Client Usage
+
+  Standard OpenAI-compatible API; model ID is the HF repo.
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model baidu/ERNIE-4.5-21B-A3B-PT \
+    --dataset-name random \
+    --random-input-len 8000 --random-output-len 1000 \
+    --request-rate 10 --num-prompts 16 --ignore-eos
+  ```
+
+  Test configurations: prompt-heavy (8k/1k), decode-heavy (1k/8k), balanced (1k/1k).
+  Vary `--num-prompts` across 1, 16, 32, 64, 128, 256, 512.
+
+  ## References
+
+  - [ERNIE-4.5-21B-A3B-PT](https://huggingface.co/baidu/ERNIE-4.5-21B-A3B-PT)
+  - [ERNIE-4.5-300B-A47B-PT](https://huggingface.co/baidu/ERNIE-4.5-300B-A47B-PT)
+  - [vLLM multi-node deployment](https://docs.vllm.ai/en/latest/serving/parallelism_scaling.html)

--- a/models/baidu/ERNIE-4.5-VL-28B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-VL-28B-A3B-PT.yaml
@@ -9,6 +9,10 @@ meta:
     - multimodal
   related_recipes:
     - baidu/ERNIE-4.5-21B-A3B-PT
+  hardware:
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "baidu/ERNIE-4.5-VL-28B-A3B-PT"

--- a/models/baidu/ERNIE-4.5-VL-28B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-VL-28B-A3B-PT.yaml
@@ -1,0 +1,147 @@
+meta:
+  title: "ERNIE-4.5-VL"
+  slug: "ernie-4.5-vl"
+  provider: "Ernie (Baidu)"
+  description: "Baidu ERNIE 4.5 VL MoE vision-language models (28B-A3B, 424B-A47B) with heterogeneous text/vision experts"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  related_recipes:
+    - baidu/ERNIE-4.5-21B-A3B-PT
+
+model:
+  model_id: "baidu/ERNIE-4.5-VL-28B-A3B-PT"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "28B"
+  active_parameters: "3B"
+  context_length: 131072
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 67
+    description: "BF16 weights; fits on 1x80GB GPU (28B VL variant)"
+
+  "424b":
+    model_id: "baidu/ERNIE-4.5-VL-424B-A47B-PT"
+    precision: bf16
+    vram_minimum_gb: 1120
+    description: "424B total / 47B active; 8x140GB BF16 or 16x80GB BF16"
+    extra_args:
+      - "--trust-remote-code"
+      - "--tensor-parallel-size"
+      - "8"
+
+  "424b_fp8":
+    model_id: "baidu/ERNIE-4.5-VL-424B-A47B-PT"
+    precision: fp8
+    vram_minimum_gb: 640
+    description: "424B with FP8 online quantization + CPU offload for 8x80GB testing"
+    extra_args:
+      - "--trust-remote-code"
+      - "--tensor-parallel-size"
+      - "8"
+      - "--quantization"
+      - "fp8"
+      - "--cpu-offload-gb"
+      - "50"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  ERNIE 4.5 VL is Baidu's multimodal MoE model with heterogeneous experts (separate text
+  and vision experts). Because of the heterogeneous architecture, **torch.compile and CUDA
+  graphs are not supported**.
+
+  - `baidu/ERNIE-4.5-VL-28B-A3B-PT` — 28B total / 3B active (1x80GB)
+  - `baidu/ERNIE-4.5-VL-424B-A47B-PT` — 424B total / 47B active (8x140GB BF16, 8x80GB FP8+offload, or 16x80GB BF16)
+
+  ## Prerequisites
+
+  - vLLM: support added to main branch recently; install latest
+  - Hardware depends on variant
+
+  ### Install vLLM (CUDA)
+
+  ```bash
+  uv venv --python 3.12 --seed
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (AMD ROCm MI300X/MI325X/MI355X)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+
+  ## Launch commands
+
+  28B on 1x80GB:
+
+  ```bash
+  vllm serve baidu/ERNIE-4.5-VL-28B-A3B-PT --trust-remote-code
+  ```
+
+  424B BF16 on 8x140GB:
+
+  ```bash
+  vllm serve baidu/ERNIE-4.5-VL-424B-A47B-PT \
+    --trust-remote-code \
+    --tensor-parallel-size 8
+  ```
+
+  424B with FP8 + CPU offload on 8x80GB (testing only):
+
+  ```bash
+  vllm serve baidu/ERNIE-4.5-VL-424B-A47B-PT \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --quantization fp8 \
+    --cpu-offload-gb 50
+  ```
+
+  28B on AMD MI300X+:
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 SAFETENSORS_FAST_GPU=1 \
+    vllm serve baidu/ERNIE-4.5-VL-28B-A3B-PT \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.9 \
+    --disable-log-requests \
+    --trust-remote-code
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model baidu/ERNIE-4.5-VL-28B-A3B-PT \
+    --dataset-name random \
+    --random-input-len 8000 --random-output-len 1000 \
+    --request-rate 10 --num-prompts 16 --ignore-eos --trust-remote-code
+  ```
+
+  ## References
+
+  - [ERNIE-4.5-VL-28B-A3B-PT](https://huggingface.co/baidu/ERNIE-4.5-VL-28B-A3B-PT)
+  - [ERNIE-4.5-VL-424B-A47B-PT](https://huggingface.co/baidu/ERNIE-4.5-VL-424B-A47B-PT)

--- a/models/deepseek-ai/DeepSeek-OCR-2.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR-2.yaml
@@ -44,13 +44,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/deepseek-ai/DeepSeek-OCR-2.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR-2.yaml
@@ -1,0 +1,176 @@
+meta:
+  title: "DeepSeek-OCR-2"
+  slug: "deepseek-ocr-2"
+  provider: "DeepSeek"
+  description: "Next-generation DeepSeek OCR model with improved document-to-markdown grounding and optical context compression."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  performance_headline: "Improved grounding and markdown conversion over DeepSeek-OCR"
+  related_recipes:
+    - "deepseek-ai/DeepSeek-OCR"
+
+model:
+  model_id: "deepseek-ai/DeepSeek-OCR-2"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "3B"
+  active_parameters: "3B"
+  context_length: 8192
+  base_args:
+    - "--trust-remote-code"
+    - "--logits_processors"
+    - "vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor"
+    - "--no-enable-prefix-caching"
+    - "--mm-processor-cache-gb"
+    - "0"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 7
+    description: "Full precision BF16 (~3.4B params)"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  DeepSeek-OCR-2 is a frontier OCR model exploring optical context compression for LLMs.
+  It iterates on DeepSeek-OCR with better grounding and markdown conversion, and supports
+  prompts like `<image>\n<|grounding|>Convert the document to markdown.` for richer
+  document parsing.
+
+  ## Prerequisites
+
+  - **Hardware**: Single GPU with >=8 GB VRAM is typically sufficient for BF16 inference.
+  - **vLLM**: Current stable release (tested with `uv pip install -U vllm --torch-backend auto`).
+  - **Python**: 3.10+
+
+  Install vLLM:
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Client Usage
+
+  ### Offline OCR (Python)
+
+  ```python
+  from vllm import LLM, SamplingParams
+  from vllm.model_executor.models.deepseek_ocr import NGramPerReqLogitsProcessor
+  from PIL import Image
+
+  llm = LLM(
+      model="deepseek-ai/DeepSeek-OCR-2",
+      enable_prefix_caching=False,
+      mm_processor_cache_gb=0,
+      logits_processors=[NGramPerReqLogitsProcessor],
+  )
+
+  image_1 = Image.open("path/to/your/image_1.png").convert("RGB")
+  image_2 = Image.open("path/to/your/image_2.png").convert("RGB")
+  # prompt = "<image>\nFree OCR. "
+  prompt = "<image>\n<|grounding|>Convert the document to markdown. "
+
+  model_input = [
+      {"prompt": prompt, "multi_modal_data": {"image": image_1}},
+      {"prompt": prompt, "multi_modal_data": {"image": image_2}},
+  ]
+
+  sampling_param = SamplingParams(
+      temperature=0.0,
+      max_tokens=8192,
+      extra_args=dict(
+          ngram_size=30,
+          window_size=90,
+          whitelist_token_ids={128821, 128822},  # <td>, </td>
+      ),
+      skip_special_tokens=False,
+  )
+
+  for output in llm.generate(model_input, sampling_param):
+      print(output.outputs[0].text)
+  ```
+
+  ### Online OCR serving
+
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-OCR-2 \
+    --logits_processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor \
+    --no-enable-prefix-caching \
+    --mm-processor-cache-gb 0
+  ```
+
+  ```python
+  import time
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  messages = [
+      {
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://ofasys-multimodal-wlcb-3-toshanghai.oss-accelerate.aliyuncs.com/wpf272043/keepme/image/receipt.png"}},
+              {"type": "text", "text": "Free OCR."},
+          ],
+      }
+  ]
+
+  start = time.time()
+  response = client.chat.completions.create(
+      model="deepseek-ai/DeepSeek-OCR-2",
+      messages=messages,
+      max_tokens=2048,
+      temperature=0.0,
+      extra_body={
+          "skip_special_tokens": False,
+          "vllm_xargs": {
+              "ngram_size": 30,
+              "window_size": 90,
+              "whitelist_token_ids": [128821, 128822],
+          },
+      },
+  )
+  print(f"Response costs: {time.time() - start:.2f}s")
+  print(f"Generated text: {response.choices[0].message.content}")
+  ```
+
+  ## Troubleshooting / Configuration Tips
+
+  - **Use the custom logits processor** along with the model for optimal OCR and markdown
+    generation performance.
+  - Unlike multi-turn chat, OCR tasks do not typically benefit from prefix caching or image
+    reuse, so disable these features to avoid unnecessary hashing and caching overhead.
+  - DeepSeek-OCR-2 works better with plain prompts than instruction formats. See the
+    [official main prompts](https://huggingface.co/deepseek-ai/DeepSeek-OCR-2#main-prompts).
+  - Depending on your hardware, adjust `max_num_batched_tokens` for better throughput.
+
+  ## References
+
+  - [DeepSeek-OCR-2 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-OCR-2)
+  - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html#offline-inference)

--- a/models/deepseek-ai/DeepSeek-OCR.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR.yaml
@@ -10,6 +10,10 @@ meta:
   performance_headline: "Optical context compression for efficient OCR and document understanding"
   related_recipes:
     - "deepseek-ai/DeepSeek-OCR-2"
+  hardware:
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-OCR"
@@ -45,12 +49,6 @@ compatible_strategies:
   - multi_node_dep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     # Disable Triton FA → AITER FA is faster for dense OCR on MI300X/MI325X/MI355X.
     extra_args: []

--- a/models/deepseek-ai/DeepSeek-OCR.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR.yaml
@@ -10,10 +10,6 @@ meta:
   performance_headline: "Optical context compression for efficient OCR and document understanding"
   related_recipes:
     - "deepseek-ai/DeepSeek-OCR-2"
-  hardware:
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-OCR"
@@ -54,7 +50,6 @@ hardware_overrides:
     extra_args: []
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
-      VLLM_USE_TRITON_FLASH_ATTN: "0"
       SAFETENSORS_FAST_GPU: "1"
 
 strategy_overrides: {}

--- a/models/deepseek-ai/DeepSeek-OCR.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR.yaml
@@ -1,0 +1,181 @@
+meta:
+  title: "DeepSeek-OCR"
+  slug: "deepseek-ocr"
+  provider: "DeepSeek"
+  description: "Frontier OCR model exploring optical context compression for LLMs, optimized for document parsing and markdown generation."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  performance_headline: "Optical context compression for efficient OCR and document understanding"
+  related_recipes:
+    - "deepseek-ai/DeepSeek-OCR-2"
+
+model:
+  model_id: "deepseek-ai/DeepSeek-OCR"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "3B"
+  active_parameters: "3B"
+  context_length: 8192
+  base_args:
+    - "--trust-remote-code"
+    - "--logits_processors"
+    - "vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor"
+    - "--no-enable-prefix-caching"
+    - "--mm-processor-cache-gb"
+    - "0"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 7
+    description: "Full precision BF16 (~3.3B params)"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    # Disable Triton FA → AITER FA is faster for dense OCR on MI300X/MI325X/MI355X.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_USE_TRITON_FLASH_ATTN: "0"
+      SAFETENSORS_FAST_GPU: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  DeepSeek-OCR is a frontier OCR model exploring optical context compression for LLMs.
+  It is optimized for document parsing, free-form OCR, and markdown generation from images,
+  and ships with a custom n-gram logits processor for optimal quality.
+
+  ## Prerequisites
+
+  - **Hardware**: Single GPU with >=8 GB VRAM is typically sufficient for BF16 inference.
+  - **vLLM**: Current stable release (tested with `uv pip install -U vllm --torch-backend auto`).
+  - **Python**: 3.10+
+
+  Install vLLM:
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Client Usage
+
+  ### Offline OCR (Python)
+
+  ```python
+  from vllm import LLM, SamplingParams
+  from vllm.model_executor.models.deepseek_ocr import NGramPerReqLogitsProcessor
+  from PIL import Image
+
+  llm = LLM(
+      model="deepseek-ai/DeepSeek-OCR",
+      enable_prefix_caching=False,
+      mm_processor_cache_gb=0,
+      logits_processors=[NGramPerReqLogitsProcessor],
+  )
+
+  image_1 = Image.open("path/to/your/image_1.png").convert("RGB")
+  image_2 = Image.open("path/to/your/image_2.png").convert("RGB")
+  prompt = "<image>\nFree OCR."
+
+  model_input = [
+      {"prompt": prompt, "multi_modal_data": {"image": image_1}},
+      {"prompt": prompt, "multi_modal_data": {"image": image_2}},
+  ]
+
+  sampling_param = SamplingParams(
+      temperature=0.0,
+      max_tokens=8192,
+      extra_args=dict(
+          ngram_size=30,
+          window_size=90,
+          whitelist_token_ids={128821, 128822},  # <td>, </td>
+      ),
+      skip_special_tokens=False,
+  )
+
+  for output in llm.generate(model_input, sampling_param):
+      print(output.outputs[0].text)
+  ```
+
+  ### Online OCR serving
+
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-OCR \
+    --logits_processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor \
+    --no-enable-prefix-caching \
+    --mm-processor-cache-gb 0
+  ```
+
+  ```python
+  import time
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  messages = [
+      {
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://ofasys-multimodal-wlcb-3-toshanghai.oss-accelerate.aliyuncs.com/wpf272043/keepme/image/receipt.png"}},
+              {"type": "text", "text": "Free OCR."},
+          ],
+      }
+  ]
+
+  start = time.time()
+  response = client.chat.completions.create(
+      model="deepseek-ai/DeepSeek-OCR",
+      messages=messages,
+      max_tokens=2048,
+      temperature=0.0,
+      extra_body={
+          "skip_special_tokens": False,
+          "vllm_xargs": {
+              "ngram_size": 30,
+              "window_size": 90,
+              "whitelist_token_ids": [128821, 128822],
+          },
+      },
+  )
+  print(f"Response costs: {time.time() - start:.2f}s")
+  print(f"Generated text: {response.choices[0].message.content}")
+  ```
+
+  ## Troubleshooting / Configuration Tips
+
+  - **Use the custom logits processor** along with the model for optimal OCR and markdown
+    generation performance.
+  - Unlike multi-turn chat, OCR tasks do not typically benefit from prefix caching or image
+    reuse, so disable these features to avoid unnecessary hashing and caching overhead.
+  - DeepSeek-OCR works better with plain prompts than instruction formats. See the
+    [official example prompts](https://github.com/deepseek-ai/DeepSeek-OCR/blob/2ac6d64a00656693b79c4f759a5e62c1b78bbeb1/DeepSeek-OCR-master/DeepSeek-OCR-vllm/config.py#L27-L37).
+  - Depending on your hardware, adjust `max_num_batched_tokens` for better throughput.
+
+  ## References
+
+  - [DeepSeek-OCR on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-OCR)
+  - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html#offline-inference)

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -11,6 +11,16 @@ meta:
   related_recipes:
     - "deepseek-ai/DeepSeek-V3"
     - "deepseek-ai/DeepSeek-V3.1"
+  hardware:
+    h100: supported
+    h200: verified
+    b200: verified
+    gb200: verified
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-R1"

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -1,0 +1,197 @@
+meta:
+  title: "DeepSeek-R1"
+  slug: "deepseek-r1"
+  provider: "DeepSeek"
+  description: "DeepSeek-R1 is a 671B-parameter MoE reasoning model built on the DeepSeek-V3 architecture, trained with large-scale reinforcement learning for strong chain-of-thought capabilities."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Open-weights RL-trained reasoning model with native FP8 / FP4 variants"
+  related_recipes:
+    - "deepseek-ai/DeepSeek-V3"
+    - "deepseek-ai/DeepSeek-V3.1"
+
+model:
+  model_id: "deepseek-ai/DeepSeek-R1"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "671B"
+  active_parameters: "37B"
+  context_length: 163840
+  supports_dcp: true
+  base_args:
+    - "--trust-remote-code"
+    - "--enable-expert-parallel"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 805
+    description: "Native FP8 weights on 8xH200 (recommended)"
+  r1_0528:
+    model_id: "deepseek-ai/DeepSeek-R1-0528"
+    precision: fp8
+    vram_minimum_gb: 805
+    description: "May 2025 DeepSeek-R1 refresh (DeepSeek-R1-0528)"
+  nvfp4:
+    model_id: "nvidia/DeepSeek-R1-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 403
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP8: "1"
+  blackwell:
+    extra_args: []
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+  amd:
+    # AITER attention wins over Triton FA for DeepSeek MoE on MI300X/MI325X/MI355X.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MOE: "1"
+      VLLM_USE_TRITON_FLASH_ATTN: "0"
+      SAFETENSORS_FAST_GPU: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  DeepSeek-R1 is a 671B-parameter Mixture-of-Experts reasoning model (37B activated per
+  token) that shares its architecture with DeepSeek-V3, so the same launch recipes apply
+  to both. DeepSeek publishes a refreshed checkpoint as `DeepSeek-R1-0528`, and NVIDIA
+  publishes an FP4 quantized variant (`nvidia/DeepSeek-R1-FP4`) that runs on Blackwell
+  GPUs with fewer devices.
+
+  ## Prerequisites
+
+  - **Hardware (FP8)**: 8x H200 GPUs (verified)
+  - **Hardware (FP4)**: 4x B200 GPUs
+  - **vLLM**: Install with `uv pip install -U vllm --torch-backend auto`
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Client Usage
+
+  ### 8xH200 (FP8)
+
+  Tensor Parallel + Expert Parallel (TP8+EP):
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-R1-0528 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel
+  ```
+
+  Data Parallel + Expert Parallel (DP8+EP):
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-R1-0528 \
+    --trust-remote-code \
+    --data-parallel-size 8 \
+    --enable-expert-parallel
+  ```
+
+  ### 4xB200 (FP4)
+
+  Enable FlashInfer MoE kernels before launching:
+  ```bash
+  # For FP4 (recommended on Blackwell)
+  export VLLM_USE_FLASHINFER_MOE_FP4=1
+  # For FP8 on Blackwell
+  export VLLM_USE_FLASHINFER_MOE_FP8=1
+  ```
+
+  Tensor Parallel + Expert Parallel (TP4+EP):
+  ```bash
+  CUDA_VISIBLE_DEVICES=0,1,2,3 vllm serve nvidia/DeepSeek-R1-FP4 \
+    --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel
+  ```
+
+  Data Parallel + Expert Parallel (DP4+EP):
+  ```bash
+  CUDA_VISIBLE_DEVICES=0,1,2,3 vllm serve nvidia/DeepSeek-R1-FP4 \
+    --trust-remote-code \
+    --data-parallel-size 4 \
+    --enable-expert-parallel
+  ```
+
+  ## Benchmarking
+
+  For benchmarking, disable prefix caching by adding `--no-enable-prefix-caching`
+  to the server command.
+
+  ```bash
+  # FP8 benchmark
+  vllm bench serve \
+    --model deepseek-ai/DeepSeek-R1-0528 \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos
+  ```
+
+  ```bash
+  # FP4 benchmark
+  vllm bench serve \
+    --model nvidia/DeepSeek-R1-FP4 \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos
+  ```
+
+  Test different workloads by adjusting input/output lengths:
+  - Prompt-heavy: 8000 input / 1000 output
+  - Decode-heavy: 1000 input / 8000 output
+  - Balanced: 1000 input / 1000 output
+
+  ## Troubleshooting
+
+  - **Disaggregated Serving with Wide EP (Experimental GB200)**: See
+    [vLLM issue #33583](https://github.com/vllm-project/vllm/issues/33583),
+    [the vLLM blog post](https://blog.vllm.ai/2026/02/03/dsr1-gb200-part1.html), and
+    [this reference fork](https://github.com/minosfuture/vllm/tree/pd_gb200_0114/runs/DS-R1/fp4)
+    for GB200 disaggregated serving recipes.
+
+  ## References
+
+  - [DeepSeek-R1 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1)
+  - [DeepSeek-R1-0528 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1-0528)
+  - [NVIDIA DeepSeek-R1-FP4](https://huggingface.co/nvidia/DeepSeek-R1-FP4)
+  - [vLLM Expert Parallelism docs](https://docs.vllm.ai/en/latest/serving/expert_parallel_deployment.html)

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -12,15 +12,9 @@ meta:
     - "deepseek-ai/DeepSeek-V3"
     - "deepseek-ai/DeepSeek-V3.1"
   hardware:
-    h100: supported
     h200: verified
     b200: verified
     gb200: verified
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-R1"
@@ -85,7 +79,6 @@ hardware_overrides:
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
-      VLLM_USE_TRITON_FLASH_ATTN: "0"
       SAFETENSORS_FAST_GPU: "1"
 
 strategy_overrides: {}

--- a/models/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.1.yaml
@@ -12,15 +12,7 @@ meta:
     - "deepseek-ai/DeepSeek-V3"
     - "deepseek-ai/DeepSeek-V3.2-Exp"
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.1"
@@ -83,7 +75,6 @@ hardware_overrides:
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
-      VLLM_USE_TRITON_FLASH_ATTN: "0"
       SAFETENSORS_FAST_GPU: "1"
 
 strategy_overrides: {}

--- a/models/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.1.yaml
@@ -1,0 +1,177 @@
+meta:
+  title: "DeepSeek-V3.1"
+  slug: "deepseek-v3.1"
+  provider: "DeepSeek"
+  description: "DeepSeek-V3.1 is a hybrid MoE model that supports dynamic switching between thinking and non-thinking modes, with tool calling and function execution."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Hybrid thinking / non-thinking MoE with native FP8 and tool calling"
+  related_recipes:
+    - "deepseek-ai/DeepSeek-V3"
+    - "deepseek-ai/DeepSeek-V3.2-Exp"
+
+model:
+  model_id: "deepseek-ai/DeepSeek-V3.1"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "671B"
+  active_parameters: "37B"
+  context_length: 163840
+  supports_dcp: true
+  base_args:
+    - "--trust-remote-code"
+    - "--enable-expert-parallel"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Enable DeepSeek-V3.1 tool calling with the deepseek_v31 tool-call parser."
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "deepseek_v31"
+      - "--chat-template"
+      - "examples/tool_chat_template_deepseekv31.jinja"
+  reasoning:
+    description: "Dynamic thinking mode via chat_template_kwargs={'thinking': true|false}. No separate parser flag is required; the chat template emits <think>...</think> content."
+    args: []
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 805
+    description: "Native FP8 weights on 8xH200 (or H20) with 141GB per GPU"
+  nvfp4:
+    model_id: "nvidia/DeepSeek-V3.1-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 403
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    # AITER attention wins over Triton FA for DeepSeek MoE on MI300X/MI325X/MI355X.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MOE: "1"
+      VLLM_USE_TRITON_FLASH_ATTN: "0"
+      SAFETENSORS_FAST_GPU: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  DeepSeek-V3.1 is a hybrid MoE model that supports both thinking and non-thinking modes.
+  You can dynamically switch between the two modes from the client by passing
+  `extra_body={"chat_template_kwargs": {"thinking": True|False}}`.
+
+  ## Prerequisites
+
+  - **Hardware**: 8x H200 (or H20) GPUs (141 GB per GPU)
+  - **vLLM**: Current stable release
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launching DeepSeek-V3.1
+
+  ### Serving on 8xH200 (or H20) GPUs
+
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-V3.1 \
+    --enable-expert-parallel \
+    --tensor-parallel-size 8 \
+    --served-model-name ds31
+  ```
+
+  ### Function calling
+
+  vLLM supports user-defined tool calling for DeepSeek-V3.1. Add these flags when launching
+  the server. The example chat template ships in the official container and can also be
+  downloaded from the vLLM repo:
+  [`tool_chat_template_deepseekv31.jinja`](https://github.com/vllm-project/vllm/blob/main/examples/tool_chat_template_deepseekv31.jinja).
+
+  ```bash
+  vllm serve ... \
+    --enable-auto-tool-choice \
+    --tool-call-parser deepseek_v31 \
+    --chat-template examples/tool_chat_template_deepseekv31.jinja
+  ```
+
+  ## Client Usage
+
+  ### OpenAI Python SDK
+
+  Control thinking mode via `extra_body={"chat_template_kwargs": {"thinking": False}}`
+  (or `True` to enable thinking).
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  model = client.models.list().data[0].id
+
+  messages = [
+      {"role": "system", "content": "You are a helpful assistant"},
+      {"role": "user", "content": "Who are you?"},
+      {"role": "assistant", "content": "<think>Hmm</think>I am DeepSeek"},
+      {"role": "user", "content": "9.11 and 9.8, which is greater?"},
+  ]
+  response = client.chat.completions.create(
+      model=model,
+      messages=messages,
+      extra_body={"chat_template_kwargs": {"thinking": False}},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  When `thinking=True`, output includes a `</think>` segment delimiting chain-of-thought;
+  when `thinking=False`, the model produces a direct answer without the thinking segment.
+
+  ### curl
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+      -H "Content-Type: application/json" \
+      -d '{
+          "model": "ds31",
+          "messages": [
+              {"role": "user", "content": "9.11 and 9.8, which is greater?"}
+          ],
+          "chat_template_kwargs": {"thinking": true}
+      }'
+  ```
+
+  ## References
+
+  - [DeepSeek-V3.1 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-V3.1)
+  - [vLLM tool chat template for DeepSeek-V3.1](https://github.com/vllm-project/vllm/blob/main/examples/tool_chat_template_deepseekv31.jinja)

--- a/models/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.1.yaml
@@ -11,6 +11,16 @@ meta:
   related_recipes:
     - "deepseek-ai/DeepSeek-V3"
     - "deepseek-ai/DeepSeek-V3.2-Exp"
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.1"
@@ -67,12 +77,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     # AITER attention wins over Triton FA for DeepSeek MoE on MI300X/MI325X/MI355X.
     extra_args: []

--- a/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -1,0 +1,149 @@
+meta:
+  title: "DeepSeek-V3.2-Exp"
+  slug: "deepseek-v3.2-exp"
+  provider: "DeepSeek"
+  description: "Experimental DeepSeek-V3.2 preview with sparse attention (MQA-like logits) and FP8 KV cache; architecture matches DeepSeek-V3.1 except for the sparse attention mechanism."
+  date_updated: 2026-04-17
+  difficulty: advanced
+  tasks:
+    - text
+  performance_headline: "Sparse attention MoE with FP8 KV cache and strong GSM8K score (~0.96)"
+  related_recipes:
+    - "deepseek-ai/DeepSeek-V3.1"
+    - "deepseek-ai/DeepSeek-V3.2"
+
+model:
+  model_id: "deepseek-ai/DeepSeek-V3.2-Exp"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "671B"
+  active_parameters: "37B"
+  context_length: 163840
+  supports_dcp: true
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+dependencies:
+  - note: "DeepGEMM pinned build for MQA logits (FP8 MoE kernels)"
+    command: "uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation"
+
+features:
+  reasoning:
+    description: "Dynamic thinking mode via chat_template_kwargs, same as DeepSeek-V3.1."
+    args: []
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 805
+    description: "Native FP8 weights on 8xH200 (or H20, or 8xB200) with FP8 KV cache default"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    # V3.2-Exp uses sparse attention → --block-size 1 + bfloat16 KV cache.
+    extra_args:
+      - "--block-size"
+      - "1"
+      - "--kv-cache-dtype"
+      - "bfloat16"
+      - "--no-enable-prefix-caching"
+      - "--max-num-batched-tokens"
+      - "32768"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MOE: "1"
+      SAFETENSORS_FAST_GPU: "1"
+      VLLM_RPC_TIMEOUT: "18000000"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  DeepSeek-V3.2-Exp is a sparse-attention MoE preview. Its main architecture is similar to
+  DeepSeek-V3.1, with a sparse attention mechanism. Only Hopper and Blackwell data center
+  GPUs are supported for now.
+
+  ## Prerequisites
+
+  - **Hardware**: 8x H200 (or H20, or 8xB200) GPUs
+  - **vLLM**: Current stable release
+  - **DeepGEMM**: Required for MQA logits computation (and optionally for MoE)
+
+  ```bash
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation
+  ```
+
+  Note: DeepGEMM is used both for MoE and for MQA logits computation. It is required for
+  MQA logits. To disable the MoE path only, set `VLLM_USE_DEEP_GEMM=0`. Some users report
+  better performance with `VLLM_USE_DEEP_GEMM=0` (e.g. on H20), and this also skips the
+  long warmup.
+
+  ## Launching DeepSeek-V3.2-Exp
+
+  ### Serving on 8xH200 (or H20) GPUs
+
+  Using the recommended EP/DP mode:
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-V3.2-Exp -dp 8 --enable-expert-parallel
+  ```
+
+  Using tensor parallel:
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-V3.2-Exp -tp 8
+  ```
+
+  ### Serving on 8xB200 GPUs
+
+  Same as the above.
+
+  ## Accuracy Benchmarking
+
+  ```bash
+  lm-eval --model local-completions --tasks gsm8k \
+    --model_args model=deepseek-ai/DeepSeek-V3.2-Exp,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=100,max_retries=3,tokenized_requests=False
+  ```
+
+  Reported GSM8K score: `0.9591` (5-shot) and `0.9538` (20-shot).
+
+  ## Performance Tips
+
+  1. The kernels are mainly optimized for TP=1, so it is recommended to run this model
+     under EP/DP mode (e.g. DP=8, EP=8, TP=1). If you hit any errors or hangs, try tensor
+     parallel instead. Simple TP works and is more robust, but the performance is not optimal.
+  2. The default config uses a custom `fp8` KV cache. You can also use `bfloat16` KV cache
+     by specifying `kv_cache_dtype=bfloat16`. FP8 allows more tokens to be cached but incurs
+     quantization/dequantization overhead. Use `bfloat16` for short requests and `fp8` for
+     long requests.
+
+  ## Troubleshooting
+
+  - **`CUDA error (flashmla-src/csrc/smxx/mla_combine.cu:201): invalid configuration argument`**:
+    This may be caused by too large a batch size. Try `--max-num-seqs 256` or smaller
+    (default is 1024).
+  - For thinking-mode toggling, refer to the DeepSeek-V3.1 recipe (`deepseek-ai/DeepSeek-V3.1`).
+
+  ## References
+
+  - [DeepSeek-V3.2-Exp on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp)
+  - [End-to-end tutorial (Jupyter Notebook)](https://github.com/vllm-project/recipes/blob/main/DeepSeek/DeepSeek_v3_2_vLLM_getting_started_guide.ipynb)

--- a/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -11,6 +11,16 @@ meta:
   related_recipes:
     - "deepseek-ai/DeepSeek-V3.1"
     - "deepseek-ai/DeepSeek-V3.2"
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.2-Exp"
@@ -51,12 +61,6 @@ compatible_strategies:
   - multi_node_tep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     # V3.2-Exp uses sparse attention → --block-size 1 + bfloat16 KV cache.
     extra_args:

--- a/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -12,15 +12,7 @@ meta:
     - "deepseek-ai/DeepSeek-V3.1"
     - "deepseek-ai/DeepSeek-V3.2"
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.2-Exp"

--- a/models/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2.yaml
@@ -12,13 +12,6 @@ meta:
   hardware:
     h100: verified
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.2"

--- a/models/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "GPT-5-level reasoning with efficient MoE inference"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.2"
@@ -80,9 +90,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
   blackwell:
     extra_args:
       - "--attention-backend"

--- a/models/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2.yaml
@@ -1,0 +1,189 @@
+meta:
+  title: "DeepSeek-V3.2"
+  slug: "deepseek-v3.2"
+  provider: "DeepSeek"
+  description: "DeepSeek V3.2 MoE model with MLA attention, sparse attention, and scalable RL for strong reasoning and agent capabilities."
+  date_updated: 2026-04-01
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "GPT-5-level reasoning with efficient MoE inference"
+  related_recipes: []
+
+model:
+  model_id: "deepseek-ai/DeepSeek-V3.2"
+  min_vllm_version: "0.18.0"
+  architecture: moe
+  parameter_count: "671B"
+  active_parameters: "37B"
+  context_length: 163840
+  supports_dcp: true
+  base_args:
+    - "--trust-remote-code"
+    - "--kernel-config.enable_flashinfer_autotune=False"
+  base_env: {}
+
+dependencies:
+  - note: "DeepGEMM pinned build for MQA logits (FP8 MoE kernels)"
+    command: "uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation"
+  - note: "Set VLLM_USE_DEEP_GEMM=0 to skip DeepGEMM for the MoE path (recommended on H20)"
+    command: "export VLLM_USE_DEEP_GEMM=0"
+    optional: true
+
+features:
+  tool_calling:
+    description: "Enable tool calling with DeepSeek V3.2 chat template support."
+    args:
+      - "--tokenizer-mode"
+      - "deepseek_v32"
+      - "--tool-call-parser"
+      - "deepseek_v32"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "Enable reasoning/thinking mode with the DeepSeek V3 reasoning parser."
+    args:
+      - "--reasoning-parser"
+      - "deepseek_v3"
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding with 3 speculative tokens."
+    args:
+      - "--speculative_config"
+      - '{"method":"mtp","num_speculative_tokens":3}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 805
+    description: "Native FP8 checkpoint (F8_E4M3)"
+  nvfp4:
+    model_id: "nvidia/DeepSeek-V3.2-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 403
+    description: "NVIDIA FP4 quantized variant with FP8 KV cache for reduced VRAM usage."
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args:
+      - "--attention-backend"
+      - "FLASHINFER_MLA"
+    extra_env: {}
+  amd:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides:
+  pd_cluster:
+    prefill:
+      extra_args: []
+      extra_env: {}
+    decode:
+      extra_args: []
+      extra_env: {}
+  single_node_dep:
+    extra_args: []
+    extra_env: {}
+
+guide: |
+  ## Overview
+
+  DeepSeek-V3.2 is a Mixture-of-Experts model that balances computational efficiency with
+  strong reasoning and agent capabilities through three technical innovations: DeepSeek Sparse
+  Attention (DSA) for efficient long-context processing, a scalable reinforcement learning
+  framework achieving GPT-5-level performance, and a large-scale agentic task synthesis pipeline
+  for robust tool-use generalization.
+
+  ## Prerequisites
+
+  - **Hardware**: Minimum 8x H100/H200 80GB GPUs (BF16) or 3x H200 (NVFP4 variant).
+  - **vLLM**: Version 0.18.0 or later (nightly recommended).
+  - **Python**: 3.10+
+  - **CUDA**: 12.x or later (CUDA 13.x may require extra env vars; see Troubleshooting).
+  - **Disk**: ~1.3 TB for BF16 weights; ~350 GB for NVFP4 variant.
+  - **DeepGEMM** (recommended):
+    ```bash
+    uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation
+    ```
+    Note: Set `VLLM_USE_DEEP_GEMM=0` to disable MoE DeepGEMM if you experience issues
+    (e.g., on H20 GPUs) or want to skip the long warmup.
+
+  ## Client Usage
+
+  Launch the server:
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-V3.2 \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --kernel-config.enable_flashinfer_autotune=False \
+    --tokenizer-mode deepseek_v32 \
+    --tool-call-parser deepseek_v32 \
+    --enable-auto-tool-choice \
+    --reasoning-parser deepseek_v3
+  ```
+
+  Use the OpenAI Python SDK to interact with the server:
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(
+      api_key="your-api-key",
+      base_url="http://localhost:8000/v1",
+  )
+
+  # Standard chat
+  response = client.chat.completions.create(
+      model="deepseek-ai/DeepSeek-V3.2",
+      messages=[{"role": "user", "content": "Hello!"}],
+  )
+
+  # Thinking / reasoning mode
+  response = client.chat.completions.create(
+      model="deepseek-ai/DeepSeek-V3.2",
+      messages=[{"role": "user", "content": "Solve this step by step..."}],
+      extra_body={"chat_template_kwargs": {"thinking": True}},
+  )
+  ```
+
+  ## Troubleshooting
+
+  **`ptxas fatal: Value 'sm_110a' is not defined for option 'gpu-name'`**
+  This can occur on CUDA 13.x. Fix by exporting:
+  ```bash
+  export TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
+  export PATH=/usr/local/cuda/bin:$PATH
+  export LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}
+  ```
+
+  **TP=8 performance on Hopper/Blackwell**
+  Avoid `-tp 8` with FlashMLA-Sparse. Due to kernel restrictions, TP=8 yields only 16 heads
+  per rank but is padded to 64, causing overhead. Prefer TP=2 (Hopper) or TP=1 (Blackwell)
+  with DP/EP mode: `vllm serve deepseek-ai/DeepSeek-V3.2 -dp 8 --enable-expert-parallel`.
+
+  **DeepGEMM warmup too slow**
+  Set `VLLM_USE_DEEP_GEMM=0` to disable MoE DeepGEMM and skip the long warmup.
+
+  ## References
+
+  - [DeepSeek-V3.2 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-V3.2)
+  - [DeepSeek API Documentation](https://api-docs.deepseek.com/)
+  - [vLLM Data Parallel Deployment Guide](https://docs.vllm.ai/en/latest/serving/data_parallel_deployment.html)

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -1,0 +1,175 @@
+meta:
+  title: "DeepSeek-V3"
+  slug: "deepseek-v3"
+  provider: "DeepSeek"
+  description: "DeepSeek-V3 is a 671B-parameter Mixture-of-Experts model with native FP8 weights and strong reasoning, coding, and math capabilities."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Frontier open-weights MoE with native FP8 and FP4 variants"
+  related_recipes:
+    - "deepseek-ai/DeepSeek-R1"
+    - "deepseek-ai/DeepSeek-V3.1"
+
+model:
+  model_id: "deepseek-ai/DeepSeek-V3"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "671B"
+  active_parameters: "37B"
+  context_length: 163840
+  supports_dcp: true
+  base_args:
+    - "--trust-remote-code"
+    - "--enable-expert-parallel"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 805
+    description: "Native FP8 weights on 8xH200 (recommended)"
+  fp4:
+    model_id: "nvidia/DeepSeek-V3-FP4"
+    precision: fp4
+    vram_minimum_gb: 403
+    description: "NVIDIA FP4 quantized weights for Blackwell (e.g. 4xB200)"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP8: "1"
+  blackwell:
+    extra_args: []
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+  amd:
+    # AITER attention wins over Triton FA for DeepSeek MoE on MI300X/MI325X/MI355X.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MOE: "1"
+      VLLM_USE_TRITON_FLASH_ATTN: "0"
+      SAFETENSORS_FAST_GPU: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  DeepSeek-V3 is a 671B-parameter Mixture-of-Experts model (37B activated per token)
+  shipped with native FP8 weights. It shares its architecture with DeepSeek-R1, so the
+  same launch recipes apply to both models. For Blackwell GPUs, NVIDIA publishes an FP4
+  quantized variant (`nvidia/DeepSeek-V3-FP4` / `nvidia/DeepSeek-R1-FP4`) that runs on
+  fewer GPUs.
+
+  ## Prerequisites
+
+  - **Hardware (FP8)**: 8x H200 GPUs (verified)
+  - **Hardware (FP4)**: 4x B200 GPUs
+  - **vLLM**: Install with `uv pip install -U vllm --torch-backend auto`
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Client Usage
+
+  ### 8xH200 (FP8)
+
+  Tensor Parallel + Expert Parallel (TP8+EP):
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-V3 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel
+  ```
+
+  Data Parallel + Expert Parallel (DP8+EP):
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-V3 \
+    --trust-remote-code \
+    --data-parallel-size 8 \
+    --enable-expert-parallel
+  ```
+
+  ### 4xB200 (FP4)
+
+  Enable FlashInfer MoE kernels before launching:
+  ```bash
+  # For FP4 (recommended on Blackwell)
+  export VLLM_USE_FLASHINFER_MOE_FP4=1
+  # For FP8 on Blackwell
+  export VLLM_USE_FLASHINFER_MOE_FP8=1
+  ```
+
+  Tensor Parallel + Expert Parallel (TP4+EP):
+  ```bash
+  CUDA_VISIBLE_DEVICES=0,1,2,3 vllm serve nvidia/DeepSeek-V3-FP4 \
+    --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel
+  ```
+
+  Data Parallel + Expert Parallel (DP4+EP):
+  ```bash
+  CUDA_VISIBLE_DEVICES=0,1,2,3 vllm serve nvidia/DeepSeek-V3-FP4 \
+    --trust-remote-code \
+    --data-parallel-size 4 \
+    --enable-expert-parallel
+  ```
+
+  ## Benchmarking
+
+  For benchmarking, disable prefix caching by adding `--no-enable-prefix-caching`
+  to the server command.
+
+  ```bash
+  # Prompt-heavy benchmark (8k/1k)
+  vllm bench serve \
+    --model deepseek-ai/DeepSeek-V3 \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos
+  ```
+
+  Test different workloads by adjusting input/output lengths:
+  - Prompt-heavy: 8000 input / 1000 output
+  - Decode-heavy: 1000 input / 8000 output
+  - Balanced: 1000 input / 1000 output
+
+  ## Troubleshooting
+
+  - **Disaggregated Serving with Wide EP (Experimental GB200)**: See
+    [vLLM issue #33583](https://github.com/vllm-project/vllm/issues/33583) and the
+    [vLLM blog post](https://blog.vllm.ai/2026/02/03/dsr1-gb200-part1.html) for
+    GB200 disaggregated serving recipes.
+
+  ## References
+
+  - [DeepSeek-V3 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-V3)
+  - [NVIDIA DeepSeek-V3-FP4](https://huggingface.co/nvidia/DeepSeek-V3-FP4)
+  - [vLLM Expert Parallelism docs](https://docs.vllm.ai/en/latest/serving/expert_parallel_deployment.html)

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -12,15 +12,9 @@ meta:
     - "deepseek-ai/DeepSeek-R1"
     - "deepseek-ai/DeepSeek-V3.1"
   hardware:
-    h100: supported
     h200: verified
     b200: verified
     gb200: verified
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3"
@@ -77,7 +71,6 @@ hardware_overrides:
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
-      VLLM_USE_TRITON_FLASH_ATTN: "0"
       SAFETENSORS_FAST_GPU: "1"
 
 strategy_overrides: {}

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -11,6 +11,16 @@ meta:
   related_recipes:
     - "deepseek-ai/DeepSeek-R1"
     - "deepseek-ai/DeepSeek-V3.1"
+  hardware:
+    h100: supported
+    h200: verified
+    b200: verified
+    gb200: verified
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3"

--- a/models/inclusionAI/Ring-1T-FP8.yaml
+++ b/models/inclusionAI/Ring-1T-FP8.yaml
@@ -1,0 +1,127 @@
+meta:
+  title: "Ring-1T-FP8"
+  slug: "ring-1t-fp8"
+  provider: "inclusionAI"
+  description: "Ring-1T (BailingMoeV2) FP8 model (~1T total params) for 8xH200 or 8xMI300X deployment"
+  date_updated: 2026-04-17
+  difficulty: advanced
+  tasks:
+    - text
+  related_recipes: []
+
+model:
+  model_id: "inclusionAI/Ring-1T-FP8"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "1T"
+  active_parameters: "50B"
+  context_length: 65536
+  base_args:
+    - "--trust-remote-code"
+    - "--tensor-parallel-size"
+    - "8"
+    - "--max_num_seqs"
+    - "32"
+    - "--kv-cache-dtype"
+    - "fp8"
+    - "--served-model-name"
+    - "Ring-1T-FP8"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 1200
+    description: "FP8 weights on 8x H200 (80 GB) with FP8 KV cache"
+    extra_args:
+      - "--gpu-memory-utilization"
+      - "0.97"
+      - "--compilation-config"
+      - '{"use_inductor": false}'
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Ring-1T-FP8 is inclusionAI's BailingMoeV2 FP8 model (~1T total parameters). This recipe
+  covers pure tensor-parallel deployment across 8 GPUs on NVIDIA H200 or AMD MI300X+.
+
+  ## Prerequisites
+
+  - Hardware: 8x H200 or 8x MI300X/MI325X/MI355X
+  - vLLM >= 0.11.0
+
+  ### Install vLLM (CUDA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700
+  ```
+
+  ## Launch commands
+
+  8x H200 (FP8 KV cache):
+
+  ```bash
+  vllm serve inclusionAI/Ring-1T-FP8 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --gpu-memory-utilization 0.97 \
+    --max_num_seqs 32 \
+    --kv-cache-dtype fp8 \
+    --compilation-config '{"use_inductor": false}' \
+    --served-model-name Ring-1T-FP8
+  ```
+
+  8x MI300X/MI325X/MI355X:
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve inclusionAI/Ring-1T-FP8 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --gpu-memory-utilization 0.9 \
+    --max_num_seqs 32 \
+    --kv-cache-dtype fp8 \
+    --served-model-name Ring-1T-FP8
+  ```
+
+  Tuning flags:
+  - `--max-model-len=65536` works well for most scenarios.
+  - `--max-num-batched-tokens=32768` for prompt-heavy; 16384/8192 for lower latency.
+  - Reduce `--gpu-memory-utilization` below 0.97 if you hit OOM.
+
+  ## Client Usage
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Ring-1T-FP8",
+      "messages": [{"role": "user", "content": "9.11 and 9.8, which is greater?"}]
+    }'
+  ```
+
+  ## References
+
+  - [Ring-1T-FP8 on Hugging Face](https://huggingface.co/inclusionAI/Ring-1T-FP8)

--- a/models/inclusionAI/Ring-1T-FP8.yaml
+++ b/models/inclusionAI/Ring-1T-FP8.yaml
@@ -8,6 +8,16 @@ meta:
   tasks:
     - text
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "inclusionAI/Ring-1T-FP8"

--- a/models/inclusionAI/Ring-1T-FP8.yaml
+++ b/models/inclusionAI/Ring-1T-FP8.yaml
@@ -9,12 +9,7 @@ meta:
     - text
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/internlm/Intern-S1.yaml
+++ b/models/internlm/Intern-S1.yaml
@@ -9,6 +9,10 @@ meta:
     - multimodal
   related_recipes:
     - OpenGVLab/InternVL3_5-8B
+  hardware:
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "internlm/Intern-S1"

--- a/models/internlm/Intern-S1.yaml
+++ b/models/internlm/Intern-S1.yaml
@@ -1,0 +1,160 @@
+meta:
+  title: "Intern-S1"
+  slug: "intern-s1"
+  provider: "InternLM"
+  description: "Intern-S1 vision-language model from Shanghai AI Lab with BF16/FP8 variants and thinking/non-thinking modes"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  related_recipes:
+    - OpenGVLab/InternVL3_5-8B
+
+model:
+  model_id: "internlm/Intern-S1"
+  min_vllm_version: "0.10.0"
+  architecture: moe
+  parameter_count: "241B"
+  active_parameters: "28B"
+  context_length: 65536
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "InternLM tool-call parser with automatic tool choice"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "internlm"
+  reasoning:
+    description: "DeepSeek-R1 reasoning parser extracts <think>...</think>"
+    args:
+      - "--reasoning-parser"
+      - "deepseek_r1"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 578
+    description: "BF16 on 8x H800 (80GB each)"
+    extra_args:
+      - "--tensor-parallel-size"
+      - "8"
+
+  fp8:
+    model_id: "internlm/Intern-S1-FP8"
+    precision: fp8
+    vram_minimum_gb: 289
+    description: "FP8 on 4x H800 (80GB each)"
+    extra_args:
+      - "--tensor-parallel-size"
+      - "4"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  amd:
+    # VLLM_ROCM_USE_AITER_MOE=0 is required on MI300X/MI325X (FP8 checkpoint).
+    # On MI355X, unset this env for faster AITER MoE kernels.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MOE: "0"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Intern-S1](https://github.com/InternLM/Intern-S1) is a vision-language model developed
+  by Shanghai AI Laboratory. It supports thinking and non-thinking modes via chat-template
+  kwargs and ships in BF16 and FP8 variants.
+
+  ## Prerequisites
+
+  - Hardware: 8xH800 (80GB) for BF16, 4xH800 for FP8, or 4-8x MI300X/MI325X/MI355X
+  - vLLM >= 0.10.0
+
+  ### Install vLLM (CUDA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700
+  ```
+
+  ## Launch commands
+
+  BF16 on 8xH800:
+
+  ```bash
+  vllm serve internlm/Intern-S1 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --enable-auto-tool-choice \
+    --reasoning-parser deepseek_r1 \
+    --tool-call-parser internlm
+  ```
+
+  FP8 on 4xH800:
+
+  ```bash
+  vllm serve internlm/Intern-S1-FP8 \
+    --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --enable-auto-tool-choice \
+    --reasoning-parser deepseek_r1 \
+    --tool-call-parser internlm
+  ```
+
+  FP8 on 8xMI300X/MI325X:
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_USE_AITER_MOE=0
+  vllm serve internlm/Intern-S1-FP8 \
+    --trust-remote-code --tensor-parallel-size 8 \
+    --enable-auto-tool-choice --reasoning-parser deepseek_r1 --tool-call-parser internlm
+  ```
+
+  FP8 on 8xMI355X: set only `VLLM_ROCM_USE_AITER=1` (no need to disable AITER MoE).
+
+  ## Switching Between Thinking and Non-Thinking Modes
+
+  ```python
+  from openai import OpenAI
+  client = OpenAI(api_key="YOUR_API_KEY", base_url="http://0.0.0.0:8000/v1")
+  model_name = client.models.list().data[0].id
+
+  response = client.chat.completions.create(
+      model=model_name,
+      messages=[{"role": "user", "content": "9.11 and 9.8, which is greater?"}],
+      temperature=0.8, top_p=0.8,
+      extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+  )
+  print(response)
+  ```
+
+  ## Troubleshooting
+
+  - `ValueError: No available memory for the cache blocks.` — add `--gpu-memory-utilization 0.95`.
+
+  ## References
+
+  - [Intern-S1 on Hugging Face](https://huggingface.co/internlm/Intern-S1)
+  - [Intern-S1-FP8](https://huggingface.co/internlm/Intern-S1-FP8)
+  - [Intern-S1 GitHub](https://github.com/InternLM/Intern-S1)

--- a/models/jinaai/jina-reranker-m0.yaml
+++ b/models/jinaai/jina-reranker-m0.yaml
@@ -1,0 +1,169 @@
+meta:
+  title: "Jina Reranker m0"
+  slug: "jina-reranker-m0"
+  provider: "Jina AI"
+  description: "Multilingual, multimodal reranker for text and visual documents across 29+ languages via Qwen2-VL backbone"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - embedding
+  related_recipes: []
+
+model:
+  model_id: "jinaai/jina-reranker-m0"
+  min_vllm_version: "0.8.0"
+  architecture: dense
+  parameter_count: "2.4B"
+  active_parameters: "2.4B"
+  context_length: 32768
+  base_args:
+    - "--gpu-memory-utilization"
+    - "0.75"
+    - "--max-num-seqs"
+    - "32"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 6
+    description: "BF16 weights; 2x T4 or 2x L4 GPUs"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  amd:
+    # AITER is optional here but recommended for perf on MI300X/MI325X/MI355X.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [jinaai/jina-reranker-m0](https://huggingface.co/jinaai/jina-reranker-m0) is a
+  multilingual, multimodal reranker that ranks visual documents across 29+ languages.
+  It accepts text and visual content, including pages with mixed text, figures, tables,
+  and various layouts.
+
+  Deployment target: 2x NVIDIA T4 or 2x NVIDIA L4.
+
+  ## Prerequisites
+
+  - Hardware: 2x T4 or 2x L4 (or any 2x GPU with ~16 GB each)
+  - vLLM >= 0.8.0
+
+  ### Install vLLM (CUDA)
+
+  ```bash
+  uv pip install vllm
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700
+  ```
+
+  ## Launch command
+
+  ```bash
+  vllm serve jinaai/jina-reranker-m0 \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tensor_parallel_size 2 \
+    --gpu-memory-utilization 0.75 \
+    --max_num_seqs 32
+  ```
+
+  On AMD:
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve jinaai/jina-reranker-m0 \
+    --tensor_parallel_size 2 --gpu-memory-utilization 0.75 --max_num_seqs 32
+  ```
+
+  ## Rerank API
+
+  ```bash
+  curl -X POST http://localhost:8000/v1/rerank \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "jinaai/jina-reranker-m0",
+      "query": "What are the health benefits of green tea?",
+      "documents": [
+        "Green tea contains antioxidants called catechins...",
+        "El precio del café ha aumentado un 20% este año...",
+        "Studies show that drinking green tea regularly..."
+      ],
+      "top_n": 3,
+      "return_documents": true
+    }'
+  ```
+
+  ## Score API
+
+  Text-to-text:
+
+  ```bash
+  curl -X POST http://localhost:8000/v1/score \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "jinaai/jina-reranker-m0",
+      "text_1": ["What is the capital of Brazil?"],
+      "text_2": ["The capital of Brazil is Brasilia."]
+    }'
+  ```
+
+  Multimodal (text vs. images):
+
+  ```json
+  {
+    "model": "jinaai/jina-reranker-m0",
+    "text_1": "A cat",
+    "text_2": {
+      "content": [
+        {"type": "image_url", "image_url": {"url": "cat_img.jpg"}},
+        {"type": "image_url", "image_url": {"url": "dog_img.jpg"}}
+      ]
+    }
+  }
+  ```
+
+  ## Offline Deployment
+
+  ```python
+  from vllm import LLM
+
+  llm = LLM(
+      model="jinaai/jina-reranker-m0",
+      tensor_parallel_size=2,
+      gpu_memory_utilization=0.75,
+      max_model_len=1024,
+      max_num_seqs=32,
+      kv_cache_dtype="fp8",
+      dtype="bfloat16",
+  )
+
+  res = llm.score("fast recipes for weeknight dinners", [
+      "A 65-minute pasta with garlic and olive oil.",
+      "Slow braised short ribs that cook for 5 hours.",
+      "Stir-fry veggies with pre-cooked rice.",
+  ])
+  for item in res:
+      print(item.outputs.score)
+  ```
+
+  ## References
+
+  - [jina-reranker-m0 on Hugging Face](https://huggingface.co/jinaai/jina-reranker-m0)
+  - [vLLM Score API documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#score-api)

--- a/models/jinaai/jina-reranker-m0.yaml
+++ b/models/jinaai/jina-reranker-m0.yaml
@@ -8,6 +8,10 @@ meta:
   tasks:
     - embedding
   related_recipes: []
+  hardware:
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "jinaai/jina-reranker-m0"

--- a/models/jinaai/jina-reranker-m0.yaml
+++ b/models/jinaai/jina-reranker-m0.yaml
@@ -8,10 +8,6 @@ meta:
   tasks:
     - embedding
   related_recipes: []
-  hardware:
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "jinaai/jina-reranker-m0"

--- a/models/meituan-longcat/LongCat-Image-Edit.yaml
+++ b/models/meituan-longcat/LongCat-Image-Edit.yaml
@@ -1,0 +1,97 @@
+meta:
+  title: "LongCat-Image-Edit"
+  slug: "longcat-image-edit"
+  provider: "Meituan"
+  description: "Bilingual (Chinese-English) image editing model from Meituan LongCat, served via vLLM-Omni"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - omni
+  related_recipes: []
+
+model:
+  model_id: "meituan-longcat/LongCat-Image-Edit"
+  min_vllm_version: "0.12.0"
+  architecture: dense
+  parameter_count: "6B"
+  active_parameters: "6B"
+  context_length: 0
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "vLLM-Omni must be installed from source with vllm==0.12.0 for LongCat-Image-Edit"
+    command: "git clone https://github.com/vllm-project/vllm-omni.git && cd vllm-omni && uv pip install -e . vllm==0.12.0"
+  - note: "xformers CUDA 12.8 build required for the diffusion attention kernels"
+    command: "uv pip install -U xformers --index-url https://download.pytorch.org/whl/cu128"
+  - note: "diffusers from source (needed by the image-edit pipeline)"
+    command: "git clone https://github.com/huggingface/diffusers.git && cd diffusers && uv pip install -e ."
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 36
+    description: "BF16 weights; served via vLLM-Omni (offline inference)"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  LongCat-Image-Edit is the image-editing variant of LongCat-Image by Meituan. It supports
+  bilingual (Chinese-English) editing instructions and is served via **vLLM-Omni** (not
+  standard vLLM). It achieves SOTA performance among open-source image editing models.
+
+  ## Prerequisites
+
+  - Hardware: 1x GPU with >=40 GB VRAM
+  - vLLM-Omni (runs on top of vLLM 0.12.0)
+  - diffusers (latest from source)
+  - xformers (latest)
+
+  ## Installation
+
+  ```bash
+  # Clone and install vllm-omni
+  git clone https://github.com/vllm-project/vllm-omni.git
+  cd vllm-omni
+  uv venv
+  source .venv/bin/activate
+  uv pip install -e . vllm==0.12.0
+
+  # Update xformers to the latest version
+  uv pip install -U xformers --index-url https://download.pytorch.org/whl/cu128
+
+  # Update diffusers to the latest version
+  git clone https://github.com/huggingface/diffusers.git
+  cd diffusers
+  uv pip install -e .
+  ```
+
+  ## Usage
+
+  ```bash
+  cd vllm-omni
+  python3 ./examples/offline_inference/image_to_image/image_edit.py \
+      --image qwen_bear.png \
+      --prompt "Add a white art board written with colorful text 'vLLM-Omni' on grassland. Add a paintbrush in the bear's hands. Position the bear standing in front of the art board as if painting." \
+      --output output_image_edit.png \
+      --num_inference_steps 50 \
+      --guidance_scale 4.5 \
+      --seed 42 \
+      --model meituan-longcat/LongCat-Image-Edit \
+      --cache_backend cache_dit \
+      --cache_dit_max_continuous_cached_steps 2
+  ```
+
+  ## References
+
+  - [LongCat-Image-Edit on Hugging Face](https://huggingface.co/meituan-longcat/LongCat-Image-Edit)
+  - [vLLM-Omni](https://github.com/vllm-project/vllm-omni)

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   related_recipes:
     - meta-llama/Llama-3.3-70B-Instruct
+  hardware:
+    h100: verified
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "meta-llama/Llama-3.1-8B-Instruct"

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -1,0 +1,109 @@
+meta:
+  title: "Llama-3.1-8B-Instruct"
+  slug: "llama-3.1-8b-instruct"
+  provider: "Meta"
+  description: "Meta's Llama 3.1 8B dense instruction-tuned language model with 128K context"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - text
+  related_recipes:
+    - meta-llama/Llama-3.3-70B-Instruct
+
+model:
+  model_id: "meta-llama/Llama-3.1-8B-Instruct"
+  min_vllm_version: "0.6.0"
+  architecture: dense
+  parameter_count: "8B"
+  active_parameters: "8B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 20
+    description: "Full precision BF16"
+  nvfp4:
+    model_id: "nvidia/Llama-3.1-8B-Instruct-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 5
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+  nvidia_fp8:
+    model_id: "nvidia/Llama-3.1-8B-Instruct-FP8"
+    precision: fp8
+    vram_minimum_gb: 10
+    description: "FP8 quantized weights for Hopper/Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  amd:
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Llama 3.1 Instruct is Meta's instruction-tuned language model family. The 8B dense
+  variant is lightweight and ideal for single-GPU deployment, with 128K context support.
+  A 70B variant is also available (see related recipes).
+
+  ## Prerequisites
+
+  - Hardware: 1x GPU with >=16 GB VRAM (e.g. A100, L40S, H100, H200)
+  - vLLM >= 0.6.0
+  - CUDA Driver compatible with your vLLM version
+  - Docker with NVIDIA Container Toolkit (recommended)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --torch-backend auto
+  ```
+
+  ### TPU Deployment
+
+  - [Llama3.x-70B on Trillium (v6e)](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Llama3.x)
+  - [Llama3.1-8B on Trillium (v6e)](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Llama3.x)
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
+  response = client.chat.completions.create(
+      model="meta-llama/Llama-3.1-8B-Instruct",
+      messages=[{"role": "user", "content": "Hello, how are you?"}],
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Troubleshooting
+
+  **OOM on small GPUs:**
+  Lower `--max-model-len` or `--gpu-memory-utilization`.
+
+  ## References
+
+  - [Model card](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)
+  - [Llama 3.1 70B model card](https://huggingface.co/meta-llama/Llama-3.1-70B-Instruct)

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -12,13 +12,6 @@ meta:
   hardware:
     h100: verified
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "meta-llama/Llama-3.1-8B-Instruct"

--- a/models/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -10,6 +10,16 @@ meta:
   performance_headline: ""
   related_recipes:
     - meta-llama/Llama-4-Scout-17B-16E-Instruct
+  hardware:
+    h100: verified
+    h200: verified
+    b200: verified
+    gb200: verified
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "meta-llama/Llama-3.3-70B-Instruct"

--- a/models/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -15,11 +15,6 @@ meta:
     h200: verified
     b200: verified
     gb200: verified
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "meta-llama/Llama-3.3-70B-Instruct"

--- a/models/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -1,0 +1,122 @@
+meta:
+  title: "Llama-3.3-70B"
+  slug: "llama3.3-70b"
+  provider: "Meta"
+  description: "Llama 3.3 70B dense model with NVIDIA FP8/FP4 quantized variants for Hopper and Blackwell GPUs"
+  date_updated: 2026-04-16
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: ""
+  related_recipes:
+    - meta-llama/Llama-4-Scout-17B-16E-Instruct
+
+model:
+  model_id: "meta-llama/Llama-3.3-70B-Instruct"
+  min_vllm_version: "0.12.0"
+  architecture: dense
+  parameter_count: "70B"
+  active_parameters: "70B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 170
+    description: "Full precision BF16"
+
+  fp8:
+    model_id: "nvidia/Llama-3.3-70B-Instruct-FP8"
+    precision: fp8
+    vram_minimum_gb: 84
+    description: "NVIDIA FP8 quantization for Hopper and Blackwell"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env: {}
+
+  nvfp4:
+    model_id: "nvidia/Llama-3.3-70B-Instruct-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 42
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args:
+      - "--async-scheduling"
+      - "--no-enable-prefix-caching"
+      - "--max-num-batched-tokens"
+      - "8192"
+    extra_env: {}
+  blackwell:
+    extra_args:
+      - "--async-scheduling"
+      - "--no-enable-prefix-caching"
+      - "--max-num-batched-tokens"
+      - "8192"
+      - "--compilation-config"
+      - '{"pass_config":{"fuse_allreduce_rms":true,"fuse_attn_quant":true,"eliminate_noops":true}}'
+    extra_env: {}
+  amd:
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Llama 3.3 70B Instruct is Meta's 70-billion parameter dense language model.
+  NVIDIA provides FP8 and FP4 quantized variants optimized for Hopper (H100/H200)
+  and Blackwell (B200/GB200) GPUs. FP4 is Blackwell-only and provides the best
+  VRAM efficiency.
+
+  ## Prerequisites
+
+  - Hardware: 1x H100/H200 (FP8), 1x B200 (FP4), or 2x GPUs for BF16
+  - vLLM >= 0.12.0
+  - CUDA Driver >= 575
+  - Docker with NVIDIA Container Toolkit (recommended)
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
+  response = client.chat.completions.create(
+      model="nvidia/Llama-3.3-70B-Instruct-FP8",
+      messages=[{"role": "user", "content": "Hello, how are you?"}],
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Troubleshooting
+
+  **FP4 variant not loading:**
+  FP4 is only supported on Blackwell (compute capability 10.0). Use FP8 on Hopper.
+
+  **OOM with BF16 on single GPU:**
+  Use the FP8 variant (~70 GB) or FP4 variant (~40 GB) to fit on a single GPU.
+
+  ## References
+
+  - [Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct)
+  - [NVIDIA FP8 variant](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP8)
+  - [NVIDIA FP4 variant](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP4)

--- a/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -12,14 +12,8 @@ meta:
     - meta-llama/Llama-3.3-70B-Instruct
   hardware:
     h100: verified
-    h200: supported
     b200: verified
     gb200: verified
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "meta-llama/Llama-4-Scout-17B-16E-Instruct"

--- a/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -1,0 +1,137 @@
+meta:
+  title: "Llama-4-Scout"
+  slug: "llama-4-scout"
+  provider: "Meta"
+  description: "Llama 4 Scout 17B-16E MoE model with NVIDIA FP8/FP4 variants, fits on a single GPU with quantization"
+  date_updated: 2026-04-16
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: ""
+  related_recipes:
+    - meta-llama/Llama-3.3-70B-Instruct
+
+model:
+  model_id: "meta-llama/Llama-4-Scout-17B-16E-Instruct"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "109B"
+  active_parameters: "17B"
+  context_length: 10485760
+  base_args: []
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 262
+    description: "Full precision BF16"
+
+  fp8:
+    model_id: "nvidia/Llama-4-Scout-17B-16E-Instruct-FP8"
+    precision: fp8
+    vram_minimum_gb: 131
+    description: "NVIDIA FP8 quantization for Hopper and Blackwell, fits on 1x H100"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env: {}
+
+  nvfp4:
+    model_id: "nvidia/Llama-4-Scout-17B-16E-Instruct-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 65
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args:
+      - "--async-scheduling"
+      - "--no-enable-prefix-caching"
+      - "--max-num-batched-tokens"
+      - "8192"
+    extra_env: {}
+  blackwell:
+    extra_args:
+      - "--async-scheduling"
+      - "--no-enable-prefix-caching"
+      - "--max-num-batched-tokens"
+      - "8192"
+      - "--compilation-config"
+      - '{"pass_config":{"fuse_allreduce_rms":true,"eliminate_noops":true}}'
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP8: "1"
+  amd:
+    # 8 GPUs required for 17B×16E MoE. AITER JIT-compiles on first launch.
+    extra_args:
+      - "--no-enable-prefix-caching"
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--max-num-seqs"
+      - "64"
+      - "--max-model-len"
+      - "32000"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Llama 4 Scout is Meta's MoE model with 17B active parameters across 16 experts
+  (109B total). NVIDIA provides FP8 and FP4 quantized variants. With FP4 quantization,
+  the model fits on a single B200 GPU — making it one of the most accessible MoE models.
+
+  ## Prerequisites
+
+  - Hardware: 1x B200 (FP4), 1x H100 (FP8), or 4x GPUs (BF16)
+  - vLLM >= 0.12.0
+  - CUDA Driver >= 575
+  - Docker with NVIDIA Container Toolkit (recommended)
+  - License: Must agree to Meta's Llama 4 Scout Community License
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
+  response = client.chat.completions.create(
+      model="nvidia/Llama-4-Scout-17B-16E-Instruct-FP8",
+      messages=[{"role": "user", "content": "Explain MoE models briefly."}],
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Troubleshooting
+
+  **FP4 only works on Blackwell:**
+  FP4 quantization requires compute capability 10.0 (B200/GB200). Use FP8 on Hopper.
+
+  **TP=1 recommended for best throughput:**
+  For maximum throughput per GPU, keep TP=1. Increase TP to 2/4/8 for lower latency.
+
+  ## References
+
+  - [Llama-4-Scout-17B-16E-Instruct](https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct)
+  - [NVIDIA FP8 variant](https://huggingface.co/nvidia/Llama-4-Scout-17B-16E-Instruct-FP8)
+  - [NVIDIA FP4 variant](https://huggingface.co/nvidia/Llama-4-Scout-17B-16E-Instruct-FP4)

--- a/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -10,6 +10,16 @@ meta:
   performance_headline: ""
   related_recipes:
     - meta-llama/Llama-3.3-70B-Instruct
+  hardware:
+    h100: verified
+    h200: supported
+    b200: verified
+    gb200: verified
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "meta-llama/Llama-4-Scout-17B-16E-Instruct"

--- a/models/microsoft/Phi-4-mini-instruct.yaml
+++ b/models/microsoft/Phi-4-mini-instruct.yaml
@@ -9,6 +9,13 @@ meta:
     - text
     - multimodal
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: supported
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
 
 model:
   model_id: "microsoft/Phi-4-mini-instruct"

--- a/models/microsoft/Phi-4-mini-instruct.yaml
+++ b/models/microsoft/Phi-4-mini-instruct.yaml
@@ -1,0 +1,156 @@
+meta:
+  title: "Phi-4"
+  slug: "phi-4"
+  provider: "Microsoft"
+  description: "Microsoft's Phi-4 family of lightweight dense models (mini-instruct, reasoning, multimodal) with 128K context"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - text
+    - multimodal
+  related_recipes: []
+
+model:
+  model_id: "microsoft/Phi-4-mini-instruct"
+  min_vllm_version: "0.7.0"
+  architecture: dense
+  parameter_count: "4B"
+  active_parameters: "4B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 10
+    description: "Phi-4-mini-instruct, conversational instruction-tuned"
+
+  mini_reasoning:
+    model_id: "microsoft/Phi-4-mini-reasoning"
+    precision: bf16
+    vram_minimum_gb: 10
+    description: "Optimized for reasoning tasks"
+
+  reasoning:
+    model_id: "microsoft/Phi-4-reasoning"
+    precision: bf16
+    vram_minimum_gb: 30
+    description: "Advanced reasoning capabilities (14B)"
+
+  multimodal:
+    model_id: "microsoft/Phi-4-multimodal-instruct"
+    precision: bf16
+    vram_minimum_gb: 16
+    description: "Multimodal instruction-following (text + image)"
+    extra_args:
+      - "--trust-remote-code"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  The Phi-4 family includes several lightweight, open models from Microsoft. These models
+  can process text and, in some variants, multimodal inputs like images, to generate
+  text outputs. They come with a 128K token context length.
+
+  ## Prerequisites
+
+  - Hardware: 1x GPU with >=16 GB VRAM (A100, L40S, H100, etc.)
+  - vLLM >= 0.7.0
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launch commands
+
+  Phi-4-mini-instruct on a single GPU:
+
+  ```bash
+  vllm serve microsoft/Phi-4-mini-instruct \
+    --host 0.0.0.0 \
+    --max-model-len 4000
+  ```
+
+  Phi-4-multimodal-instruct (requires --trust-remote-code for LoRA modules):
+
+  ```bash
+  vllm serve microsoft/Phi-4-multimodal-instruct \
+    --host 0.0.0.0 \
+    --max-model-len 4000 \
+    --trust-remote-code
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  response = client.chat.completions.create(
+      model="microsoft/Phi-4-mini-instruct",
+      messages=[{"role": "user", "content": "Write a short story"}],
+      temperature=0.0,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  Multimodal (requires Phi-4-multimodal-instruct):
+
+  ```python
+  response = client.chat.completions.create(
+      model="microsoft/Phi-4-multimodal-instruct",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "text", "text": "Describe this image."},
+              {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+          ],
+      }],
+  )
+  ```
+
+  ## Available Phi-4 Variants
+
+  - `microsoft/Phi-4-mini-instruct` — conversational instruction-tuned
+  - `microsoft/Phi-4-mini-reasoning` — optimized for reasoning
+  - `microsoft/Phi-4-reasoning` — advanced reasoning
+  - `microsoft/Phi-4-multimodal-instruct` — multimodal (text + image)
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model microsoft/Phi-4-mini-instruct \
+    --dataset-name random \
+    --random-input-len 2000 \
+    --random-output-len 512 \
+    --num-prompts 100
+  ```
+
+  ## Troubleshooting
+
+  - Multimodal variant fails to load: add `--trust-remote-code`.
+
+  ## References
+
+  - [Phi-4-mini-instruct](https://huggingface.co/microsoft/Phi-4-mini-instruct)
+  - [Phi-4-multimodal-instruct](https://huggingface.co/microsoft/Phi-4-multimodal-instruct)
+  - [Phi-4-reasoning](https://huggingface.co/microsoft/Phi-4-reasoning)

--- a/models/microsoft/Phi-4-mini-instruct.yaml
+++ b/models/microsoft/Phi-4-mini-instruct.yaml
@@ -11,11 +11,6 @@ meta:
   related_recipes: []
   hardware:
     h100: verified
-    h200: supported
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
 
 model:
   model_id: "microsoft/Phi-4-mini-instruct"

--- a/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
+++ b/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
@@ -11,15 +11,7 @@ meta:
     - mistralai/Ministral-3-8B-Reasoning-2512
     - mistralai/Mistral-Large-3-675B-Instruct-2512
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "mistralai/Ministral-3-14B-Instruct-2512"

--- a/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
+++ b/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
@@ -10,6 +10,16 @@ meta:
   related_recipes:
     - mistralai/Ministral-3-8B-Reasoning-2512
     - mistralai/Mistral-Large-3-675B-Instruct-2512
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "mistralai/Ministral-3-14B-Instruct-2512"

--- a/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
+++ b/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
@@ -1,0 +1,169 @@
+meta:
+  title: "Ministral-3-Instruct"
+  slug: "ministral-3-instruct"
+  provider: "Mistral AI"
+  description: "Ministral 3 Instruct family (3B/8B/14B) with FP8 weights, vision support, and 256K context"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - multimodal
+  related_recipes:
+    - mistralai/Ministral-3-8B-Reasoning-2512
+    - mistralai/Mistral-Large-3-675B-Instruct-2512
+
+model:
+  model_id: "mistralai/Ministral-3-14B-Instruct-2512"
+  min_vllm_version: "0.11.0"
+  architecture: dense
+  parameter_count: "14B"
+  active_parameters: "14B"
+  context_length: 262144
+  base_args:
+    - "--tokenizer_mode"
+    - "mistral"
+    - "--config_format"
+    - "mistral"
+    - "--load_format"
+    - "mistral"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Mistral tool-call parser with automatic tool choice"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "mistral"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 17
+    description: "Native FP8 weights (14B), fits on 1x H200"
+
+  "8b":
+    model_id: "mistralai/Ministral-3-8B-Instruct-2512"
+    precision: fp8
+    vram_minimum_gb: 12
+    description: "Smaller 8B variant with independent embedding/output layers"
+
+  "3b":
+    model_id: "mistralai/Ministral-3-3B-Instruct-2512"
+    precision: fp8
+    vram_minimum_gb: 6
+    description: "Smallest 3B variant with tied embeddings"
+  fp8:
+    model_id: "mistralai/Ministral-3-14B-Instruct-2512-FP8"
+    precision: fp8
+    vram_minimum_gb: 17
+    description: "FP8 quantized weights for Hopper/Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  amd:
+    extra_args:
+      - "--config_format"
+      - "mistral"
+      - "--load_format"
+      - "mistral"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Ministral-3 Instruct comes with FP8 weights in 3 different sizes:
+
+  - 3B: tied embeddings (shares embedding and output layers)
+  - 8B and 14B: independent embedding and output layers
+
+  Each variant has vision support and a 256K context length. Smaller models offer faster
+  inference at the cost of lower quality; pick the best trade-off for your use case.
+
+  ## Prerequisites
+
+  - Hardware: 1x H200 (sufficient for all three sizes thanks to FP8 weights)
+  - vLLM >= 0.11.0
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launch command
+
+  ```bash
+  vllm serve mistralai/Ministral-3-14B-Instruct-2512 \
+    --tokenizer_mode mistral --config_format mistral --load_format mistral \
+    --enable-auto-tool-choice --tool-call-parser mistral
+  ```
+
+  For 8B: `mistralai/Ministral-3-8B-Instruct-2512`
+  For 3B: `mistralai/Ministral-3-3B-Instruct-2512`
+
+  - `enable-auto-tool-choice`: required for tool usage
+  - `tool-call-parser mistral`: required for tool usage
+  - `--max-model-len` defaults to `262144`; reduce to save memory
+  - `--max-num-batched-tokens` balances throughput and latency
+
+  ## Client Usage
+
+  Vision reasoning example:
+
+  ```python
+  from datetime import datetime, timedelta
+  from openai import OpenAI
+  from huggingface_hub import hf_hub_download
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  model = client.models.list().data[0].id
+
+  def load_system_prompt(repo_id, filename):
+      path = hf_hub_download(repo_id=repo_id, filename=filename)
+      with open(path) as f:
+          prompt = f.read()
+      today = datetime.today().strftime("%Y-%m-%d")
+      yesterday = (datetime.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+      return prompt.format(name=repo_id.split("/")[-1], today=today, yesterday=yesterday)
+
+  SYSTEM_PROMPT = load_system_prompt(model, "SYSTEM_PROMPT.txt")
+  image_url = "https://static.wikia.nocookie.net/essentialsdocs/images/7/70/Battle.png/revision/latest?cb=20220523172438"
+
+  response = client.chat.completions.create(
+      model=model,
+      messages=[
+          {"role": "system", "content": SYSTEM_PROMPT},
+          {"role": "user", "content": [
+              {"type": "text", "text": "What action should I take here?"},
+              {"type": "image_url", "image_url": {"url": image_url}},
+          ]},
+      ],
+      temperature=0.15, max_tokens=262144,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  Function calling and text-only examples follow a similar OpenAI-compatible pattern.
+
+  ## Troubleshooting
+
+  - OOM: lower `--max-model-len` (e.g. 32768) or use the 3B/8B variant.
+
+  ## References
+
+  - [Ministral-3-14B-Instruct](https://huggingface.co/mistralai/Ministral-3-14B-Instruct-2512)
+  - [Ministral-3-8B-Instruct](https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512)
+  - [Ministral-3-3B-Instruct](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512)

--- a/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
+++ b/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
@@ -10,6 +10,16 @@ meta:
   related_recipes:
     - mistralai/Ministral-3-14B-Instruct-2512
     - mistralai/Mistral-Large-3-675B-Instruct-2512
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: verified
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "mistralai/Ministral-3-8B-Reasoning-2512"

--- a/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
+++ b/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
@@ -1,0 +1,160 @@
+meta:
+  title: "Ministral-3-Reasoning"
+  slug: "ministral-3-reasoning"
+  provider: "Mistral AI"
+  description: "Ministral 3 Reasoning family (3B/8B/14B) with BF16 weights, vision support, and 256K context"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  related_recipes:
+    - mistralai/Ministral-3-14B-Instruct-2512
+    - mistralai/Mistral-Large-3-675B-Instruct-2512
+
+model:
+  model_id: "mistralai/Ministral-3-8B-Reasoning-2512"
+  min_vllm_version: "0.11.0"
+  architecture: dense
+  parameter_count: "8B"
+  active_parameters: "8B"
+  context_length: 262144
+  base_args:
+    - "--tokenizer_mode"
+    - "mistral"
+    - "--config_format"
+    - "mistral"
+    - "--load_format"
+    - "mistral"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Mistral tool-call parser with automatic tool choice"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "mistral"
+  reasoning:
+    description: "Mistral reasoning parser extracts <think>...</think> into message.reasoning"
+    args:
+      - "--reasoning-parser"
+      - "mistral"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 22
+    description: "Native BF16 weights (8B)"
+
+  "3b":
+    model_id: "mistralai/Ministral-3-3B-Reasoning-2512"
+    precision: bf16
+    vram_minimum_gb: 8
+    description: "Smallest 3B variant with tied embeddings"
+
+  "14b":
+    model_id: "mistralai/Ministral-3-14B-Reasoning-2512"
+    precision: bf16
+    vram_minimum_gb: 32
+    description: "Largest 14B variant; 2xH200 recommended for full context"
+    extra_args:
+      - "--tensor-parallel-size"
+      - "2"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  amd:
+    extra_args:
+      - "--no-enable-prefix-caching"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      SAFETENSORS_FAST_GPU: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Ministral-3 Reasoning comes with BF16 weights in 3 sizes:
+
+  - 3B (tied embeddings)
+  - 8B, 14B (independent embeddings/outputs)
+
+  Each variant has vision support and 256K max context. On GB200, we observe significant
+  speed-ups with NVFP4 Marlin fallback for older GPUs.
+
+  ## Prerequisites
+
+  - Hardware: 1x H200 (3B/8B), 2x H200 recommended for 14B with full context
+  - vLLM >= 0.11.0
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launch command
+
+  3B or 8B on 1x H200:
+
+  ```bash
+  vllm serve mistralai/Ministral-3-8B-Reasoning-2512 \
+    --tokenizer_mode mistral --config_format mistral --load_format mistral \
+    --enable-auto-tool-choice --tool-call-parser mistral \
+    --reasoning-parser mistral
+  ```
+
+  14B on 2x H200:
+
+  ```bash
+  vllm serve mistralai/Ministral-3-14B-Reasoning-2512 \
+    --tensor-parallel-size 2 \
+    --tokenizer_mode mistral --config_format mistral --load_format mistral \
+    --enable-auto-tool-choice --tool-call-parser mistral \
+    --reasoning-parser mistral
+  ```
+
+  Key flags:
+  - `enable-auto-tool-choice`: required for tool usage
+  - `tool-call-parser mistral`: required for tool usage
+  - `reasoning-parser mistral`: required to extract reasoning content
+
+  ## Client Usage
+
+  Streaming reasoning + answer:
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  stream = client.chat.completions.create(
+      model="mistralai/Ministral-3-8B-Reasoning-2512",
+      messages=[{"role": "user", "content": "Solve: use 2,5,6,3 to make 24."}],
+      stream=True, temperature=0.7, top_p=0.95, max_tokens=262144,
+  )
+  for chunk in stream:
+      delta = chunk.choices[0].delta
+      rc = getattr(delta, "reasoning_content", None)
+      if rc:
+          print(rc, end="", flush=True)
+      if delta.content:
+          print(delta.content, end="", flush=True)
+  ```
+
+  ## Troubleshooting
+
+  - OOM on 14B: use `--tensor-parallel-size 2` or lower `--max-model-len`.
+
+  ## References
+
+  - [Ministral-3-8B-Reasoning](https://huggingface.co/mistralai/Ministral-3-8B-Reasoning-2512)
+  - [Ministral-3-3B-Reasoning](https://huggingface.co/mistralai/Ministral-3-3B-Reasoning-2512)
+  - [Ministral-3-14B-Reasoning](https://huggingface.co/mistralai/Ministral-3-14B-Reasoning-2512)

--- a/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
+++ b/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
@@ -11,15 +11,8 @@ meta:
     - mistralai/Ministral-3-14B-Instruct-2512
     - mistralai/Mistral-Large-3-675B-Instruct-2512
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
     gb200: verified
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "mistralai/Ministral-3-8B-Reasoning-2512"

--- a/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
+++ b/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
@@ -9,6 +9,16 @@ meta:
     - multimodal
   related_recipes:
     - mistralai/Ministral-3-14B-Instruct-2512
+  hardware:
+    h100: verified
+    h200: supported
+    b200: verified
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "mistralai/Mistral-Large-3-675B-Instruct-2512"

--- a/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
+++ b/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
@@ -1,0 +1,156 @@
+meta:
+  title: "Mistral-Large-3-675B-Instruct"
+  slug: "mistral-large-3-675b-instruct"
+  provider: "Mistral AI"
+  description: "Mistral Large 3 (675B) with FP8 and NVFP4 weights for 8xH200 / 4xB200 deployments"
+  date_updated: 2026-04-17
+  difficulty: advanced
+  tasks:
+    - multimodal
+  related_recipes:
+    - mistralai/Ministral-3-14B-Instruct-2512
+
+model:
+  model_id: "mistralai/Mistral-Large-3-675B-Instruct-2512"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "675B"
+  active_parameters: "22B"
+  context_length: 294912
+  base_args:
+    - "--tokenizer_mode"
+    - "mistral"
+    - "--config_format"
+    - "mistral"
+    - "--load_format"
+    - "mistral"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Mistral tool-call parser with automatic tool choice"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "mistral"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 810
+    description: "FP8 weights on 8xH200 (recommended for fine-tuning; up to 256K context)"
+    extra_args:
+      - "--tensor-parallel-size"
+      - "8"
+
+  nvfp4:
+    model_id: "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 405
+    description: "NVFP4 weights on 4xB200 (use for <64K context; B200-native, Marlin fallback on A100/H100)"
+    extra_args:
+      - "--tensor-parallel-size"
+      - "4"
+  fp8:
+    model_id: "mistralai/Mistral-Large-3-675B-Instruct-2512-FP8"
+    precision: fp8
+    vram_minimum_gb: 810
+    description: "FP8 quantized weights for Hopper/Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  amd:
+    extra_args:
+      - "--no-enable-prefix-caching"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      SAFETENSORS_FAST_GPU: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Mistral-Large-3-675B-Instruct-2512 is available in FP8 and NVFP4 formats:
+
+  - **FP8** (`mistralai/Mistral-Large-3-675B-Instruct-2512`): up to 256K context, 8xH200
+  - **NVFP4** (`mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4`): best for <64K context, 4xB200
+
+  NVFP4 gives significant speed-up on B200 (native FP4 support). On older GPUs (A100/H100),
+  vLLM falls back to Marlin FP4, which matches FP8 speed while saving memory.
+
+  For large contexts (>64K) we observed a performance regression on NVFP4 — use FP8 in
+  those cases. A minor regression on vision datasets is expected with NVFP4 (calibration
+  was mainly on text).
+
+  ## Prerequisites
+
+  - Hardware: 8xH200 for FP8, 4xB200 for NVFP4
+  - vLLM >= 0.11.0
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launch commands
+
+  FP8 on 8xH200:
+
+  ```bash
+  vllm serve mistralai/Mistral-Large-3-675B-Instruct-2512 \
+    --tensor-parallel-size 8 \
+    --tokenizer_mode mistral --config_format mistral --load_format mistral \
+    --enable-auto-tool-choice --tool-call-parser mistral
+  ```
+
+  NVFP4 on 4xB200:
+
+  ```bash
+  vllm serve mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4 \
+    --tensor-parallel-size 4 \
+    --tokenizer_mode mistral --config_format mistral --load_format mistral \
+    --enable-auto-tool-choice --tool-call-parser mistral
+  ```
+
+  Additional flags:
+  - `--max-model-len`: default 262144; reduce to save memory
+  - `--max-num-batched-tokens`: balance throughput vs. latency
+  - `--limit-mm-per-prompt.image 0`: skip vision encoder for text-only tasks
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  response = client.chat.completions.create(
+      model="mistralai/Mistral-Large-3-675B-Instruct-2512",
+      messages=[{"role": "user", "content": "Write a sentence..."}],
+      temperature=0.15, max_tokens=262144,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Troubleshooting
+
+  - Accuracy regression with NVFP4 at long context: switch to FP8 variant.
+  - OOM: reduce `--max-model-len` or adjust TP size.
+
+  ## References
+
+  - [Mistral-Large-3 FP8](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512)
+  - [Mistral-Large-3 NVFP4](https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4)

--- a/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
+++ b/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
@@ -11,14 +11,7 @@ meta:
     - mistralai/Ministral-3-14B-Instruct-2512
   hardware:
     h100: verified
-    h200: supported
     b200: verified
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "mistralai/Mistral-Large-3-675B-Instruct-2512"

--- a/models/moonshotai/Kimi-K2-Instruct.yaml
+++ b/models/moonshotai/Kimi-K2-Instruct.yaml
@@ -11,6 +11,13 @@ meta:
   related_recipes:
     - "moonshotai/Kimi-K2-Thinking"
     - "moonshotai/Kimi-K2.5"
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
 
 model:
   model_id: "moonshotai/Kimi-K2-Instruct"
@@ -57,13 +64,7 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides:
   # Kimi-K2 16xH800 reference command from the original recipe: TP8 inside each

--- a/models/moonshotai/Kimi-K2-Instruct.yaml
+++ b/models/moonshotai/Kimi-K2-Instruct.yaml
@@ -1,0 +1,223 @@
+meta:
+  title: "Kimi-K2-Instruct"
+  slug: "kimi-k2-instruct"
+  provider: "Moonshot AI"
+  description: "Moonshot AI's Kimi-K2 is a trillion-parameter MoE instruction model (~32B active) with native FP8 weights and strong tool-calling capabilities."
+  date_updated: 2026-04-17
+  difficulty: advanced
+  tasks:
+    - text
+  performance_headline: "Open-weights 1T-parameter MoE with native FP8 and Kimi K2 tool calling"
+  related_recipes:
+    - "moonshotai/Kimi-K2-Thinking"
+    - "moonshotai/Kimi-K2.5"
+
+model:
+  model_id: "moonshotai/Kimi-K2-Instruct"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "1T"
+  active_parameters: "32B"
+  context_length: 131072
+  supports_dcp: true
+  base_args:
+    - "--trust-remote-code"
+    - "--tokenizer-mode"
+    - "auto"
+  base_env: {}
+
+dependencies:
+  - note: "Optional: DeepEP + DeepGEMM for the DP+EP deployment path on H800/H200"
+    command: "uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation"
+    optional: true
+
+features:
+  tool_calling:
+    description: "Enable Kimi K2 tool calling with the kimi_k2 tool-call parser."
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "kimi_k2"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 1200
+    description: "Native FP8 weights on 16xH800 / 16xH200 (smallest deployment for 128k seqlen)"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides:
+  # Kimi-K2 16xH800 reference command from the original recipe: TP8 inside each
+  # node, PP2 across nodes, plus DCP=8 for decode-context parallel and the
+  # full FP8 / chunked-prefill tuning.
+  multi_node_tp_pp:
+    vllm_args:
+      - "--dtype"
+      - "bfloat16"
+      - "--quantization"
+      - "fp8"
+      - "--kv-cache-dtype"
+      - "fp8"
+      - "--decode-context-parallel-size"
+      - "8"
+      - "--enable-chunked-prefill"
+      - "--max-model-len"
+      - "65536"
+      - "--max-num-batched-tokens"
+      - "1024"
+      - "--max-num-seqs"
+      - "1"
+      - "--disable-log-requests"
+
+guide: |
+  ## Overview
+
+  Kimi-K2-Instruct is Moonshot AI's trillion-parameter Mixture-of-Experts instruction
+  model (approximately 32B activated per token) shipped with native FP8 weights. The
+  smallest deployment unit for Kimi-K2 FP8 weights with 128k seqlen on mainstream H800
+  platforms is a 16-GPU cluster using either Tensor Parallel (TP) or Data Parallel +
+  Expert Parallel (DP+EP). This guide is partially adapted from the official
+  [Kimi-K2-Instruct Deployment Guidance](https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/deploy_guidance.md).
+
+  ## Prerequisites
+
+  - **Hardware (FP8)**: 16x H800 or 16x H200 GPUs (verified)
+  - **vLLM**: Current stable release
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Running Kimi-K2 with FP8 on 16xH800
+
+  ### Tensor Parallelism + Pipeline Parallelism (TP8+PP2)
+
+  ```bash
+  # node 0 (start Ray on both nodes first)
+  vllm serve moonshotai/Kimi-K2-Instruct \
+    --trust-remote-code \
+    --tokenizer-mode auto \
+    --tensor-parallel-size 8 \
+    --pipeline-parallel-size 2 \
+    --dtype bfloat16 \
+    --quantization fp8 \
+    --max-model-len 2048 \
+    --max-num-seqs 1 \
+    --max-num-batched-tokens 1024 \
+    --enable-chunked-prefill \
+    --disable-log-requests \
+    --kv-cache-dtype fp8 \
+    -dcp 8
+  ```
+
+  Key parameter notes:
+  - `--enable-auto-tool-choice`: required when enabling tool usage.
+  - `--tool-call-parser kimi_k2`: required when enabling tool usage.
+
+  ### Data Parallelism + Expert Parallelism (DP16+EP)
+
+  You can install libraries like DeepEP and DeepGEMM as needed. Then run the command
+  (example on H800):
+
+  ```bash
+  # node 0
+  vllm serve moonshotai/Kimi-K2-Instruct \
+    --port 8000 --served-model-name kimi-k2 \
+    --trust-remote-code \
+    --data-parallel-size 16 \
+    --data-parallel-size-local 8 \
+    --data-parallel-address $MASTER_IP \
+    --data-parallel-rpc-port $PORT \
+    --enable-expert-parallel \
+    --max-num-batched-tokens 8192 \
+    --max-num-seqs 256 \
+    --gpu-memory-utilization 0.85 \
+    --enable-auto-tool-choice \
+    --tool-call-parser kimi_k2
+
+  # node 1
+  vllm serve moonshotai/Kimi-K2-Instruct \
+    --headless \
+    --data-parallel-start-rank 8 \
+    --port 8000 --served-model-name kimi-k2 \
+    --trust-remote-code \
+    --data-parallel-size 16 \
+    --data-parallel-size-local 8 \
+    --data-parallel-address $MASTER_IP \
+    --data-parallel-rpc-port $PORT \
+    --enable-expert-parallel \
+    --max-num-batched-tokens 8192 \
+    --max-num-seqs 256 \
+    --gpu-memory-utilization 0.85 \
+    --enable-auto-tool-choice \
+    --tool-call-parser kimi_k2
+  ```
+
+  Additional flags:
+  - `--max-model-len` preserves memory; `--max-model-len=65536` is usually good for most scenarios.
+  - `--max-num-batched-tokens` balances throughput vs latency. `32768` is good for prompt-heavy
+    workloads; reduce to 16k or 8k to cut activation memory and decrease latency.
+  - vLLM conservatively uses 90% of GPU memory. Set `--gpu-memory-utilization=0.95` to
+    maximize KV cache.
+
+  ## Benchmarking
+
+  ### FP8 Benchmark on 16xH800
+
+  ```bash
+  vllm bench serve \
+    --model moonshotai/Kimi-K2-Instruct \
+    --dataset-name random \
+    --random-input-len 1000 \
+    --random-output-len 512 \
+    --request-rate 1.0 \
+    --num-prompts 8 \
+    --ignore-eos \
+    --trust-remote-code
+  ```
+
+  ### FP8 Benchmark on 16xH200
+
+  ```bash
+  vllm bench serve \
+    --model moonshotai/Kimi-K2-Instruct \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos \
+    --trust-remote-code
+  ```
+
+  Adding `-dcp 8` at launch can further improve throughput on H200 (observed ~33% lower
+  mean TTFT and higher tok/s in internal benchmarks).
+
+  Test different batch sizes by changing `--num-prompts`, e.g. 1, 16, 32, 64, 128, 256, 512.
+
+  ## References
+
+  - [Kimi-K2-Instruct on Hugging Face](https://huggingface.co/moonshotai/Kimi-K2-Instruct)
+  - [Official Kimi-K2 Deployment Guidance](https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/deploy_guidance.md)
+  - [vLLM Expert Parallelism docs](https://docs.vllm.ai/en/latest/serving/expert_parallel_deployment.html)

--- a/models/moonshotai/Kimi-K2-Instruct.yaml
+++ b/models/moonshotai/Kimi-K2-Instruct.yaml
@@ -12,12 +12,7 @@ meta:
     - "moonshotai/Kimi-K2-Thinking"
     - "moonshotai/Kimi-K2.5"
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
 
 model:
   model_id: "moonshotai/Kimi-K2-Instruct"

--- a/models/moonshotai/Kimi-K2-Thinking.yaml
+++ b/models/moonshotai/Kimi-K2-Thinking.yaml
@@ -1,0 +1,178 @@
+meta:
+  title: "Kimi-K2-Thinking"
+  slug: "kimi-k2-thinking"
+  provider: "Moonshot AI"
+  description: "Kimi-K2-Thinking is an advanced reasoning MoE model with native INT4 QAT weights, designed for long-horizon agent workflows interleaving chain-of-thought reasoning with tool calls."
+  date_updated: 2026-04-17
+  difficulty: advanced
+  tasks:
+    - text
+  performance_headline: "1T MoE thinking model with native INT4 QAT for 2x low-latency speed-up"
+  related_recipes:
+    - "moonshotai/Kimi-K2-Instruct"
+    - "moonshotai/Kimi-K2.5"
+
+model:
+  model_id: "moonshotai/Kimi-K2-Thinking"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "1T"
+  active_parameters: "32B"
+  context_length: 262144
+  supports_dcp: true
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Enable Kimi K2 tool calling with the kimi_k2 tool-call parser."
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "kimi_k2"
+  reasoning:
+    description: "Kimi K2 reasoning parser for extracting chain-of-thought content."
+    args:
+      - "--reasoning-parser"
+      - "kimi_k2"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: int4
+    vram_minimum_gb: 600
+    description: "Native INT4 (QAT) weights on 8xH200 / 8xH20; 2x low-latency speed-up vs FP8"
+  nvfp4:
+    model_id: "nvidia/Kimi-K2-Thinking-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 600
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Kimi-K2-Thinking](https://huggingface.co/moonshotai/Kimi-K2-Thinking) is an advanced
+  trillion-parameter MoE created by Moonshot AI with these highlights:
+
+  - **Deep Thinking & Tool Orchestration**: End-to-end trained to interleave
+    chain-of-thought reasoning with function calls, enabling autonomous research, coding,
+    and writing workflows that last hundreds of steps without drift.
+  - **Native INT4 Quantization**: Quantization-Aware Training (QAT) delivers lossless 2x
+    speed-up in low-latency mode.
+  - **Stable Long-Horizon Agency**: Maintains coherent goal-directed behavior across up to
+    200-300 consecutive tool invocations, surpassing prior models that degrade after
+    30-50 steps.
+
+  ## Prerequisites
+
+  - **Hardware**: 8x H200 or 8x H20 GPUs
+  - **vLLM**: Current stable release
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launching Kimi-K2-Thinking with vLLM
+
+  ### Low-Latency Scenarios (TP8)
+
+  ```bash
+  vllm serve moonshotai/Kimi-K2-Thinking \
+    --tensor-parallel-size 8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --trust-remote-code
+  ```
+
+  The `--reasoning-parser` flag specifies the parser used to extract reasoning content
+  from the model output.
+
+  ### High-Throughput Scenarios (TP8+DCP8)
+
+  vLLM supports [Decode Context Parallel](https://docs.vllm.ai/en/latest/serving/context_parallel_deployment.html#decode-context-parallel),
+  which provides significant benefits in high-throughput scenarios. Enable DCP by adding
+  `--decode-context-parallel-size 8`:
+
+  ```bash
+  vllm serve moonshotai/Kimi-K2-Thinking \
+    --tensor-parallel-size 8 \
+    --decode-context-parallel-size 8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --trust-remote-code
+  ```
+
+  ## Metrics (GSM8K)
+
+  | Config | exact_match (flexible) | exact_match (strict) |
+  |--------|-----------------------|----------------------|
+  | TP8 | 0.9416 | 0.9409 |
+  | TP8+DCP8 | 0.9386 | 0.9371 |
+
+  ## Benchmarking
+
+  We used the following script to benchmark `moonshotai/Kimi-K2-Thinking` on 8xH200:
+
+  ```bash
+  vllm bench serve \
+    --model moonshotai/Kimi-K2-Thinking \
+    --dataset-name random \
+    --random-input 8000 \
+    --random-output 4000 \
+    --request-rate 100 \
+    --num-prompt 1000 \
+    --trust-remote-code
+  ```
+
+  ### DCP Gain Analysis
+
+  | Metric | TP8 | TP8+DCP8 | Change | Improvement |
+  |--------|-----|----------|--------|-------------|
+  | Request throughput (req/s) | 1.25 | 1.57 | +0.32 | +25.6% |
+  | Output token throughput (tok/s) | 485.78 | 695.13 | +209.35 | +43.1% |
+  | Mean TTFT (s) | 271.2 | 227.8 | -43.4 | +16.0% |
+
+  DCP multiplies the GPU KV cache size by `dcp_world_size`:
+  - TP8 KV cache: `715,072` tokens
+  - TP8+DCP8 KV cache: `5,721,088` tokens (8x)
+
+  Enabling DCP delivers strong advantages (43% faster token generation, 26% higher
+  throughput) with minimal drawbacks. Read the
+  [DCP doc](https://docs.vllm.ai/en/latest/serving/context_parallel_deployment.html#decode-context-parallel)
+  and try it in your LLM workloads.
+
+  ## References
+
+  - [Kimi-K2-Thinking on Hugging Face](https://huggingface.co/moonshotai/Kimi-K2-Thinking)
+  - [vLLM Decode Context Parallel docs](https://docs.vllm.ai/en/latest/serving/context_parallel_deployment.html#decode-context-parallel)

--- a/models/moonshotai/Kimi-K2-Thinking.yaml
+++ b/models/moonshotai/Kimi-K2-Thinking.yaml
@@ -11,6 +11,13 @@ meta:
   related_recipes:
     - "moonshotai/Kimi-K2-Instruct"
     - "moonshotai/Kimi-K2.5"
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
 
 model:
   model_id: "moonshotai/Kimi-K2-Thinking"
@@ -65,13 +72,7 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/moonshotai/Kimi-K2-Thinking.yaml
+++ b/models/moonshotai/Kimi-K2-Thinking.yaml
@@ -12,12 +12,7 @@ meta:
     - "moonshotai/Kimi-K2-Instruct"
     - "moonshotai/Kimi-K2.5"
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
 
 model:
   model_id: "moonshotai/Kimi-K2-Thinking"

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -1,0 +1,220 @@
+meta:
+  title: "Kimi-K2.5"
+  slug: "kimi-k2.5"
+  provider: "Moonshot AI"
+  description: "Open-source native multimodal agentic MoE model with vision-language understanding, tool calling, and thinking modes"
+  date_updated: 2026-04-16
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  performance_headline: "Multimodal agentic MoE model with DeepSeek-V3 backbone and MLA attention"
+  related_recipes: []
+
+model:
+  model_id: "moonshotai/Kimi-K2.5"
+  min_vllm_version: "0.15.0"
+  architecture: moe
+  parameter_count: "1T"
+  active_parameters: "32B"
+  context_length: 262144
+  supports_dcp: true
+  base_args:
+    - "--trust-remote-code"
+
+features:
+  tool_calling:
+    description: "Kimi K2 tool-call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "kimi_k2"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "Kimi K2 reasoning parser for extracting chain-of-thought content"
+    args:
+      - "--reasoning-parser"
+      - "kimi_k2"
+  spec_decoding:
+    description: "Eagle3 speculative decoding for accelerated inference (requires vLLM >= 0.18.0)"
+    args:
+      - "--speculative-config"
+      - '{"model":"lightseekorg/kimi-k2.5-eagle3","method":"eagle3","num_speculative_tokens":3}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: int4
+    vram_minimum_gb: 714
+    description: "Packed INT4 via compressed-tensors (~595 GB on disk); fits 8×H200"
+  nvfp4:
+    model_id: "nvidia/Kimi-K2.5-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 600
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs (e.g. GB200)"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+  - pd_cluster
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
+    extra_args:
+      - "--block-size=1"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
+      VLLM_ROCM_USE_AITER_RMSNORM: "0"
+
+strategy_overrides:
+  single_node_dep:
+    extra_args: []
+    extra_env: {}
+  single_node_tep:
+    extra_args: []
+    extra_env: {}
+  pd_cluster:
+    env:
+      VLLM_USE_NCCL_SYMM_MEM: "1"
+      NCCL_CUMEM_ENABLE: "1"
+      NCCL_MNNVL_ENABLE: "1"
+      NCCL_NVLS_ENABLE: "1"
+    prefill:
+      vllm_args:
+        - "--enforce-eager"
+        - "--max-num-batched-tokens"
+        - "16384"
+        - "--gpu-memory-utilization"
+        - "0.9"
+        - "--block-size"
+        - "64"
+      env: {}
+    decode:
+      vllm_args:
+        - "--gpu-memory-utilization"
+        - "0.9"
+        - "--compilation-config"
+        - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        - "--block-size"
+        - "64"
+        - "--all2all-backend"
+        - "flashinfer_nvlink_one_sided"
+      env: {}
+
+guide: |
+  ## Overview
+
+  Kimi K2.5 is an open-source, native multimodal agentic model built through continual
+  pretraining on approximately 15 trillion mixed visual and text tokens atop Kimi-K2-Base.
+  It seamlessly integrates vision and language understanding with advanced agentic
+  capabilities, instant and thinking modes, as well as conversational and agentic paradigms.
+
+  ## Prerequisites
+
+  - **vLLM version:** >= 0.15.0 (speculative decoding with Eagle3 requires >= 0.18.0)
+  - **Hardware (BF16):** 8x H200 GPUs (verified), or equivalent aggregate VRAM (~640 GB)
+  - **Hardware (NVFP4):** 4x Blackwell GPUs (e.g. GB200)
+  - **AMD support:** 8x MI300X / MI325X / MI355X with ROCm 7.2.1 and Python 3.12
+
+  ### Install vLLM
+
+  **Pip (NVIDIA):**
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --torch-backend auto
+  ```
+
+  **Pip (AMD ROCm):**
+  ```bash
+  uv venv --python 3.12
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  **Docker (NVIDIA):**
+  ```bash
+  docker pull vllm/vllm-openai:v0.17.0-cu130
+  ```
+
+  ## Client Usage
+
+  Once the vLLM server is running, consume it via the OpenAI-compatible API:
+
+  ```python
+  import time
+  from openai import OpenAI
+
+  client = OpenAI(
+      api_key="EMPTY",
+      base_url="http://localhost:8000/v1",
+      timeout=3600
+  )
+
+  messages = [
+      {
+          "role": "user",
+          "content": [
+              {
+                  "type": "image_url",
+                  "image_url": {
+                      "url": "https://ofasys-multimodal-wlcb-3-toshanghai.oss-accelerate.aliyuncs.com/wpf272043/keepme/image/receipt.png"
+                  }
+              },
+              {
+                  "type": "text",
+                  "text": "Read all the text in the image."
+              }
+          ]
+      }
+  ]
+
+  start = time.time()
+  response = client.chat.completions.create(
+      model="moonshotai/Kimi-K2.5",
+      messages=messages,
+      max_tokens=2048
+  )
+  print(f"Response costs: {time.time() - start:.2f}s")
+  print(f"Generated text: {response.choices[0].message.content}")
+  ```
+
+  ## Troubleshooting
+
+  - **OOM errors:** Lower `--gpu-memory-utilization` or adjust TP/EP to match your GPU count.
+  - **Vision encoder performance:** Use `--mm-encoder-tp-mode data` to run the vision encoder
+    in data-parallel mode. The encoder is small, so TP adds communication overhead with little gain.
+  - **Unique multimodal inputs:** Pass `--mm-processor-cache-gb 0` to avoid caching overhead.
+    For repeated inputs, `--mm-processor-cache-type shm` uses host shared memory for better
+    performance at high TP settings.
+  - **MoE kernel tuning:** Use the `benchmark_moe` script from vLLM to tune Triton kernels
+    for your specific hardware.
+  - **Async scheduling:** Enabled by default for better throughput. Disable if you encounter
+    issues, and file a bug report to vLLM.
+
+  ## References
+
+  - [Kimi-K2.5 on Hugging Face](https://huggingface.co/moonshotai/Kimi-K2.5)
+  - [NVIDIA Kimi-K2.5-NVFP4 on Hugging Face](https://huggingface.co/nvidia/Kimi-K2.5-NVFP4)
+  - [Eagle3 speculative decoding model](https://huggingface.co/lightseekorg/kimi-k2.5-eagle3)
+  - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html)
+  - [vLLM Expert Parallelism docs](https://docs.vllm.ai/en/latest/serving/expert_parallel_deployment.html)
+  - [vLLM NixlConnector usage guide](https://docs.vllm.ai/en/latest/features/nixl_connector_usage.html)

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -9,6 +9,16 @@ meta:
     - multimodal
   performance_headline: "Multimodal agentic MoE model with DeepSeek-V3 backbone and MLA attention"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: verified
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "moonshotai/Kimi-K2.5"
@@ -69,12 +79,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
     extra_args:

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -10,12 +10,8 @@ meta:
   performance_headline: "Multimodal agentic MoE model with DeepSeek-V3 backbone and MLA attention"
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
     gb200: verified
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/moonshotai/Kimi-Linear-48B-A3B-Instruct.yaml
+++ b/models/moonshotai/Kimi-Linear-48B-A3B-Instruct.yaml
@@ -1,0 +1,121 @@
+meta:
+  title: "Kimi-Linear-48B-A3B-Instruct"
+  slug: "kimi-linear-48b-a3b-instruct"
+  provider: "Moonshot AI"
+  description: "Kimi-Linear is a 48B-parameter instruction-tuned MoE model (~3B activated) with a linear-attention variant supporting very long context (1M tokens)."
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Linear-attention MoE with 1M-token context on a single node"
+  related_recipes: []
+
+model:
+  model_id: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
+  min_vllm_version: "0.11.2"
+  architecture: moe
+  parameter_count: "48B"
+  active_parameters: "3B"
+  context_length: 1048576
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+dependencies:
+  - note: "Pin vllm==0.11.2 — 0.12.0 has a known Kimi-Linear regression"
+    command: "uv pip install vllm==0.11.2 --torch-backend auto"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 115
+    description: "Full precision BF16 on 4 or 8 GPUs (single node)"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Kimi-Linear is Moonshot AI's 48B-parameter instruction-tuned MoE model (`A3B` indicates
+  ~3B active parameters per token) featuring a linear-attention variant that enables very
+  long context windows (up to 1,048,576 tokens).
+
+  ## Prerequisites
+
+  - **Hardware**: 4 or 8 GPUs on a single node
+  - **vLLM**: `0.11.2` recommended. Avoid vLLM `0.12.0`, which has a known bug
+    `MLAModules.__init__() missing 1 required positional argument: 'indexer_rotary_emb'`
+    that affects Kimi-Linear.
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  # Install a stable version (avoid 0.12.0)
+  uv pip install vllm==0.11.2 --torch-backend auto
+  ```
+
+  ## Running Kimi-Linear
+
+  The following snippets assume 4 or 8 GPUs on a single node.
+
+  ### 4-GPU Tensor Parallel
+
+  ```bash
+  vllm serve moonshotai/Kimi-Linear-48B-A3B-Instruct \
+    --port 8000 \
+    --tensor-parallel-size 4 \
+    --max-model-len 1048576 \
+    --trust-remote-code
+  ```
+
+  ### 8-GPU Tensor Parallel
+
+  ```bash
+  vllm serve moonshotai/Kimi-Linear-48B-A3B-Instruct \
+    --port 8000 \
+    --tensor-parallel-size 8 \
+    --max-model-len 1048576 \
+    --trust-remote-code
+  ```
+
+  If you see OOM, reduce `--max-model-len` (e.g. 65536) or increase
+  `--gpu-memory-utilization` (<= 0.95).
+
+  ## Client Usage
+
+  Once the server is up, test it with:
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{"model":"moonshotai/Kimi-Linear-48B-A3B-Instruct","messages":[{"role":"user","content":"Hello!"}]}'
+  ```
+
+  ## Troubleshooting
+
+  - **`MLAModules.__init__() missing 1 required positional argument: 'indexer_rotary_emb'`**:
+    Known bug in vLLM 0.12.0 affecting Kimi-Linear. Pin to `vllm==0.11.2` instead.
+  - **OOM**: Reduce `--max-model-len` or increase `--gpu-memory-utilization` up to 0.95.
+
+  ## References
+
+  - [Kimi-Linear-48B-A3B-Instruct on Hugging Face](https://huggingface.co/moonshotai/Kimi-Linear-48B-A3B-Instruct)

--- a/models/moonshotai/Kimi-Linear-48B-A3B-Instruct.yaml
+++ b/models/moonshotai/Kimi-Linear-48B-A3B-Instruct.yaml
@@ -42,13 +42,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -12,10 +12,6 @@ meta:
   hardware:
     h100: verified
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
 
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -1,0 +1,171 @@
+meta:
+  title: "NVIDIA Nemotron-3-Nano-30B-A3B"
+  slug: "nemotron-3-nano-30b-a3b"
+  provider: "NVIDIA"
+  description: "NVIDIA Nemotron-3-Nano Mamba-hybrid MoE (30B total / ~3B active) with BF16 and FP8 variants"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  related_recipes:
+    - nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
+
+model:
+  model_id: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+  min_vllm_version: "0.11.2"
+  architecture: moe
+  parameter_count: "30B"
+  active_parameters: "3B"
+  context_length: 262144
+  base_args:
+    - "--trust-remote-code"
+    - "--async-scheduling"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Qwen3 Coder tool-call parser with automatic tool choice"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "qwen3_coder"
+  reasoning:
+    description: "Custom Nano v3 reasoning parser (download plugin: nano_v3_reasoning_parser.py)"
+    args:
+      - "--reasoning-parser-plugin"
+      - "nano_v3_reasoning_parser.py"
+      - "--reasoning-parser"
+      - "nano_v3"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 72
+    description: "BF16 weights"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "auto"
+
+  fp8:
+    model_id: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8"
+    precision: fp8
+    vram_minimum_gb: 35
+    description: "FP8 weights + FP8 KV cache"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP8: "1"
+      VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  hopper:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  NVIDIA Nemotron-3-Nano-30B-A3B is a hybrid-Mamba MoE model (30B total, ~3B active) with
+  FP8 and BF16 variants. It supports DGX Spark and Jetson Thor in addition to standard
+  Hopper/Blackwell servers.
+
+  ## Prerequisites
+
+  - Hardware: 1x H100/H200 or comparable; DGX Spark and Jetson Thor supported
+  - vLLM >= 0.11.2 (0.12.0 recommended for full support)
+  - Docker with NVIDIA Container Toolkit (recommended)
+
+  ### Pull Docker Image
+
+  ```bash
+  docker pull --platform linux/amd64 vllm/vllm-openai:v0.12.0
+  docker tag vllm/vllm-openai:v0.12.0 vllm/vllm-openai:deploy
+  ```
+
+  DGX Spark users can build from source (see README) or use the NGC image:
+
+  ```bash
+  docker pull nvcr.io/nvidia/vllm:25.12.post1-py3
+  ```
+
+  Jetson Thor:
+
+  ```bash
+  docker pull ghcr.io/nvidia-ai-iot/vllm:latest-jetson-thor
+  ```
+
+  ## Launch commands
+
+  FP8 with FlashInfer MoE backend (Blackwell/Hopper):
+
+  ```bash
+  export VLLM_USE_FLASHINFER_MOE_FP8=1
+  export VLLM_FLASHINFER_MOE_BACKEND=throughput
+
+  vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 \
+    --trust-remote-code \
+    --async-scheduling \
+    --kv-cache-dtype fp8 \
+    --tensor-parallel-size 1
+  ```
+
+  BF16 (with reasoning + tool parsers — typical for Spark/Thor):
+
+  ```bash
+  wget https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/resolve/main/nano_v3_reasoning_parser.py
+
+  vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
+    --max-num-seqs 8 \
+    --tensor-parallel-size 1 \
+    --max-model-len 262144 \
+    --trust-remote-code \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser-plugin nano_v3_reasoning_parser.py \
+    --reasoning-parser nano_v3
+  ```
+
+  Key flags:
+  - `kv-cache-dtype fp8` for FP8 variant, `auto` for BF16
+  - `async-scheduling` reduces host overhead between decode steps
+  - `mamba-ssm-cache-dtype float32` for best accuracy, `float16` for speed
+  - `max-num-seqs` cap to match client concurrency for lower per-user latency
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 \
+    --trust-remote-code \
+    --dataset-name random \
+    --random-input-len 1024 --random-output-len 1024 \
+    --num-warmups 20 \
+    --ignore-eos \
+    --max-concurrency 1024 \
+    --num-prompts 2048
+  ```
+
+  ## Troubleshooting
+
+  - Use `--kv-cache-dtype fp8` only with the FP8 checkpoint.
+  - Balance TP and `--max-num-seqs` for throughput vs. per-user latency.
+
+  ## References
+
+  - [Nemotron-3-Nano-30B-A3B-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16)
+  - [Nemotron-3-Nano-30B-A3B-FP8](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8)

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -16,6 +16,7 @@ meta:
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
   min_vllm_version: "0.11.2"
+  docker_image: "vllm/vllm-openai:v0.12.0"
   architecture: moe
   parameter_count: "30B"
   active_parameters: "3B"

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -9,6 +9,13 @@ meta:
     - text
   related_recipes:
     - nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
+  hardware:
+    h100: verified
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
 
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
@@ -67,13 +74,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  blackwell:
-    extra_args: []
-    extra_env: {}
-  hopper:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
@@ -16,6 +16,7 @@ meta:
 model:
   model_id: "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
   min_vllm_version: "0.11.1"
+  docker_image: "vllm/vllm-openai:nightly-8bff831f0aa239006f34b721e63e1340e3472067"
   architecture: dense
   parameter_count: "12B"
   active_parameters: "12B"

--- a/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
@@ -1,0 +1,151 @@
+meta:
+  title: "NVIDIA Nemotron-Nano-12B-v2-VL"
+  slug: "nemotron-nano-12b-v2-vl"
+  provider: "NVIDIA"
+  description: "NVIDIA Nemotron-Nano 12B vision-language model with video support and Efficient Video Sampling (EVS)"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  related_recipes:
+    - nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+
+model:
+  model_id: "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+  min_vllm_version: "0.11.1"
+  architecture: dense
+  parameter_count: "12B"
+  active_parameters: "12B"
+  context_length: 131072
+  base_args:
+    - "--trust-remote-code"
+  base_env:
+    VLLM_VIDEO_LOADER_BACKEND: "opencv"
+
+features:
+  video_compression:
+    description: "Efficient Video Sampling (EVS) prunes video tokens; 0.75 means 75% pruning"
+    args:
+      - "--video-pruning-rate"
+      - "0.75"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 29
+    description: "BF16 weights on 1 GPU"
+
+  fp8:
+    model_id: "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8"
+    precision: fp8
+    vram_minimum_gb: 14
+    description: "FP8 weights on 1 GPU"
+
+  nvfp4:
+    model_id: "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD"
+    precision: nvfp4
+    vram_minimum_gb: 8
+    description: "NVFP4 (QAD) weights for Blackwell"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Nemotron-Nano-12B-v2-VL is a vision-language model with image and video support. It
+  includes Efficient Video Sampling (EVS) to prune video tokens and reduce compute. The
+  model is available in BF16, FP8, and NVFP4 (QAD) precisions.
+
+  ## Prerequisites
+
+  - Hardware: 1x GPU (A100/H100/B200, etc.)
+  - vLLM: 0.11.0 does NOT include this model; use latest nightly or install from source
+  - DGX Spark: use `nvcr.io/nvidia/vllm:25.12.post1-py3`
+
+  ### Install vLLM
+
+  ```bash
+  docker pull vllm/vllm-openai:nightly-8bff831f0aa239006f34b721e63e1340e3472067
+  # or for DGX Spark:
+  docker pull nvcr.io/nvidia/vllm:25.12.post1-py3
+  ```
+
+  ## Launch command
+
+  ```bash
+  export VLLM_VIDEO_LOADER_BACKEND=opencv
+  export CHECKPOINT_PATH="nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+  export CUDA_VISIBLE_DEVICES=0
+
+  python3 -m vllm.entrypoints.openai.api_server \
+    --model ${CHECKPOINT_PATH} \
+    --trust-remote-code \
+    --media-io-kwargs '{"video": {"fps": 2, "num_frames": 128}}' \
+    --max-model-len 131072 \
+    --data-parallel-size 1 \
+    --port 5566 \
+    --allowed-local-media-path / \
+    --video-pruning-rate 0.75 \
+    --served-model-name "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+  ```
+
+  Flags:
+  - `--max-model-len`: reduce for shorter contexts to save memory
+  - `--allowed-local-media-path <root>`: limit local-file access
+  - `--video-pruning-rate <0..1>`: EVS compression; higher prunes more video tokens
+
+  ## Client Usage
+
+  Describe a video:
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:5566/v1", api_key="<ignored>")
+  completion = client.chat.completions.create(
+      model="nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "text", "text": "Describe the video."},
+              {"type": "video_url", "video_url": {"url": "file:///path/to/video.mp4"}},
+          ],
+      }],
+  )
+  print(completion.choices[0].message.content)
+  ```
+
+  ## Offline / LLM API
+
+  ```python
+  from vllm import LLM, SamplingParams
+
+  llm = LLM(
+      "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16",
+      trust_remote_code=True,
+      max_model_len=2**17,
+      allowed_local_media_path="/",
+      video_pruning_rate=0.75,
+      media_io_kwargs=dict(video=dict(fps=2, num_frames=128)),
+  )
+  ```
+
+  ## Troubleshooting
+
+  - Set `VLLM_VIDEO_LOADER_BACKEND=opencv` (required for video inputs).
+  - OOM: lower `--max-model-len` or increase `--video-pruning-rate`.
+
+  ## References
+
+  - [Nemotron-Nano-12B-v2-VL-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16)
+  - [Nemotron-Nano-12B-v2-VL-FP8](https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8)
+  - [Nemotron-Nano-12B-v2-VL-NVFP4-QAD](https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD)
+  - [EVS paper](https://arxiv.org/abs/2510.14624)

--- a/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
@@ -9,6 +9,13 @@ meta:
     - multimodal
   related_recipes:
     - nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  hardware:
+    h100: verified
+    h200: supported
+    b200: verified
+    gb200: supported
+    b300: supported
+    gb300: supported
 
 model:
   model_id: "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"

--- a/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
@@ -11,11 +11,7 @@ meta:
     - nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
   hardware:
     h100: verified
-    h200: supported
     b200: verified
-    gb200: supported
-    b300: supported
-    gb300: supported
 
 model:
   model_id: "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -12,9 +12,6 @@ meta:
     h100: verified
     h200: verified
     b200: verified
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -1,0 +1,250 @@
+meta:
+  title: "GPT-OSS"
+  slug: "gpt-oss"
+  provider: "OpenAI"
+  description: "OpenAI's gpt-oss family (20B / 120B) with MXFP4 MoE, attention-sinks, built-in tools via Responses API"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  related_recipes: []
+
+model:
+  model_id: "openai/gpt-oss-120b"
+  min_vllm_version: "0.10.0"
+  architecture: moe
+  parameter_count: "120B"
+  active_parameters: "5.1B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "OpenAI harmony tool-call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "openai"
+      - "--enable-auto-tool-choice"
+  spec_decoding:
+    description: "EAGLE3 speculative decoding for accelerated inference"
+    args:
+      - "--speculative-config"
+      - '{"model":"nvidia/gpt-oss-120b-Eagle3-v2","num_speculative_tokens":3,"method":"eagle3","draft_tensor_parallel_size":1}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: mxfp4
+    vram_minimum_gb: 96
+    description: "gpt-oss-120b with MXFP4 MoE; fits on 1xA100 80GB, scales to TP 2/4/8"
+
+  "20b":
+    model_id: "openai/gpt-oss-20b"
+    precision: mxfp4
+    vram_minimum_gb: 40
+    description: "gpt-oss-20b, fits on a single A100"
+
+  amd_fp8:
+    model_id: "amd/gpt-oss-120b-w-mxfp4-a-fp8"
+    precision: mxfp4
+    vram_minimum_gb: 80
+    description: "Quark-quantized MXFP4 weights with FP8 activations for MI355X (gfx950)"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  blackwell:
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+      - "--no-enable-prefix-caching"
+      - "--max-cudagraph-capture-size"
+      - "2048"
+      - "--max-num-batched-tokens"
+      - "8192"
+      - "--stream-interval"
+      - "20"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: "1"
+  hopper:
+    extra_args:
+      - "--no-enable-prefix-caching"
+      - "--max-cudagraph-capture-size"
+      - "2048"
+      - "--max-num-batched-tokens"
+      - "8192"
+      - "--stream-interval"
+      - "20"
+    extra_env: {}
+  amd:
+    # vLLM 0.17.0+ replaces the old VLLM_ROCM_USE_AITER_* env knobs with
+    # --attention-backend ROCM_AITER_UNIFIED_ATTN. HSA_NO_SCRATCH_RECLAIM is
+    # required on GPUs with firmware MEC < 177; harmless to keep set.
+    extra_args:
+      - "--attention-backend"
+      - "ROCM_AITER_UNIFIED_ATTN"
+      - "-cc.pass_config.fuse_rope_kvcache=True"
+      - "-cc.use_inductor_graph_partition=True"
+      - "--gpu-memory-utilization"
+      - "0.95"
+      - "--block-size=64"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
+      HSA_NO_SCRATCH_RECLAIM: "1"
+      AMDGCN_USE_BUFFER_OPS: "0"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  `gpt-oss-20b` and `gpt-oss-120b` are open-weight reasoning models from OpenAI. vLLM
+  supports NVIDIA H100/H200/B200, AMD MI300X/MI325X/MI355X, and Radeon AI PRO R9700,
+  with ongoing work for Ampere/Ada/RTX 5090.
+
+  Optimizations:
+  - Flexible parallelism (TP 2/4/8)
+  - Attention kernels for attention-sinks and sliding-window shapes
+  - Asynchronous scheduling for CPU/GPU overlap
+
+  ## Prerequisites
+
+  - Hardware: NVIDIA H100/H200/B200 (or A100 80GB for single-GPU), AMD MI300+
+  - vLLM >= 0.10.0
+  - CUDA >= 12.8 if building from source (must match between install and serving)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --torch-backend=auto
+  ```
+
+  Docker quickstart:
+
+  ```bash
+  docker run --gpus all -p 8000:8000 --ipc=host vllm/vllm-openai --model openai/gpt-oss-20b
+  ```
+
+  AMD ROCm wheels:
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  ## Launch commands
+
+  A100 (single card, default TRITON_ATTN + Marlin MXFP4 MoE):
+
+  ```bash
+  vllm serve openai/gpt-oss-120b
+  vllm serve openai/gpt-oss-120b --tensor-parallel-size 4
+  ```
+
+  Blackwell (B200) with FlashInfer MXFP4+MXFP8 MoE:
+
+  ```bash
+  export VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1
+
+  # GPT-OSS_Blackwell.yaml
+  # kv-cache-dtype: fp8
+  # no-enable-prefix-caching: true
+  # max-cudagraph-capture-size: 2048
+  # max-num-batched-tokens: 8192
+  # stream-interval: 20
+  vllm serve openai/gpt-oss-120b --config GPT-OSS_Blackwell.yaml --tensor-parallel-size 1
+  ```
+
+  Hopper (H100/H200): same as Blackwell without `kv-cache-dtype` and without the env var.
+
+  AMD MI300X/MI325X:
+
+  ```bash
+  export HSA_NO_SCRATCH_RECLAIM=1
+  export AMDGCN_USE_BUFFER_OPS=0
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+  vllm serve openai/gpt-oss-120b \
+    --tensor-parallel-size 8 \
+    --attention-backend ROCM_AITER_UNIFIED_ATTN \
+    -cc.pass_config.fuse_rope_kvcache=True \
+    -cc.use_inductor_graph_partition=True \
+    --gpu-memory-utilization 0.95 \
+    --block-size 64
+  ```
+
+  ## Tool Use
+
+  `/v1/responses` endpoint supports built-in tools (browsing, python, MCP). Setup
+  requires `uv pip install gpt-oss` and either docker (for Python sandbox) or
+  `PYTHON_EXECUTION_BACKEND=dangerously_use_uv`. For demo tools:
+
+  ```bash
+  vllm serve ... --tool-server demo
+  ```
+
+  For user-defined function calling:
+
+  ```bash
+  vllm serve ... --tool-call-parser openai --enable-auto-tool-choice
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  response = client.chat.completions.create(
+      model="openai/gpt-oss-120b",
+      messages=[{"role": "user", "content": "Explain sinks attention."}],
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Accuracy Evaluation
+
+  OpenAI recommends evaluating with the gpt-oss reference library:
+
+  ```bash
+  vllm serve openai/gpt-oss-120b \
+    --tensor_parallel_size 8 --max-model-len 131072 \
+    --max-num-batched-tokens 10240 --max-num-seqs 128 \
+    --gpu-memory-utilization 0.85 --no-enable-prefix-caching
+
+  mkdir -p /tmp/gpqa_openai
+  OPENAI_API_KEY=empty python -m gpt_oss.evals \
+    --model openai/gpt-oss-120b --eval gpqa --n-threads 128
+  ```
+
+  Reproduced scores (120B): Low 65.3 / 51.2; Mid 72.4 / 79.6; High 79.4 / 93.0 (GPQA / AIME25).
+
+  ## Troubleshooting
+
+  - **Attention sinks dtype error on Blackwell:** ensure env vars above are set.
+  - **`tl.language not defined`:** make sure no extra Triton (e.g., pytorch-triton) is installed.
+  - **H100 TP1 OOM:** `--gpu-memory-utilization 0.95 --max-num-batched-tokens 1024`.
+  - **Harmony vocab download failure:** pre-download tiktoken files and set `TIKTOKEN_ENCODINGS_BASE`.
+
+  ## Known Limitations
+
+  - Responses API: streaming is basic, annotations/citations unsupported, usage accounting returns zeros.
+  - Function calling currently supports only `tool_choice="auto"`.
+
+  ## References
+
+  - [gpt-oss-120b](https://huggingface.co/openai/gpt-oss-120b)
+  - [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b)
+  - [amd/gpt-oss-120b-w-mxfp4-a-fp8](https://huggingface.co/amd/gpt-oss-120b-w-mxfp4-a-fp8)
+  - [Eagle3 draft model](https://huggingface.co/nvidia/gpt-oss-120b-Eagle3-v2)

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -8,6 +8,16 @@ meta:
   tasks:
     - text
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: verified
+    b200: verified
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "openai/gpt-oss-120b"

--- a/models/stabilityai/stable-audio-open-1.0.yaml
+++ b/models/stabilityai/stable-audio-open-1.0.yaml
@@ -1,0 +1,129 @@
+meta:
+  title: "Stable Audio Open"
+  slug: "stable-audio-open"
+  provider: "Stability AI"
+  description: "Text-to-audio generation model (1.2B params) producing up to ~47 s stereo audio at 44.1 kHz, served via vLLM-Omni"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - omni
+  related_recipes:
+    - stabilityai/stable-diffusion-3.5-medium
+
+model:
+  model_id: "stabilityai/stable-audio-open-1.0"
+  min_vllm_version: "0.14.1"
+  architecture: dense
+  parameter_count: "1.2B"
+  active_parameters: "1.2B"
+  context_length: 0
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Pin vllm==0.14.1 for Stable Audio Open"
+    command: "uv pip install vllm==0.14.1"
+  - note: "vllm-omni provides the audio generation backend"
+    command: "uv pip install git+https://github.com/vllm-project/vllm-omni.git"
+  - note: "soundfile (recommended) or scipy for WAV output"
+    command: "uv pip install soundfile"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 19
+    description: "BF16 weights for text-to-audio generation (via vLLM-Omni)"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Stable Audio Open 1.0](https://huggingface.co/stabilityai/stable-audio-open-1.0) is
+  Stability AI's text-to-audio generation model (~1.2B parameters). It produces stereo
+  audio at 44.1 kHz, up to ~47 seconds. Served via **vLLM-Omni** (not standard vLLM).
+
+  Limitations:
+  - No realistic vocals (no singing or speech).
+  - English-only training data.
+  - Better at sound effects than complex music.
+
+  ## Prerequisites
+
+  - vLLM-Omni on top of vLLM 0.14.1
+  - `soundfile` or `scipy` for saving audio
+
+  ## Installation
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm==0.14.1
+  uv pip install git+https://github.com/vllm-project/vllm-omni.git
+
+  # Audio saving
+  uv pip install soundfile
+  ```
+
+  ## Python Usage
+
+  ```python
+  import torch
+  import soundfile as sf
+  from vllm_omni.entrypoints.omni import Omni
+
+  omni = Omni(model="stabilityai/stable-audio-open-1.0")
+  generator = torch.Generator(device="cuda").manual_seed(42)
+
+  audio = omni.generate(
+      "The sound of a dog barking",
+      negative_prompt="Low quality.",
+      generator=generator,
+      guidance_scale=7.0,
+      num_inference_steps=100,
+      extra={"audio_start_in_s": 0.0, "audio_end_in_s": 10.0},
+  )
+
+  audio_data = audio[0].cpu().float().numpy().T  # [samples, channels]
+  sf.write("output.wav", audio_data, 44100)
+  ```
+
+  ## CLI Usage (from vLLM-Omni repo)
+
+  ```bash
+  python examples/offline_inference/text_to_audio/text_to_audio.py \
+    --model stabilityai/stable-audio-open-1.0 \
+    --prompt "The sound of a dog barking" \
+    --audio_length 10.0 \
+    --num_inference_steps 100 \
+    --guidance_scale 7.0 \
+    --output dog_barking.wav
+  ```
+
+  ## Key Parameters
+
+  | Parameter | Default | Description |
+  |-----------|---------|-------------|
+  | `audio_start_in_s` | 0.0 | Start time in seconds |
+  | `audio_end_in_s` | 10.0 | End time in seconds |
+  | `num_inference_steps` | 100 | Denoising steps (higher = better quality, slower) |
+  | `guidance_scale` | 7.0 | Classifier-free guidance scale |
+  | `negative_prompt` | "Low quality." | Text to avoid |
+  | `num_waveforms` | 1 | Samples per prompt |
+  | `sample_rate` | 44100 | Output sample rate (Hz) |
+
+  ## License
+
+  Released under the Stability AI Community License. Commercial use requires a separate license.
+
+  ## References
+
+  - [Stable Audio Open on Hugging Face](https://huggingface.co/stabilityai/stable-audio-open-1.0)
+  - [vLLM-Omni text-to-audio example](https://github.com/vllm-project/vllm-omni/blob/main/examples/offline_inference/text_to_audio/text_to_audio.py)

--- a/models/stabilityai/stable-diffusion-3.5-medium.yaml
+++ b/models/stabilityai/stable-diffusion-3.5-medium.yaml
@@ -1,0 +1,141 @@
+meta:
+  title: "Stable Diffusion 3.5"
+  slug: "stable-diffusion-3.5"
+  provider: "Stability AI"
+  description: "Stability AI's Stable Diffusion 3.5 text-to-image family (medium 2.5B, large 8.1B, large-turbo) via vLLM-Omni with Cache-DiT acceleration"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - omni
+  related_recipes:
+    - stabilityai/stable-audio-open-1.0
+
+model:
+  model_id: "stabilityai/stable-diffusion-3.5-medium"
+  min_vllm_version: "0.12.0"
+  architecture: dense
+  parameter_count: "2.5B"
+  active_parameters: "2.5B"
+  context_length: 0
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Pin vllm==0.12.0 for Stable Diffusion 3.5"
+    command: "uv pip install vllm==0.12.0"
+  - note: "vllm-omni provides the image generation backend"
+    command: "uv pip install git+https://github.com/vllm-project/vllm-omni.git"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 44
+    description: "Stable Diffusion 3.5 medium (2.5B)"
+
+  large:
+    model_id: "stabilityai/stable-diffusion-3.5-large"
+    precision: bf16
+    vram_minimum_gb: 24
+    description: "Stable Diffusion 3.5 large (8.1B)"
+
+  large_turbo:
+    model_id: "stabilityai/stable-diffusion-3.5-large-turbo"
+    precision: bf16
+    vram_minimum_gb: 24
+    description: "Stable Diffusion 3.5 large-turbo (8.1B, timestep-distilled for few-step inference)"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Stable Diffusion 3.5 text-to-image generation models, served via **vLLM-Omni** with
+  optional **Cache-DiT** acceleration.
+
+  Supported variants:
+  - `stabilityai/stable-diffusion-3.5-medium` — 2.5B params
+  - `stabilityai/stable-diffusion-3.5-large` — 8.1B params
+  - `stabilityai/stable-diffusion-3.5-large-turbo` — 8.1B params (timestep-distilled for few-step inference)
+
+  ## Prerequisites
+
+  - vLLM-Omni on top of vLLM 0.12.0
+  - `diffusers` library
+
+  ## Installation
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm==0.12.0
+  uv pip install git+https://github.com/vllm-project/vllm-omni.git
+  ```
+
+  ## Python Usage
+
+  ```python
+  from vllm_omni.entrypoints.omni import Omni
+
+  omni = Omni(model="stabilityai/stable-diffusion-3.5-medium")
+
+  images = omni.generate(
+      prompt="a cat wearing sunglasses, cyberpunk style",
+      negative_prompt="blurry, low quality",
+      height=1024, width=1024,
+      num_inference_steps=28,
+      guidance_scale=7.5,
+      num_outputs_per_prompt=2,
+  )
+  ```
+
+  ## CLI Usage
+
+  ```bash
+  python examples/offline_inference/text_to_image/text_to_image.py \
+    --model stabilityai/stable-diffusion-3.5-medium \
+    --prompt "a cat wearing sunglasses, cyberpunk style" \
+    --negative_prompt "blurry, low quality" \
+    --height 1024 --width 1024 \
+    --num_inference_steps 28 \
+    --guidance_scale 7.5
+  ```
+
+  ## Cache-DiT Acceleration
+
+  Enable caching for significant speed-ups:
+
+  ```python
+  omni = Omni(
+      model="stabilityai/stable-diffusion-3.5-medium",
+      cache_backend="cache_dit",
+      cache_config={
+          "Fn_compute_blocks": 8,
+          "Bn_compute_blocks": 0,
+          "max_warmup_steps": 4,
+          "residual_diff_threshold": 0.12,
+      },
+  )
+  ```
+
+  ## Key Parameters
+
+  | Parameter | Default | Description |
+  |-----------|---------|-------------|
+  | `height` | 1024 | Image height (multiples of 16) |
+  | `width` | 1024 | Image width (multiples of 16) |
+  | `num_inference_steps` | 28 | Denoising steps |
+  | `guidance_scale` | 1.0 | Classifier-free guidance scale |
+
+  ## References
+
+  - [SD3.5 Medium](https://huggingface.co/stabilityai/stable-diffusion-3.5-medium)
+  - [SD3.5 Large](https://huggingface.co/stabilityai/stable-diffusion-3.5-large)
+  - [SD3.5 Large Turbo](https://huggingface.co/stabilityai/stable-diffusion-3.5-large-turbo)
+  - [Cache-DiT Acceleration](https://github.com/vipshop/cache-dit)

--- a/models/stepfun-ai/Step-3.5-Flash.yaml
+++ b/models/stepfun-ai/Step-3.5-Flash.yaml
@@ -1,0 +1,193 @@
+meta:
+  title: "Step-3.5-Flash"
+  slug: "step-3.5-flash"
+  provider: "StepFun"
+  description: "Production-grade reasoning MoE (~196B total / 11B active parameters) with hybrid attention schedules, SWA compensation, and multi-token prediction for low-latency long-context inference"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Sparse MoE reasoning model with hybrid attention and step3p5 MTP speculative decoding"
+  related_recipes: []
+
+model:
+  model_id: "stepfun-ai/Step-3.5-Flash"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "196B"
+  active_parameters: "11B"
+  context_length: 262144
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Step-3.5 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "step3p5"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "Step-3.5 reasoning parser for chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "step3p5"
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding with the step3p5_mtp method"
+    args:
+      - "--hf-overrides"
+      - '{"num_nextn_predict_layers": 1}'
+      - "--speculative-config"
+      - '{"method": "step3p5_mtp", "num_speculative_tokens": 1}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 470
+    description: "Full precision BF16 — runs on 4xH200/H20/B200"
+  fp8:
+    model_id: "stepfun-ai/Step-3.5-Flash-FP8"
+    precision: fp8
+    vram_minimum_gb: 235
+    description: "Native FP8 checkpoint (TP4 not supported — use DP4)"
+  int4:
+    model_id: "stepfun-ai/Step-3.5-Flash-INT4"
+    precision: int4
+    vram_minimum_gb: 118
+    description: "INT4 quantized weights"
+  int8:
+    model_id: "stepfun-ai/Step-3.5-Flash-INT8"
+    precision: int8
+    vram_minimum_gb: 235
+    description: "INT8 quantized weights"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP8: "0"
+  amd:
+    # Step-3.5 uses a custom SWIGLUSTEP activation that AITER MoE doesn't
+    # support in vLLM 0.17.1 — keep AITER on for attention, MoE off.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MOE: "0"
+      VLLM_USE_TRITON_FLASH_ATTN: "0"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Step-3.5-Flash](https://huggingface.co/stepfun-ai/Step-3.5-Flash) is an advanced
+  reasoning engine from [StepFun](https://www.stepfun.com/company). Highlights:
+
+  - Hybrid attention schedules with compensation for sliding-window attention (SWA)
+  - Sparse MoE structure (196B total parameters, 11B active)
+  - Multi-token prediction mechanism for faster inference
+
+  Available precisions:
+
+  - [stepfun-ai/Step-3.5-Flash](https://huggingface.co/stepfun-ai/Step-3.5-Flash) (BF16)
+  - [stepfun-ai/Step-3.5-Flash-FP8](https://huggingface.co/stepfun-ai/Step-3.5-Flash-FP8)
+  - [stepfun-ai/Step-3.5-Flash-Int4](https://huggingface.co/stepfun-ai/Step-3.5-Flash-Int4) (not yet supported by vLLM)
+
+  ## Prerequisites
+
+  - **vLLM version:** latest stable
+  - **Hardware:** 4x H200/H20/B200
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --torch-backend auto
+  ```
+
+  ## Launching the Server
+
+  ### Tensor Parallel
+
+  ```bash
+  vllm serve stepfun-ai/Step-3.5-Flash \
+      --tensor-parallel-size 4 \
+      --reasoning-parser step3p5 \
+      --tool-call-parser step3p5 \
+      --enable-auto-tool-choice \
+      --trust-remote-code
+  ```
+
+  Note: The FP8 version cannot use TP4 — use DP4 instead.
+
+  ### Data Parallel + Expert Parallel (recommended for FP8)
+
+  ```bash
+  vllm serve stepfun-ai/Step-3.5-Flash \
+      --data-parallel-size 4 \
+      --enable-expert-parallel \
+      --reasoning-parser step3p5 \
+      --tool-call-parser step3p5 \
+      --enable-auto-tool-choice \
+      --trust-remote-code
+  ```
+
+  ### Enabling MTP Speculative Decoding
+
+  ```bash
+  vllm serve stepfun-ai/Step-3.5-Flash \
+      --tensor-parallel-size 4 \
+      --reasoning-parser step3p5 \
+      --tool-call-parser step3p5 \
+      --enable-auto-tool-choice \
+      --trust-remote-code \
+      --hf-overrides '{"num_nextn_predict_layers": 1}' \
+      --speculative-config '{"method": "step3p5_mtp", "num_speculative_tokens": 1}'
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --backend vllm \
+    --model stepfun-ai/Step-3.5-Flash \
+    --endpoint /v1/completions \
+    --dataset-name random \
+    --random-input 2048 \
+    --random-output 1024 \
+    --max-concurrency 10 \
+    --num-prompt 100
+  ```
+
+  ## Troubleshooting
+
+  - **MoE kernel tuning:** See [tune-moe-kernel](https://github.com/vllm-project/recipes/blob/main/Qwen/Qwen3-Next.md#tune-moe-kernel)
+    to tune Triton kernels for your hardware.
+  - **FP8 DeepGEMM:** For FP8, install DeepGEMM via [install_deepgemm.sh](https://github.com/vllm-project/vllm/blob/v0.16.0rc0/tools/install_deepgemm.sh).
+  - **B200 FlashInfer FP8 MoE error:** If you see
+    `routing_logits must be bfloat16` when serving FP8 on B200, set
+    `export VLLM_USE_FLASHINFER_MOE_FP8=0` as a workaround.
+  - **FP8 + TP4 incompatibility:** Use DP4+EP instead.
+
+  ## References
+
+  - [Model card](https://huggingface.co/stepfun-ai/Step-3.5-Flash)
+  - [FP8 checkpoint](https://huggingface.co/stepfun-ai/Step-3.5-Flash-FP8)
+  - [StepFun](https://www.stepfun.com/company)

--- a/models/stepfun-ai/Step-3.5-Flash.yaml
+++ b/models/stepfun-ai/Step-3.5-Flash.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Sparse MoE reasoning model with hybrid attention and step3p5 MTP speculative decoding"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: verified
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "stepfun-ai/Step-3.5-Flash"
@@ -75,9 +85,6 @@ compatible_strategies:
   - multi_node_dep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
   blackwell:
     extra_args: []
     extra_env:

--- a/models/stepfun-ai/Step-3.5-Flash.yaml
+++ b/models/stepfun-ai/Step-3.5-Flash.yaml
@@ -10,15 +10,8 @@ meta:
   performance_headline: "Sparse MoE reasoning model with hybrid attention and step3p5 MTP speculative decoding"
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
     b200: verified
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "stepfun-ai/Step-3.5-Flash"
@@ -96,7 +89,6 @@ hardware_overrides:
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "0"
-      VLLM_USE_TRITON_FLASH_ATTN: "0"
 
 strategy_overrides: {}
 

--- a/models/tencent/Hunyuan-A13B-Instruct.yaml
+++ b/models/tencent/Hunyuan-A13B-Instruct.yaml
@@ -1,0 +1,123 @@
+meta:
+  title: "Hunyuan-A13B-Instruct"
+  slug: "hunyuan-a13b-instruct"
+  provider: "Tencent Hunyuan"
+  description: "Tencent Hunyuan A13B instruct-tuned MoE language model with AITER-accelerated AMD ROCm deployment"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "Hunyuan-A13B MoE with AITER acceleration on AMD MI300X/MI325X/MI355X"
+  related_recipes: []
+
+model:
+  model_id: "tencent/Hunyuan-A13B-Instruct"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "80B"
+  active_parameters: "13B"
+  context_length: 32768
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 580
+    description: "Full precision BF16 — 2x GPU (TP=2) on AMD MI300X/MI325X/MI355X"
+  fp8:
+    model_id: "tencent/Hunyuan-A13B-Instruct-FP8"
+    precision: fp8
+    vram_minimum_gb: 96
+    description: "FP8 quantized weights for Hopper/Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    # Hunyuan-A13B is an AMD-first recipe; AITER acceleration required.
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Hunyuan-A13B-Instruct is Tencent's instruct-tuned Hunyuan MoE model. This recipe
+  covers deployment on AMD ROCm GPUs (MI300X / MI325X / MI355X) with
+  [AITER](https://github.com/ROCm/aiter) acceleration enabled via
+  `VLLM_ROCM_USE_AITER=1`.
+
+  ## Prerequisites
+
+  - **vLLM version:** ROCm build
+  - **Python:** 3.12
+  - **Hardware:** AMD MI300X / MI325X / MI355X
+  - **ROCm:** 7.0+, glibc >= 2.35 (or use Docker)
+
+  ### Install vLLM (ROCm)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+
+  If the environment does not meet the Python/ROCm/glibc requirements, use the
+  Docker-based setup from the vLLM install docs.
+
+  ## Launching the Server
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve tencent/Hunyuan-A13B-Instruct \
+      --tensor-parallel-size 2 \
+      --trust-remote-code
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model "tencent/Hunyuan-A13B-Instruct" \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos
+  ```
+
+  ## Troubleshooting
+
+  - **First launch delay:** AITER JIT-compiles optimized kernels on first launch, which
+    can take several minutes. Subsequent runs use cached kernels.
+  - **Environment mismatch:** If wheel install fails, fall back to the vLLM ROCm Docker image.
+
+  ## References
+
+  - [Model card](https://huggingface.co/tencent/Hunyuan-A13B-Instruct)
+  - [AITER](https://github.com/ROCm/aiter)
+  - [vLLM install docs](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/)

--- a/models/tencent/Hunyuan-A13B-Instruct.yaml
+++ b/models/tencent/Hunyuan-A13B-Instruct.yaml
@@ -9,6 +9,10 @@ meta:
     - text
   performance_headline: "Hunyuan-A13B MoE with AITER acceleration on AMD MI300X/MI325X/MI355X"
   related_recipes: []
+  hardware:
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "tencent/Hunyuan-A13B-Instruct"
@@ -48,12 +52,6 @@ compatible_strategies:
   - multi_node_dep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     # Hunyuan-A13B is an AMD-first recipe; AITER acceleration required.
     extra_args: []

--- a/models/tencent/HunyuanOCR.yaml
+++ b/models/tencent/HunyuanOCR.yaml
@@ -1,0 +1,130 @@
+meta:
+  title: "HunyuanOCR"
+  slug: "hunyuan-ocr"
+  provider: "Tencent Hunyuan"
+  description: "Tencent Hunyuan end-to-end OCR expert VLM (~1B) for online OCR serving with an OpenAI-compatible API"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - multimodal
+  performance_headline: "Compact 1B end-to-end OCR VLM from the Hunyuan native multimodal family"
+  related_recipes: []
+
+model:
+  model_id: "tencent/HunyuanOCR"
+  min_vllm_version: "0.11.0"
+  architecture: dense
+  parameter_count: "1B"
+  active_parameters: "1B"
+  context_length: 32768
+  base_args:
+    - "--no-enable-prefix-caching"
+    - "--mm-processor-cache-gb"
+    - "0"
+  base_env: {}
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 2
+    description: "Full precision BF16 — single-GPU deployment"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [HunyuanOCR](https://huggingface.co/tencent/HunyuanOCR) is a leading end-to-end OCR
+  expert VLM powered by Hunyuan's native multimodal architecture. This recipe covers
+  online serving with the OpenAI-compatible API.
+
+  ## Prerequisites
+
+  - **vLLM version:** latest stable
+  - **Hardware:** single GPU (1B model)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launching the Server
+
+  ```bash
+  vllm serve tencent/HunyuanOCR \
+      --no-enable-prefix-caching \
+      --mm-processor-cache-gb 0
+  ```
+
+  ### Configuration Tips
+
+  - Use greedy sampling (`temperature=0.0`) or low temperature for optimal OCR accuracy.
+  - OCR tasks generally do not benefit from prefix caching or image reuse; disabling
+    them (as above) removes hashing/caching overhead.
+  - Adjust `--max-num-batched-tokens` for throughput based on your hardware.
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  messages = [
+      {"role": "system", "content": ""},
+      {
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/chat-ui/tools-dark.png"}},
+              {
+                  "type": "text",
+                  "text": (
+                      "Extract all information from the main body of the document image "
+                      "and represent it in markdown format, ignoring headers and footers. "
+                      "Tables should be expressed in HTML format, formulas in the document "
+                      "should be represented using LaTeX format, and the parsing should be "
+                      "organized according to the reading order."
+                  )
+              }
+          ]
+      }
+  ]
+
+  response = client.chat.completions.create(
+      model="tencent/HunyuanOCR",
+      messages=messages,
+      temperature=0.0,
+      extra_body={"top_k": 1, "repetition_penalty": 1.0},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Troubleshooting
+
+  - **Accuracy:** Use `temperature=0.0` and `top_k=1` for deterministic OCR output.
+  - **Application-oriented prompts:** See the [official model card](https://huggingface.co/tencent/HunyuanOCR#%F0%9F%92%AC-application-oriented-prompts)
+    for prompts tuned to various document parsing tasks.
+
+  ## References
+
+  - [Model card](https://huggingface.co/tencent/HunyuanOCR)

--- a/models/tencent/HunyuanOCR.yaml
+++ b/models/tencent/HunyuanOCR.yaml
@@ -38,13 +38,7 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-4.5.yaml
+++ b/models/zai-org/GLM-4.5.yaml
@@ -10,12 +10,7 @@ meta:
   performance_headline: "GLM-4.X series MoE model with native FP8 and BF16 support and MTP speculative decoding"
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/zai-org/GLM-4.5.yaml
+++ b/models/zai-org/GLM-4.5.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "GLM-4.X series MoE model with native FP8 and BF16 support and MTP speculative decoding"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "zai-org/GLM-4.5"
@@ -64,13 +74,7 @@ compatible_strategies:
   - multi_node_dep
   - multi_node_tep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-4.5.yaml
+++ b/models/zai-org/GLM-4.5.yaml
@@ -1,0 +1,185 @@
+meta:
+  title: "GLM-4.5"
+  slug: "glm-4.5"
+  provider: "GLM (Z-AI)"
+  description: "GLM-4.5 MoE language model (~358B total parameters, BF16) with built-in MTP layers for speculative decoding and native tool calling"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "GLM-4.X series MoE model with native FP8 and BF16 support and MTP speculative decoding"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-4.5"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "358B"
+  active_parameters: "32B"
+  context_length: 131072
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "GLM-4.5 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "glm45"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "GLM-4.5 reasoning parser for chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "glm45"
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding using the model's built-in MTP layers"
+    args:
+      - "--speculative-config.method"
+      - "mtp"
+      - "--speculative-config.num_speculative_tokens"
+      - "1"
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 859
+    description: "Full precision BF16 on 8xH200 or equivalent"
+  fp8:
+    model_id: "zai-org/GLM-4.5-FP8"
+    precision: fp8
+    vram_minimum_gb: 430
+    description: "Native FP8 checkpoint with minimal accuracy loss — recommended for cost-efficient serving"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-4.5 is a Mixture-of-Experts language model from Z-AI with ~358B total parameters.
+  The checkpoint ships in both BF16 and native FP8 formats. FP8 models have minimal
+  accuracy loss, so unless you need strict reproducibility for benchmarking, FP8 is the
+  recommended precision for lower-cost serving. All GLM-4.X models include built-in
+  Multi-Token Prediction (MTP) layers that enable speculative decoding for higher
+  generation throughput.
+
+  ## Prerequisites
+
+  - **vLLM version:** >= 0.11.0 (latest stable recommended)
+  - **Hardware:** 8x H200 (BF16) or 4x-8x H200 (FP8), AMD MI300X / MI325X / MI355X for ROCm
+  - **Python:** 3.10 - 3.13 (3.12 required for ROCm wheels)
+
+  ### Install vLLM (NVIDIA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35.
+
+  ## Launching the Server
+
+  ### Tensor Parallel (FP8 on 8 GPUs)
+
+  ```bash
+  vllm serve zai-org/GLM-4.5-FP8 \
+      --tensor-parallel-size 8 \
+      --tool-call-parser glm45 \
+      --reasoning-parser glm45 \
+      --enable-auto-tool-choice
+  ```
+
+  ### Enabling MTP Speculative Decoding
+
+  ```bash
+  vllm serve zai-org/GLM-4.5-FP8 \
+      --tensor-parallel-size 4 \
+      --speculative-config.method mtp \
+      --speculative-config.num_speculative_tokens 1 \
+      --tool-call-parser glm45 \
+      --reasoning-parser glm45 \
+      --enable-auto-tool-choice
+  ```
+
+  Use `--speculative-config.num_speculative_tokens 1` for optimal throughput. Higher
+  values increase mean acceptance length but drop acceptance rate significantly.
+
+  ### Tuning Tips
+
+  - `--max-model-len=65536` works well for most scenarios; max is 128K.
+  - `--max-num-batched-tokens=32768` is a good default for prompt-heavy workloads.
+    Reduce to 16K/8K to cut activation memory and latency.
+  - Set `--gpu-memory-utilization=0.95` to maximize KV cache headroom.
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  resp = client.chat.completions.create(
+      model="zai-org/GLM-4.5-FP8",
+      messages=[{"role": "user", "content": "Explain MTP speculative decoding."}],
+      max_tokens=512,
+  )
+  print(resp.choices[0].message.content)
+  ```
+
+  ## Benchmarking
+
+  Disable prefix caching with `--no-enable-prefix-caching` on the server command,
+  then:
+
+  ```bash
+  vllm bench serve \
+    --model zai-org/GLM-4.5-FP8 \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos
+  ```
+
+  ## Troubleshooting
+
+  - **Tool calling not firing:** Ensure `--tool-call-parser glm45 --enable-auto-tool-choice`
+    are both present.
+  - **MTP memory overhead:** MTP adds memory for draft computations. Monitor GPU memory
+    and reduce `--max-model-len` or `--max-num-batched-tokens` if you OOM.
+  - **Low MTP acceptance:** If acceptance rate is below ~90%, drop speculative tokens to 1.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-4.5)
+  - [FP8 checkpoint](https://huggingface.co/zai-org/GLM-4.5-FP8)
+  - [vLLM docs](https://docs.vllm.ai/)

--- a/models/zai-org/GLM-4.5V.yaml
+++ b/models/zai-org/GLM-4.5V.yaml
@@ -12,13 +12,6 @@ meta:
   hardware:
     h100: verified
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "zai-org/GLM-4.5V"

--- a/models/zai-org/GLM-4.5V.yaml
+++ b/models/zai-org/GLM-4.5V.yaml
@@ -9,6 +9,16 @@ meta:
     - multimodal
   performance_headline: "Multimodal GLM-4.5V with native FP8 and expert parallelism, deploys on 4xH100"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "zai-org/GLM-4.5V"
@@ -64,12 +74,6 @@ compatible_strategies:
   - multi_node_dep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     # Requires transformers >= 5.0.0; see dependencies.
     extra_args:

--- a/models/zai-org/GLM-4.5V.yaml
+++ b/models/zai-org/GLM-4.5V.yaml
@@ -1,0 +1,174 @@
+meta:
+  title: "GLM-4.5V"
+  slug: "glm-4.5v"
+  provider: "GLM (Z-AI)"
+  description: "GLM-4.5 vision-language MoE model (~107B parameters, BF16) with image-text-to-text capability, 64K context, expert parallelism, and native FP8"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  performance_headline: "Multimodal GLM-4.5V with native FP8 and expert parallelism, deploys on 4xH100"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-4.5V"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "107B"
+  active_parameters: "12B"
+  context_length: 65536
+  base_args:
+    - "--trust-remote-code"
+    - "--enable-expert-parallel"
+    - "--allowed-local-media-path"
+    - "/"
+    - "--mm-encoder-tp-mode"
+    - "data"
+    - "--mm-processor-cache-type"
+    - "shm"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "GLM-4.5 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "glm45"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "GLM-4.5 reasoning parser"
+    args:
+      - "--reasoning-parser"
+      - "glm45"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 257
+    description: "Full precision BF16 — runs on 4xH100/H200"
+  fp8:
+    model_id: "zai-org/GLM-4.5V-FP8"
+    precision: fp8
+    vram_minimum_gb: 128
+    description: "Native FP8 checkpoint with minimal accuracy loss — recommended for cost-efficient serving"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    # Requires transformers >= 5.0.0; see dependencies.
+    extra_args:
+      - "--mm-encoder-tp-mode"
+      - "data"
+      - "--allowed-local-media-path"
+      - "/"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      SAFETENSORS_FAST_GPU: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-4.5V is the vision-language variant of GLM-4.5. It is an MoE model with ~107B
+  total parameters that accepts image and text inputs. FP8 models have minimal accuracy
+  loss versus BF16 and are recommended for cost-efficient serving. GLM-4.5V supports a
+  64K context length (use GLM-4.6V for 128K).
+
+  ## Prerequisites
+
+  - **vLLM version:** >= 0.12.0
+  - **Hardware:** 4x H100/H200 (BF16 or FP8)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launching the Server
+
+  ### Tensor Parallel + Expert Parallel (FP8 on 4 GPUs)
+
+  ```bash
+  vllm serve zai-org/GLM-4.5V-FP8 \
+       --tensor-parallel-size 4 \
+       --tool-call-parser glm45 \
+       --reasoning-parser glm45 \
+       --enable-auto-tool-choice \
+       --enable-expert-parallel \
+       --allowed-local-media-path / \
+       --mm-encoder-tp-mode data \
+       --mm-processor-cache-type shm
+  ```
+
+  ### Tuning Tips
+
+  - `--max-model-len=65536` is near the model's max context (64K).
+  - `--max-num-batched-tokens=32768` for prompt-heavy workloads.
+  - `--gpu-memory-utilization=0.95` maximizes KV cache.
+  - `--mm-encoder-tp-mode data` runs the vision encoder data-parallel — preferable to TP
+    since the encoder is small and TP adds communication overhead.
+  - `--mm-processor-cache-type shm` enables shared-memory caching for repeated image inputs.
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  resp = client.chat.completions.create(
+      model="zai-org/GLM-4.5V-FP8",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+              {"type": "text", "text": "Describe the image."}
+          ]
+      }],
+      max_tokens=512,
+  )
+  print(resp.choices[0].message.content)
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --backend openai-chat \
+    --endpoint /v1/chat/completions \
+    --model zai-org/GLM-4.5V-FP8 \
+    --dataset-name hf \
+    --dataset-path lmarena-ai/VisionArena-Chat \
+    --num-prompts 1000 \
+    --request-rate 20
+  ```
+
+  ## Troubleshooting
+
+  - **Vision encoder overhead:** Use `--mm-encoder-tp-mode data` unless TP-sharded encoder is known-good for your config.
+  - **Context length errors:** GLM-4.5V max is 64K; use GLM-4.6V if you need 128K.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-4.5V)
+  - [FP8 checkpoint](https://huggingface.co/zai-org/GLM-4.5V-FP8)
+  - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html)

--- a/models/zai-org/GLM-4.6.yaml
+++ b/models/zai-org/GLM-4.6.yaml
@@ -10,12 +10,7 @@ meta:
   performance_headline: "Updated GLM-4.X series MoE model with native FP8 and BF16, MTP speculative decoding"
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/zai-org/GLM-4.6.yaml
+++ b/models/zai-org/GLM-4.6.yaml
@@ -1,0 +1,172 @@
+meta:
+  title: "GLM-4.6"
+  slug: "glm-4.6"
+  provider: "GLM (Z-AI)"
+  description: "GLM-4.6 MoE language model (~357B total parameters, BF16) with MTP speculative decoding, native tool calling and reasoning"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Updated GLM-4.X series MoE model with native FP8 and BF16, MTP speculative decoding"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-4.6"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "357B"
+  active_parameters: "32B"
+  context_length: 202752
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "GLM-4.5 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "glm45"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "GLM-4.5 reasoning parser for chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "glm45"
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding using the model's built-in MTP layers"
+    args:
+      - "--speculative-config.method"
+      - "mtp"
+      - "--speculative-config.num_speculative_tokens"
+      - "1"
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 857
+    description: "Full precision BF16 on 8xH200 or equivalent"
+  fp8:
+    model_id: "zai-org/GLM-4.6-FP8"
+    precision: fp8
+    vram_minimum_gb: 428
+    description: "Native FP8 checkpoint with minimal accuracy loss — recommended for cost-efficient serving"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-4.6 is the successor to GLM-4.5 with ~357B total parameters. It retains the
+  MoE architecture and built-in Multi-Token Prediction (MTP) layers used for
+  speculative decoding. FP8 is the recommended precision for cost-efficient
+  serving with minimal accuracy loss relative to BF16.
+
+  ## Prerequisites
+
+  - **vLLM version:** >= 0.11.0 (latest stable recommended)
+  - **Hardware:** 8x H200 (BF16) or 4x-8x H200 (FP8), AMD MI300X / MI325X / MI355X for ROCm
+  - **Python:** 3.10 - 3.13 (3.12 required for ROCm wheels)
+
+  ### Install vLLM (NVIDIA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  ## Launching the Server
+
+  ### Tensor Parallel (FP8)
+
+  ```bash
+  vllm serve zai-org/GLM-4.6-FP8 \
+      --tensor-parallel-size 8 \
+      --tool-call-parser glm45 \
+      --reasoning-parser glm45 \
+      --enable-auto-tool-choice
+  ```
+
+  ### Enabling MTP Speculative Decoding
+
+  ```bash
+  vllm serve zai-org/GLM-4.6-FP8 \
+      --tensor-parallel-size 4 \
+      --speculative-config.method mtp \
+      --speculative-config.num_speculative_tokens 1 \
+      --tool-call-parser glm45 \
+      --reasoning-parser glm45 \
+      --enable-auto-tool-choice
+  ```
+
+  ### Tuning Tips
+
+  - `--max-model-len=65536` works well for most scenarios; max is 128K.
+  - `--max-num-batched-tokens=32768` is a good default for prompt-heavy workloads.
+  - `--gpu-memory-utilization=0.95` maximizes KV cache headroom.
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  resp = client.chat.completions.create(
+      model="zai-org/GLM-4.6-FP8",
+      messages=[{"role": "user", "content": "Summarize MTP speculative decoding."}],
+      max_tokens=512,
+  )
+  print(resp.choices[0].message.content)
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model zai-org/GLM-4.6-FP8 \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos
+  ```
+
+  ## Troubleshooting
+
+  - **MTP memory overhead:** Monitor GPU memory and tune batch size when enabling MTP.
+  - **Tool calling not firing:** Ensure `--tool-call-parser glm45 --enable-auto-tool-choice`
+    are both present.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-4.6)
+  - [FP8 checkpoint](https://huggingface.co/zai-org/GLM-4.6-FP8)
+  - [vLLM docs](https://docs.vllm.ai/)

--- a/models/zai-org/GLM-4.6.yaml
+++ b/models/zai-org/GLM-4.6.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Updated GLM-4.X series MoE model with native FP8 and BF16, MTP speculative decoding"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "zai-org/GLM-4.6"
@@ -64,13 +74,7 @@ compatible_strategies:
   - multi_node_dep
   - multi_node_tep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-4.6V.yaml
+++ b/models/zai-org/GLM-4.6V.yaml
@@ -9,6 +9,16 @@ meta:
     - multimodal
   performance_headline: "Updated GLM-V series with 128K context length and native FP8"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: supported
+    mi325x: supported
+    mi355x: supported
 
 model:
   model_id: "zai-org/GLM-4.6V"
@@ -64,12 +74,6 @@ compatible_strategies:
   - multi_node_dep
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
   amd:
     extra_args:
       - "--mm-encoder-tp-mode"

--- a/models/zai-org/GLM-4.6V.yaml
+++ b/models/zai-org/GLM-4.6V.yaml
@@ -12,13 +12,6 @@ meta:
   hardware:
     h100: verified
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
-    mi300x: supported
-    mi325x: supported
-    mi355x: supported
 
 model:
   model_id: "zai-org/GLM-4.6V"

--- a/models/zai-org/GLM-4.6V.yaml
+++ b/models/zai-org/GLM-4.6V.yaml
@@ -1,0 +1,169 @@
+meta:
+  title: "GLM-4.6V"
+  slug: "glm-4.6v"
+  provider: "GLM (Z-AI)"
+  description: "GLM-4.6 vision-language MoE model — image-text-to-text with 128K context, native FP8 checkpoint, and expert parallelism"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  performance_headline: "Updated GLM-V series with 128K context length and native FP8"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-4.6V"
+  min_vllm_version: "0.12.0"
+  architecture: moe
+  parameter_count: "107B"
+  active_parameters: "12B"
+  context_length: 131072
+  base_args:
+    - "--trust-remote-code"
+    - "--enable-expert-parallel"
+    - "--allowed-local-media-path"
+    - "/"
+    - "--mm-encoder-tp-mode"
+    - "data"
+    - "--mm-processor-cache-type"
+    - "shm"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "GLM-4.5 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "glm45"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "GLM-4.5 reasoning parser"
+    args:
+      - "--reasoning-parser"
+      - "glm45"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 257
+    description: "Full precision BF16 — runs on 4xH100/H200"
+  fp8:
+    model_id: "zai-org/GLM-4.6V-FP8"
+    precision: fp8
+    vram_minimum_gb: 128
+    description: "Native FP8 checkpoint with minimal accuracy loss"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+  amd:
+    extra_args:
+      - "--mm-encoder-tp-mode"
+      - "data"
+      - "--allowed-local-media-path"
+      - "/"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      SAFETENSORS_FAST_GPU: "1"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-4.6V is an updated vision-language MoE model from Z-AI. It supports a 128K
+  context length (vs 64K for GLM-4.5V). Native FP8 is recommended for cost-efficient
+  serving, matching BF16 accuracy to within a small margin.
+
+  ## Prerequisites
+
+  - **vLLM version:** >= 0.12.0
+  - **Hardware:** 4x H100/H200 (BF16 or FP8)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Launching the Server
+
+  ### Tensor Parallel + Expert Parallel (FP8 on 4 GPUs)
+
+  ```bash
+  vllm serve zai-org/GLM-4.6V-FP8 \
+       --tensor-parallel-size 4 \
+       --tool-call-parser glm45 \
+       --reasoning-parser glm45 \
+       --enable-auto-tool-choice \
+       --enable-expert-parallel \
+       --allowed-local-media-path / \
+       --mm-encoder-tp-mode data \
+       --mm-processor-cache-type shm
+  ```
+
+  ### Tuning Tips
+
+  - `--max-model-len=65536` is a common default; you can push to 131072.
+  - `--max-num-batched-tokens=32768` for prompt-heavy workloads.
+  - `--mm-encoder-tp-mode data` + `--mm-processor-cache-type shm` for efficient vision processing.
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  resp = client.chat.completions.create(
+      model="zai-org/GLM-4.6V-FP8",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+              {"type": "text", "text": "Describe the image."}
+          ]
+      }],
+      max_tokens=512,
+  )
+  print(resp.choices[0].message.content)
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --backend openai-chat \
+    --endpoint /v1/chat/completions \
+    --model zai-org/GLM-4.6V-FP8 \
+    --dataset-name hf \
+    --dataset-path lmarena-ai/VisionArena-Chat \
+    --num-prompts 1000 \
+    --request-rate 20
+  ```
+
+  ## Troubleshooting
+
+  - **Vision encoder overhead:** Prefer `--mm-encoder-tp-mode data` over TP for the encoder.
+  - **Long-context memory:** At 128K context, tune `--max-num-batched-tokens` and
+    `--gpu-memory-utilization` to prevent OOM.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-4.6V)
+  - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html)

--- a/models/zai-org/GLM-4.7.yaml
+++ b/models/zai-org/GLM-4.7.yaml
@@ -9,6 +9,16 @@ meta:
     - text
   performance_headline: "Latest GLM-4.X release with updated glm47 tool call parser and MTP speculative decoding"
   related_recipes: []
+  hardware:
+    h100: supported
+    h200: verified
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "zai-org/GLM-4.7"
@@ -80,13 +90,7 @@ compatible_strategies:
   - multi_node_dep
   - multi_node_tep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-4.7.yaml
+++ b/models/zai-org/GLM-4.7.yaml
@@ -10,12 +10,7 @@ meta:
   performance_headline: "Latest GLM-4.X release with updated glm47 tool call parser and MTP speculative decoding"
   related_recipes: []
   hardware:
-    h100: supported
     h200: verified
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
     mi355x: verified

--- a/models/zai-org/GLM-4.7.yaml
+++ b/models/zai-org/GLM-4.7.yaml
@@ -1,0 +1,194 @@
+meta:
+  title: "GLM-4.7"
+  slug: "glm-4.7"
+  provider: "GLM (Z-AI)"
+  description: "GLM-4.7 MoE language model (~358B total parameters) with MTP speculative decoding, updated tool call parser, and reasoning support"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Latest GLM-4.X release with updated glm47 tool call parser and MTP speculative decoding"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-4.7"
+  min_vllm_version: "0.11.0"
+  architecture: moe
+  parameter_count: "358B"
+  active_parameters: "32B"
+  context_length: 202752
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+dependencies:
+  - note: "GLM-4.7 requires the nightly vllm wheel"
+    command: "uv pip install -U vllm --pre --extra-index-url https://wheels.vllm.ai/nightly"
+  - note: "transformers from source — GLM-4.7 tokenizer is newer than any release"
+    command: "uv pip install git+https://github.com/huggingface/transformers.git"
+
+features:
+  tool_calling:
+    description: "GLM-4.7 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "glm47"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "GLM-4.5 reasoning parser for chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "glm45"
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding using the model's built-in MTP layers"
+    args:
+      - "--speculative-config.method"
+      - "mtp"
+      - "--speculative-config.num_speculative_tokens"
+      - "1"
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 859
+    description: "Full precision BF16 on 8xH200 or equivalent"
+  fp8:
+    model_id: "zai-org/GLM-4.7-FP8"
+    precision: fp8
+    vram_minimum_gb: 430
+    description: "Native FP8 checkpoint with minimal accuracy loss"
+  nvfp4:
+    model_id: "nvidia/GLM-4.7-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 215
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_dep
+  - multi_node_tep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-4.7 is the latest GLM-4.X MoE release from Z-AI. It introduces the `glm47`
+  tool call parser while retaining the GLM-4.5 reasoning parser. Built-in
+  Multi-Token Prediction (MTP) layers enable speculative decoding for throughput
+  gains on decode-heavy workloads.
+
+  A smaller `zai-org/GLM-4.7-Flash` variant is also available for lower-latency
+  scenarios.
+
+  ## Prerequisites
+
+  - **vLLM version:** nightly recommended for GLM-4.7 (until packaged in a stable release)
+  - **Hardware:** 4x-8x H200 (FP8), AMD MI300X / MI325X / MI355X for ROCm
+  - **Python:** 3.10 - 3.13 (3.12 required for ROCm wheels)
+
+  ### Install vLLM (NVIDIA, nightly)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --pre --extra-index-url https://wheels.vllm.ai/nightly
+  uv pip install git+https://github.com/huggingface/transformers.git
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  ## Launching the Server
+
+  ### Tensor Parallel + MTP (FP8 on 4xH200)
+
+  ```bash
+  vllm serve zai-org/GLM-4.7-FP8 \
+      --tensor-parallel-size 4 \
+      --speculative-config.method mtp \
+      --speculative-config.num_speculative_tokens 1 \
+      --tool-call-parser glm47 \
+      --reasoning-parser glm45 \
+      --enable-auto-tool-choice
+  ```
+
+  ### AMD ROCm
+
+  ```bash
+  SAFETENSORS_FAST_GPU=1 \
+  vllm serve zai-org/GLM-4.7 \
+      --tensor-parallel-size 8 \
+      --gpu-memory-utilization 0.9 \
+      --disable-log-requests \
+      --no-enable-prefix-caching \
+      --trust-remote-code
+  ```
+
+  ### Tuning Tips
+
+  - `--max-model-len=65536` is a sensible default; max is 128K.
+  - `--max-num-batched-tokens=32768` for prompt-heavy workloads; reduce to 8K-16K for latency-sensitive.
+  - Use `--gpu-memory-utilization=0.95` to maximize KV cache.
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  resp = client.chat.completions.create(
+      model="zai-org/GLM-4.7-FP8",
+      messages=[{"role": "user", "content": "Hello!"}],
+      max_tokens=512,
+  )
+  print(resp.choices[0].message.content)
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model zai-org/GLM-4.7-FP8 \
+    --dataset-name random \
+    --random-input-len 8000 \
+    --random-output-len 1000 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos
+  ```
+
+  ## Troubleshooting
+
+  - **Parser mismatch:** GLM-4.7 uses `--tool-call-parser glm47` (not `glm45`).
+  - **MTP acceptance:** 1 speculative token gives ~90%+ acceptance and best throughput.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-4.7)
+  - [FP8 checkpoint](https://huggingface.co/zai-org/GLM-4.7-FP8)
+  - [GLM-4.7-Flash](https://huggingface.co/zai-org/GLM-4.7-Flash)
+  - [vLLM docs](https://docs.vllm.ai/)

--- a/models/zai-org/GLM-5.1.yaml
+++ b/models/zai-org/GLM-5.1.yaml
@@ -13,6 +13,7 @@ meta:
 model:
   model_id: "zai-org/GLM-5.1"
   min_vllm_version: "0.19.0"
+  docker_image: "vllm/vllm-openai:glm51"
   architecture: moe
   parameter_count: "744B"
   active_parameters: "40B"

--- a/models/zai-org/GLM-5.1.yaml
+++ b/models/zai-org/GLM-5.1.yaml
@@ -64,13 +64,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-5.1.yaml
+++ b/models/zai-org/GLM-5.1.yaml
@@ -1,0 +1,202 @@
+meta:
+  title: "GLM-5.1"
+  slug: "glm-5.1"
+  provider: "GLM (Z-AI)"
+  description: "GLM-5.1 refreshed version of GLM-5 — frontier-scale MoE language model (~744B total parameters) with MTP speculative decoding and thinking mode"
+  date_updated: 2026-04-17
+  difficulty: advanced
+  tasks:
+    - text
+  performance_headline: "Refreshed GLM-5 series MoE with improved reasoning, coding, and agentic performance"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-5.1"
+  min_vllm_version: "0.19.0"
+  architecture: moe
+  parameter_count: "744B"
+  active_parameters: "40B"
+  context_length: 202752
+  base_args:
+    - "--trust-remote-code"
+    - "--chat-template-content-format=string"
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "GLM-4.7 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "glm47"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "GLM-4.5 reasoning parser — thinking mode enabled by default on requests"
+    args:
+      - "--reasoning-parser"
+      - "glm45"
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding (3 draft tokens)"
+    args:
+      - "--speculative-config.method"
+      - "mtp"
+      - "--speculative-config.num_speculative_tokens"
+      - "3"
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 1786
+    description: "Full precision BF16 — requires multi-node deployment"
+  fp8:
+    model_id: "zai-org/GLM-5.1-FP8"
+    precision: fp8
+    vram_minimum_gb: 893
+    description: "Native FP8 checkpoint — 8xH200/H20 (141GB × 8) single-node serving"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-5.1 is a refreshed version of GLM-5, the 744B parameter frontier MoE model from Z-AI.
+  It keeps the asynchronous RL training recipe and delivers best-in-class open-source
+  performance on reasoning, coding, and agentic benchmarks. Both BF16 and native FP8
+  checkpoints are published.
+
+  Thinking mode is enabled by default; disable it by passing
+  `"chat_template_kwargs": {"enable_thinking": false}` in request extras.
+
+  ## Prerequisites
+
+  - **vLLM version:** 0.19.0 (stable — preferred over nightly for model performance).
+    Use the latest main branch if you need tool calling + MTP simultaneously.
+  - **Hardware (FP8):** 8xH200 or 8xH20 (141GB × 8)
+  - **DeepGEMM (FP8):** install via `install_deepgemm.sh` from vLLM repo
+
+  ### Using Docker
+
+  ```bash
+  docker run --gpus all \
+    -p 8000:8000 \
+    --ipc=host \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:glm51 zai-org/GLM-5.1-FP8 \
+      --tensor-parallel-size 8 \
+      --tool-call-parser glm47 \
+      --reasoning-parser glm45 \
+      --enable-auto-tool-choice \
+      --chat-template-content-format=string \
+      --served-model-name glm-5.1-fp8
+  ```
+
+  Use `vllm/vllm-openai:glm51-cu130` for CUDA 13+.
+
+  ### Install vLLM from Source
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install "vllm==0.19.0" --torch-backend=auto
+  uv pip install "transformers>=5.4.0"
+  ```
+
+  ## Launching the Server
+
+  ### FP8 on 8xH200 with MTP
+
+  ```bash
+  vllm serve zai-org/GLM-5.1-FP8 \
+       --tensor-parallel-size 8 \
+       --speculative-config.method mtp \
+       --speculative-config.num_speculative_tokens 3 \
+       --tool-call-parser glm47 \
+       --reasoning-parser glm45 \
+       --enable-auto-tool-choice \
+       --chat-template-content-format=string \
+       --served-model-name glm-5.1-fp8
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+
+  # Thinking ON (default)
+  resp_on = client.chat.completions.create(
+      model="glm-5.1-fp8",
+      messages=[{"role": "user", "content": "Summarize GLM-5.1 in one sentence."}],
+      temperature=1,
+      max_tokens=4096,
+  )
+  print(resp_on.choices[0].message.reasoning)
+
+  # Thinking OFF
+  resp_off = client.chat.completions.create(
+      model="glm-5.1-fp8",
+      messages=[{"role": "user", "content": "Summarize GLM-5.1 in one sentence."}],
+      temperature=1,
+      max_tokens=4096,
+      extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+  )
+  ```
+
+  ### cURL (Thinking ON)
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "glm-5.1-fp8",
+      "messages": [
+        {"role": "user", "content": "Summarize GLM-5.1 in one sentence."}
+      ],
+      "temperature": 1,
+      "max_tokens": 4096
+    }'
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model zai-org/GLM-5.1-FP8 \
+    --dataset-name random \
+    --random-input 8000 \
+    --random-output 1024 \
+    --request-rate 10 \
+    --num-prompts 32 \
+    --ignore-eos
+  ```
+
+  ## Troubleshooting
+
+  - **Accuracy drift:** Prefer the 0.19.0 stable release for best accuracy.
+  - **Tool calling + MTP:** If both are needed, use the latest vLLM main branch.
+  - **FP8 installation:** DeepGEMM required for FP8 performance.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-5.1)
+  - [FP8 checkpoint](https://huggingface.co/zai-org/GLM-5.1-FP8)
+  - [DeepGEMM install script](https://github.com/vllm-project/vllm/blob/v0.16.0rc0/tools/install_deepgemm.sh)

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -83,13 +83,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -13,6 +13,7 @@ meta:
 model:
   model_id: "zai-org/GLM-5"
   min_vllm_version: "0.16.0"
+  docker_image: "vllm/vllm-openai:glm51"
   architecture: moe
   parameter_count: "744B"
   active_parameters: "40B"

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -1,0 +1,210 @@
+meta:
+  title: "GLM-5"
+  slug: "glm-5"
+  provider: "GLM (Z-AI)"
+  description: "GLM-5 frontier-scale MoE language model (~744B total parameters, 28.5T training tokens) with asynchronous RL infrastructure for reasoning, coding, and agentic tasks"
+  date_updated: 2026-04-17
+  difficulty: advanced
+  tasks:
+    - text
+  performance_headline: "Frontier-scale MoE with 744B parameters, best-in-class open-source performance on reasoning/coding/agents"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-5"
+  min_vllm_version: "0.16.0"
+  architecture: moe
+  parameter_count: "744B"
+  active_parameters: "40B"
+  context_length: 202752
+  base_args:
+    - "--trust-remote-code"
+    - "--chat-template-content-format=string"
+  base_env: {}
+
+dependencies:
+  - note: "Pin vllm==0.19.0 (avoid nightly)"
+    command: 'uv pip install "vllm==0.19.0" --torch-backend=auto'
+  - note: "GLM-5 requires transformers >= 5.4.0"
+    command: 'uv pip install "transformers>=5.4.0"'
+  - note: "Optional: DeepGEMM for FP8 MoE kernels (FP8 variant only)"
+    command: "bash install_deepgemm.sh"
+    optional: true
+
+features:
+  tool_calling:
+    description: "GLM-4.7 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "glm47"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "GLM-4.5 reasoning parser — thinking mode enabled by default on requests"
+    args:
+      - "--reasoning-parser"
+      - "glm45"
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding (3 draft tokens)"
+    args:
+      - "--speculative-config.method"
+      - "mtp"
+      - "--speculative-config.num_speculative_tokens"
+      - "3"
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 1786
+    description: "Full precision BF16 — requires multi-node deployment"
+  fp8:
+    model_id: "zai-org/GLM-5-FP8"
+    precision: fp8
+    vram_minimum_gb: 893
+    description: "Native FP8 checkpoint — 8xH200/H20 (141GB x 8) single-node serving"
+  nvfp4:
+    model_id: "nvidia/GLM-5-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 446
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - multi_node_tp
+  - multi_node_tp_pp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-5 is a significantly scaled-up language model with 744B parameters, trained on
+  28.5T tokens using novel asynchronous RL infrastructure. It delivers best-in-class
+  open-source performance on reasoning, coding, and agentic tasks, rivaling frontier
+  closed-source models. GLM-5 is available in both BF16 and native FP8 precisions.
+
+  Thinking mode is enabled by default; disable it by passing
+  `"chat_template_kwargs": {"enable_thinking": false}` in request extras.
+
+  ## Prerequisites
+
+  - **vLLM version:** 0.19.0 (stable — preferred over nightly for model performance)
+  - **Hardware (FP8):** 8xH200 or 8xH20 (141GB × 8)
+  - **DeepGEMM (FP8):** install via `install_deepgemm.sh` from the vLLM repo
+
+  ### Using Docker
+
+  ```bash
+  docker run --gpus all \
+    -p 8000:8000 \
+    --ipc=host \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:glm51 zai-org/GLM-5-FP8 \
+      --tensor-parallel-size 8 \
+      --tool-call-parser glm47 \
+      --reasoning-parser glm45 \
+      --enable-auto-tool-choice \
+      --chat-template-content-format=string
+  ```
+
+  Use `vllm/vllm-openai:glm51-cu130` for CUDA 13+.
+
+  ### Install vLLM from Source
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install "vllm==0.19.0" --torch-backend=auto
+  uv pip install "transformers>=5.4.0"
+  ```
+
+  Install DeepGEMM using `install_deepgemm.sh` from the vLLM tools directory.
+
+  ## Launching the Server
+
+  ### FP8 on 8xH200 with MTP
+
+  ```bash
+  vllm serve zai-org/GLM-5-FP8 \
+       --tensor-parallel-size 8 \
+       --speculative-config.method mtp \
+       --speculative-config.num_speculative_tokens 3 \
+       --tool-call-parser glm47 \
+       --reasoning-parser glm45 \
+       --enable-auto-tool-choice \
+       --chat-template-content-format=string \
+       --served-model-name glm-5-fp8
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+
+  # Thinking ON (default)
+  resp_on = client.chat.completions.create(
+      model="glm-5-fp8",
+      messages=[{"role": "user", "content": "Summarize GLM-5 in one sentence."}],
+      temperature=1,
+      max_tokens=4096,
+  )
+  print("thinking=on, think content:\n", resp_on.choices[0].message.reasoning)
+
+  # Thinking OFF
+  resp_off = client.chat.completions.create(
+      model="glm-5-fp8",
+      messages=[{"role": "user", "content": "Summarize GLM-5 in one sentence."}],
+      temperature=1,
+      max_tokens=4096,
+      extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+  )
+  print("thinking=off:\n", resp_off.choices[0].message.reasoning)
+  ```
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model zai-org/GLM-5-FP8 \
+    --dataset-name random \
+    --random-input 8000 \
+    --random-output 1024 \
+    --request-rate 10 \
+    --num-prompts 32 \
+    --ignore-eos
+  ```
+
+  The MTP acceptance rate can be relatively low in pure benchmarks; measured throughput
+  may underestimate real-world speed.
+
+  ## Troubleshooting
+
+  - **Accuracy drift:** Prefer the 0.19.0 stable release over nightly for best accuracy.
+  - **Tool calling + MTP:** If you need both, use the latest vLLM main branch.
+  - **FP8 installation:** DeepGEMM is required for FP8 performance.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-5)
+  - [FP8 checkpoint](https://huggingface.co/zai-org/GLM-5-FP8)
+  - [DeepGEMM install script](https://github.com/vllm-project/vllm/blob/v0.16.0rc0/tools/install_deepgemm.sh)

--- a/models/zai-org/GLM-ASR-Nano-2512.yaml
+++ b/models/zai-org/GLM-ASR-Nano-2512.yaml
@@ -41,13 +41,7 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-ASR-Nano-2512.yaml
+++ b/models/zai-org/GLM-ASR-Nano-2512.yaml
@@ -1,0 +1,173 @@
+meta:
+  title: "GLM-ASR-Nano-2512"
+  slug: "glm-asr-nano-2512"
+  provider: "GLM (Z-AI)"
+  description: "Open-source speech recognition model (~2B) with strong dialect support (Cantonese and others) and robust low-volume speech transcription"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - multimodal
+  performance_headline: "Outperforms Whisper V3 on multiple benchmarks at compact 1.5B active / 2B total size"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-ASR-Nano-2512"
+  min_vllm_version: "0.14.1"
+  architecture: dense
+  parameter_count: "2.3B"
+  active_parameters: "1.5B"
+  context_length: 8192
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "Audio extras required for ASR (requires vllm>=0.14.1)"
+    command: 'uv pip install -U "vllm[audio]" --torch-backend auto'
+  - note: "Install transformers from source for GLM-ASR tokenizer support"
+    command: "uv pip install git+https://github.com/huggingface/transformers.git"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 11
+    description: "Full precision BF16 — single-GPU deployment"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-ASR-Nano-2512 is an open-source automatic speech recognition model with 1.5B
+  active parameters (2B total). It outperforms OpenAI Whisper V3 on multiple benchmarks
+  while remaining compact enough for single-GPU deployment.
+
+  ### Key Capabilities
+
+  - **Dialect support:** Beyond standard Mandarin and English, strong on Cantonese
+    (粤语) and other Chinese dialects.
+  - **Low-volume speech:** Specifically trained for "whisper/quiet speech" scenarios.
+  - **SOTA accuracy:** Lowest average error rate (4.10) among comparable open-source
+    models, strong on Wenet Meeting, Aishell-1, and similar Chinese benchmarks.
+
+  ## Prerequisites
+
+  - **vLLM version:** >= 0.14.1 (with `[audio]` extras)
+  - **Transformers:** install from source for latest
+
+  ### Install Dependencies
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install git+https://github.com/huggingface/transformers.git
+  uv pip install -U "vllm[audio]" --torch-backend auto
+  ```
+
+  ## Launching the Server
+
+  ```bash
+  vllm serve zai-org/GLM-ASR-Nano-2512
+  ```
+
+  ## Client Usage
+
+  ### OpenAI SDK (Audio URL)
+
+  ```python
+  import base64
+  import httpx
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+  audio_url = "https://github.com/zai-org/GLM-ASR/raw/main/examples/example_en.wav"
+  audio_data = base64.b64encode(httpx.get(audio_url).content).decode("utf-8")
+
+  response = client.chat.completions.create(
+      model="zai-org/GLM-ASR-Nano-2512",
+      messages=[{
+          "role": "user",
+          "content": [{
+              "type": "input_audio",
+              "input_audio": {"data": audio_data, "format": "wav"}
+          }]
+      }],
+      max_tokens=500,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### Transcribe Endpoint
+
+  ```python
+  import httpx
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+  audio_file = httpx.get("https://github.com/zai-org/GLM-ASR/raw/main/examples/example_en.wav").content
+
+  response = client.audio.transcriptions.create(
+      model="zai-org/GLM-ASR-Nano-2512",
+      file=("audio.wav", audio_file),
+  )
+  print(response.text)
+  ```
+
+  ### cURL (Transcribe)
+
+  ```bash
+  curl http://localhost:8000/v1/audio/transcriptions \
+    -H "Authorization: Bearer EMPTY" \
+    -F "model=zai-org/GLM-ASR-Nano-2512" \
+    -F "file=@your_audio.wav"
+  ```
+
+  ### Local Audio File (chat API)
+
+  ```python
+  import base64
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+  with open("your_audio.mp3", "rb") as f:
+      audio_data = base64.b64encode(f.read()).decode("utf-8")
+
+  response = client.chat.completions.create(
+      model="zai-org/GLM-ASR-Nano-2512",
+      messages=[{
+          "role": "user",
+          "content": [{"type": "input_audio", "input_audio": {"data": audio_data, "format": "mp3"}}]
+      }],
+      max_tokens=500,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Troubleshooting
+
+  - **Transformers version:** Requires `transformers >= 5.0.0` for best compatibility.
+  - **Audio formats:** Supports wav, mp3, flac, and other common formats.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-ASR-Nano-2512)
+  - [GitHub repo](https://github.com/zai-org/GLM-ASR)

--- a/models/zai-org/GLM-Image.yaml
+++ b/models/zai-org/GLM-Image.yaml
@@ -1,0 +1,187 @@
+meta:
+  title: "GLM-Image"
+  slug: "glm-image"
+  provider: "GLM (Z-AI)"
+  description: "Hybrid autoregressive + diffusion image generation model — text-to-image and image-to-image with strong text rendering and knowledge-intensive generation"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  performance_headline: "9B AR generator + 7B DiT decoder, state-of-the-art text rendering in generated images"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-Image"
+  min_vllm_version: "0.11.0"
+  architecture: dense
+  parameter_count: "16B"
+  active_parameters: "16B"
+  context_length: 4096
+  base_args:
+    - "--omni"
+    - "--trust-remote-code"
+  base_env: {}
+
+dependencies:
+  - note: "vllm-omni provides the diffusion decoder path"
+    command: "uv pip install vllm-omni"
+  - note: "transformers from source (GLM-Image tokenizer)"
+    command: "uv pip install git+https://github.com/huggingface/transformers.git"
+  - note: "diffusers from source — required for the DiT decoder"
+    command: "uv pip install git+https://github.com/huggingface/diffusers.git"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 38
+    description: "Single-GPU deployment (~33 GB for model weights, plus activation headroom)"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-Image is an image generation model with a hybrid architecture:
+
+  - **Autoregressive Generator (9B):** initialized from GLM-4-9B-0414 with an expanded
+    vocabulary for visual tokens. Produces a compact encoding (~256 tokens), then
+    expands to 1K–4K tokens corresponding to 1K–2K resolution images.
+  - **Diffusion Decoder (7B):** single-stream DiT that decodes latents into pixels.
+    Includes a Glyph Encoder text module for accurate in-image text rendering.
+
+  Served via vLLM-Omni for OpenAI-compatible online inference.
+
+  ### Key Capabilities
+
+  - Text-to-image and image-to-image (editing, style transfer, identity-preserving)
+  - Exceptional text rendering inside generated images
+  - Strong knowledge-intensive generation
+
+  ## Prerequisites
+
+  - **vLLM version:** latest (with `vllm-omni` extension)
+  - **Transformers:** >= 5.0.0 (use source install for latest)
+  - **Hardware:** single H100-class GPU (approx. 33 GB for weights)
+
+  ### Install Dependencies
+
+  ```bash
+  uv venv --python 3.12 --seed
+  source .venv/bin/activate
+
+  uv pip install -U vllm --torch-backend auto
+  uv pip install vllm-omni
+
+  pip install git+https://github.com/huggingface/transformers.git
+  pip install git+https://github.com/huggingface/diffusers.git
+  ```
+
+  ## Online Serving
+
+  ```bash
+  vllm serve zai-org/GLM-Image --omni
+  ```
+
+  ## Client Usage
+
+  ### OpenAI SDK (Text-to-Image)
+
+  ```python
+  import base64
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+  response = client.chat.completions.create(
+      model="zai-org/GLM-Image",
+      messages=[{"role": "user", "content": "A beautiful landscape painting with mountains and a lake at sunset"}],
+  )
+
+  image_url = response.choices[0].message.content[0].image_url.url
+  image_data = base64.b64decode(image_url.split(",")[1])
+  with open("output.png", "wb") as f:
+      f.write(image_data)
+  ```
+
+  ### cURL (Text-to-Image)
+
+  ```bash
+  curl -s http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "messages": [{"role": "user", "content": "A beautiful landscape painting"}]
+    }' | jq -r '.choices[0].message.content[0].image_url.url' | cut -d',' -f2- | base64 -d > output.png
+  ```
+
+  ### Image-to-Image
+
+  ```python
+  import base64
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+  with open("input.png", "rb") as f:
+      image_base64 = base64.b64encode(f.read()).decode("utf-8")
+
+  response = client.chat.completions.create(
+      model="zai-org/GLM-Image",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{image_base64}"}},
+              {"type": "text", "text": "Replace the background with a sunset beach scene"}
+          ]
+      }],
+  )
+
+  image_url = response.choices[0].message.content[0].image_url.url
+  image_data = base64.b64decode(image_url.split(",")[1])
+  with open("output.png", "wb") as f:
+      f.write(image_data)
+  ```
+
+  ## Offline Inference
+
+  ```bash
+  # Text to Image
+  cd examples/offline_inference/text_to_image
+  python3 text_to_image.py --model zai-org/GLM-Image --output t2i_output.png
+
+  # Image to Image
+  cd examples/offline_inference/image_to_image
+  wget https://vllm-public-assets.s3.us-west-2.amazonaws.com/omni-assets/qwen-bear.png
+  python3 image_to_image.py --model zai-org/GLM-Image --image qwen-bear.png --output i2i_output.png
+  ```
+
+  ## Troubleshooting
+
+  - **Resolution errors:** Target image dimensions must be divisible by 32.
+  - **Text rendering:** Wrap text that should appear in the image with quotation marks
+    in the prompt.
+  - **Output stability:** Default `temperature=0.9`, `top_p=0.75`. Higher temperature
+    gives more diverse outputs but may reduce stability.
+  - **Transformers version:** Requires `transformers >= 5.0.0`.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-Image)
+  - [Technical blog](https://z.ai/blog/glm-image)
+  - [GitHub repo](https://github.com/zai-org/GLM-Image)

--- a/models/zai-org/GLM-Image.yaml
+++ b/models/zai-org/GLM-Image.yaml
@@ -11,11 +11,6 @@ meta:
   related_recipes: []
   hardware:
     h100: verified
-    h200: supported
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
 
 model:
   model_id: "zai-org/GLM-Image"

--- a/models/zai-org/GLM-Image.yaml
+++ b/models/zai-org/GLM-Image.yaml
@@ -9,6 +9,13 @@ meta:
     - multimodal
   performance_headline: "9B AR generator + 7B DiT decoder, state-of-the-art text rendering in generated images"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: supported
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
 
 model:
   model_id: "zai-org/GLM-Image"
@@ -45,13 +52,7 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-OCR.yaml
+++ b/models/zai-org/GLM-OCR.yaml
@@ -48,13 +48,7 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/GLM-OCR.yaml
+++ b/models/zai-org/GLM-OCR.yaml
@@ -1,0 +1,150 @@
+meta:
+  title: "GLM-OCR"
+  slug: "glm-ocr"
+  provider: "GLM (Z-AI)"
+  description: "GLM-OCR image-to-text model with built-in MTP speculative decoding for high-throughput OCR serving"
+  date_updated: 2026-04-17
+  difficulty: beginner
+  tasks:
+    - multimodal
+  performance_headline: "Multilingual end-to-end OCR VLM with MTP-accelerated decoding"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/GLM-OCR"
+  min_vllm_version: "0.12.0"
+  architecture: dense
+  parameter_count: "0.9B"
+  active_parameters: "0.9B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+dependencies:
+  - note: "GLM-OCR requires the nightly vllm wheel"
+    command: "uv pip install -U vllm --pre --extra-index-url https://wheels.vllm.ai/nightly"
+  - note: "transformers from source for GLM-OCR tokenizer support"
+    command: "uv pip install git+https://github.com/huggingface/transformers.git"
+
+features:
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding using the model's built-in MTP layers"
+    args:
+      - "--speculative-config.method"
+      - "mtp"
+      - "--speculative-config.num_speculative_tokens"
+      - "1"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 2
+    description: "Full precision BF16 — single-GPU deployment"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  GLM-OCR is a vision-language model for end-to-end OCR. It includes built-in
+  Multi-Token Prediction (MTP) layers enabling speculative decoding for higher
+  throughput generation.
+
+  ## Prerequisites
+
+  - **vLLM version:** nightly recommended (or latest stable with MTP support)
+  - **Transformers:** >= 5.0.0 (install from source for latest)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  Or nightly:
+
+  ```bash
+  uv pip install -U vllm --pre --extra-index-url https://wheels.vllm.ai/nightly
+  uv pip install git+https://github.com/huggingface/transformers.git
+  ```
+
+  ## Launching the Server
+
+  ### With MTP Speculative Decoding
+
+  ```bash
+  vllm serve zai-org/GLM-OCR \
+       --speculative-config.method mtp \
+       --speculative-config.num_speculative_tokens 1
+  ```
+
+  ## Client Usage
+
+  ### OpenAI SDK
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  messages = [{
+      "role": "user",
+      "content": [
+          {"type": "image_url", "image_url": {"url": "https://ofasys-multimodal-wlcb-3-toshanghai.oss-accelerate.aliyuncs.com/wpf272043/keepme/image/receipt.png"}},
+          {"type": "text", "text": "Text Recognition:"}
+      ]
+  }]
+
+  response = client.chat.completions.create(
+      model="zai-org/GLM-OCR",
+      messages=messages,
+      max_tokens=2048,
+      temperature=0.0,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### cURL
+
+  ```bash
+  curl -s http://localhost:8000/v1/chat/completions \
+       -H "Content-Type: application/json" \
+       -d '{
+            "model": "zai-org/GLM-OCR",
+            "messages": [{
+                 "role": "user",
+                 "content": [
+                      {"type": "image_url", "image_url": {"url": "https://example.com/receipt.png"}},
+                      {"type": "text", "text": "Text Recognition:"}
+                 ]
+            }],
+            "max_tokens": 2048,
+            "temperature": 0.0
+       }'
+  ```
+
+  ## Troubleshooting
+
+  - **Greedy sampling recommended:** Use `temperature=0.0` for optimal OCR accuracy.
+  - **Transformers version:** Requires `transformers >= 5.0.0`.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/GLM-OCR)

--- a/models/zai-org/Glyph.yaml
+++ b/models/zai-org/Glyph.yaml
@@ -11,11 +11,6 @@ meta:
   related_recipes: []
   hardware:
     h100: verified
-    h200: supported
-    b200: supported
-    gb200: supported
-    b300: supported
-    gb300: supported
     mi300x: verified
     mi325x: verified
 

--- a/models/zai-org/Glyph.yaml
+++ b/models/zai-org/Glyph.yaml
@@ -9,6 +9,15 @@ meta:
     - multimodal
   performance_headline: "Reasoning multimodal model for visual-text compression, single-GPU deployable"
   related_recipes: []
+  hardware:
+    h100: verified
+    h200: supported
+    b200: supported
+    gb200: supported
+    b300: supported
+    gb300: supported
+    mi300x: verified
+    mi325x: verified
 
 model:
   model_id: "zai-org/Glyph"
@@ -45,13 +54,7 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
-hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env: {}
-  blackwell:
-    extra_args: []
-    extra_env: {}
+hardware_overrides: {}
 
 strategy_overrides: {}
 

--- a/models/zai-org/Glyph.yaml
+++ b/models/zai-org/Glyph.yaml
@@ -1,0 +1,144 @@
+meta:
+  title: "Glyph"
+  slug: "glyph"
+  provider: "GLM (Z-AI)"
+  description: "Visual-text compression framework that renders long text into images and processes them with a reasoning VLM, scaling effective context length"
+  date_updated: 2026-04-17
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  performance_headline: "Reasoning multimodal model for visual-text compression, single-GPU deployable"
+  related_recipes: []
+
+model:
+  model_id: "zai-org/Glyph"
+  min_vllm_version: "0.11.0"
+  architecture: dense
+  parameter_count: "10B"
+  active_parameters: "10B"
+  context_length: 131072
+  base_args:
+    - "--no-enable-prefix-caching"
+    - "--mm-processor-cache-gb"
+    - "0"
+    - "--limit-mm-per-prompt.video"
+    - "0"
+  base_env: {}
+
+features:
+  reasoning:
+    description: "GLM-4.5 reasoning parser for extracting reasoning traces from Glyph outputs"
+    args:
+      - "--reasoning-parser"
+      - "glm45"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 24
+    description: "Full precision BF16 — single-GPU deployment on 1xH100"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+  - multi_node_tp_pp
+
+hardware_overrides:
+  hopper:
+    extra_args: []
+    extra_env: {}
+  blackwell:
+    extra_args: []
+    extra_env: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [Glyph](https://github.com/thu-coai/Glyph) is a framework from Zhipu AI for scaling
+  context length via visual-text compression. It renders long textual sequences into
+  images and processes them with a vision-language model. This recipe covers the vLLM
+  deployment of the `zai-org/Glyph` VLM as a component in that framework.
+
+  Glyph is a reasoning multimodal model, so `--reasoning-parser glm45` is recommended
+  to parse reasoning traces from outputs.
+
+  ## Prerequisites
+
+  - **vLLM version:** latest stable
+  - **Hardware:** 1x H100 or 1x MI300X/MI325X
+
+  ### Install vLLM (NVIDIA)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### Install vLLM (AMD ROCm)
+
+  ```bash
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  ROCm wheel requires Python 3.12, ROCm 7.0, glibc >= 2.35.
+
+  ## Launching the Server
+
+  ### Single H100 GPU
+
+  ```bash
+  vllm serve zai-org/Glyph \
+      --no-enable-prefix-caching \
+      --mm-processor-cache-gb 0 \
+      --reasoning-parser glm45 \
+      --limit-mm-per-prompt.video 0
+  ```
+
+  ### Single MI300X / MI325X
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 \
+  SAFETENSORS_FAST_GPU=1 \
+  vllm serve zai-org/Glyph \
+      --no-enable-prefix-caching \
+      --mm-processor-cache-gb 0 \
+      --reasoning-parser glm45 \
+      --limit-mm-per-prompt.video 0
+  ```
+
+  ### Configuration Tips
+
+  - `--no-enable-prefix-caching` and `--mm-processor-cache-gb 0` are recommended for
+    OCR-like workloads where image reuse is uncommon; they avoid unnecessary hashing
+    and caching overhead.
+  - Adjust `--max-num-batched-tokens` for throughput according to your hardware.
+
+  ## Benchmarking
+
+  ```bash
+  vllm bench serve \
+    --model zai-org/Glyph \
+    --dataset-name random \
+    --random-input-len 8192 \
+    --random-output-len 512 \
+    --request-rate 10000 \
+    --num-prompts 16 \
+    --ignore-eos
+  ```
+
+  ## Troubleshooting
+
+  - **Reasoning traces:** Use `--reasoning-parser glm45` to extract reasoning content.
+  - **Slow first inference:** Disabling prefix caching and multimodal processor caching
+    is intentional for Glyph's use case and trades off first-request latency for predictable throughput.
+
+  ## References
+
+  - [Model card](https://huggingface.co/zai-org/Glyph)
+  - [Glyph framework on GitHub](https://github.com/thu-coai/Glyph)
+  - [vLLM deployment section of Glyph docs](https://github.com/thu-coai/Glyph?tab=readme-ov-file#model-deployment-vllm-acceleration)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    unoptimized: true,
+  },
+};
+
+export default nextConfig;

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 
+{% block announce %}
+  ✨ For up-to-date, interactive recipes — hardware picker, copyable
+  <code>vllm serve</code> commands, and the full JSON API —
+  visit <a href="https://recipes.vllm.ai/"><strong>recipes.vllm.ai</strong></a>.
+  The Markdown guides below are kept as a historical reference.
+{% endblock %}
+
 {% block extrahead %}
   {{ super() }}
   {% if page %}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "vllm-recipes",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@10.24.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "node scripts/build-recipes-api.mjs && node scripts/fetch-provider-logos.mjs && node scripts/fetch-hf-dates.mjs && next build",
+    "start": "next start",
+    "lint": "next lint",
+    "validate": "node --experimental-vm-modules hooks/validate.mjs"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.2",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "js-yaml": "^4.1.1",
+    "lucide-react": "^0.483.0",
+    "next": "^15.5.9",
+    "next-mdx-remote": "^6.0.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-markdown": "^10.1.0",
+    "rehype-pretty-code": "^0.14.1",
+    "rehype-raw": "^7.0.0",
+    "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
+    "shiki": "^3.23.0",
+    "tailwind-merge": "^3.0.2"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
+    "eslint": "^9",
+    "eslint-config-next": "^15.5.9",
+    "tailwindcss": "^4"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,5351 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@radix-ui/react-slot':
+        specifier: ^1.1.2
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
+      lucide-react:
+        specifier: ^0.483.0
+        version: 0.483.0(react@19.2.5)
+      next:
+        specifier: ^15.5.9
+        version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next-mdx-remote:
+        specifier: ^6.0.0
+        version: 6.0.0(@types/react@19.2.14)(react@19.2.5)
+      react:
+        specifier: ^19.2.3
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.5(react@19.2.5)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
+      rehype-pretty-code:
+        specifier: ^0.14.1
+        version: 0.14.3(shiki@3.23.0)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      shiki:
+        specifier: ^3.23.0
+        version: 3.23.0
+      tailwind-merge:
+        specifier: ^3.0.2
+        version: 3.5.0
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3
+        version: 3.3.5
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.2.2
+      eslint:
+        specifier: ^9
+        version: 9.39.4(jiti@2.6.1)
+      eslint-config-next:
+        specifier: ^15.5.9
+        version: 15.5.15(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      tailwindcss:
+        specifier: ^4
+        version: 4.2.2
+
+packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@next/env@15.5.15':
+    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+
+  '@next/eslint-plugin-next@15.5.15':
+    resolution: {integrity: sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==}
+
+  '@next/swc-darwin-arm64@15.5.15':
+    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.15':
+    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.15':
+    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@15.5.15':
+    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@15.5.15':
+    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@15.5.15':
+    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@15.5.15':
+    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.15':
+    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@nolyfill/is-core-module@1.0.39':
+    resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
+    engines: {node: '>=12.4.0'}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@rushstack/eslint-patch@1.16.1':
+    resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.2.2':
+    resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@typescript-eslint/eslint-plugin@8.58.2':
+    resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.58.2
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.58.2':
+    resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.58.2':
+    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.58.2':
+    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.58.2':
+    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.58.2':
+    resolution: {integrity: sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.58.2':
+    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.58.2':
+    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.58.2':
+    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.58.2':
+    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+    cpu: [x64]
+    os: [win32]
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlast@1.2.5:
+    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlastindex@1.2.6:
+    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.tosorted@1.1.4:
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-iterator-helpers@1.3.2:
+    resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
+
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  eslint-config-next@15.5.15:
+    resolution: {integrity: sha512-mI5KIONOIosjF3jK2z9a8fY2LePNeW5C4lRJ+XZoJHAKkwx2MQjMPQ2/kL7tsMRPcQPZc/UBtCfqxElluL1CBg==}
+    peerDependencies:
+      eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  eslint-import-resolver-node@0.3.10:
+    resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
+
+  eslint-import-resolver-typescript@3.10.1:
+    resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+      eslint-plugin-import-x: '*'
+    peerDependenciesMeta:
+      eslint-plugin-import:
+        optional: true
+      eslint-plugin-import-x:
+        optional: true
+
+  eslint-module-utils@2.12.1:
+    resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-import@2.32.0:
+    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react@7.37.5:
+    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-bun-module@2.0.0:
+    resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  iterator.prototype@1.1.5:
+    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
+    engines: {node: '>= 0.4'}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lucide-react@0.483.0:
+    resolution: {integrity: sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-mdx-remote@6.0.0:
+    resolution: {integrity: sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ==}
+    engines: {node: '>=14', npm: '>=7'}
+    peerDependencies:
+      react: '>=16'
+
+  next@15.5.15:
+    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  node-exports-info@1.6.0:
+    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
+    engines: {node: '>= 0.4'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.entries@1.1.9:
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
+    engines: {node: '>= 0.4'}
+
+  oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+
+  oniguruma-to-es@4.3.5:
+    resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-numeric-range@1.3.0:
+    resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
+  rehype-pretty-code@0.14.3:
+    resolution: {integrity: sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      shiki: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@2.0.0-next.6:
+    resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-array-concat@1.1.3:
+    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+    engines: {node: '>=0.4'}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stable-hash@0.0.5:
+    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.matchall@4.0.12:
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.repeat@1.0.0:
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
+
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove@4.0.0:
+    resolution: {integrity: sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  unrs-resolver@1.11.1:
+    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
+  vfile-matter@5.0.1:
+    resolution: {integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdx': 2.0.13
+      acorn: 8.16.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.16.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.5
+
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@next/env@15.5.15': {}
+
+  '@next/eslint-plugin-next@15.5.15':
+    dependencies:
+      fast-glob: 3.3.1
+
+  '@next/swc-darwin-arm64@15.5.15':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.15':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.15':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.15':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.15':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.15':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.15':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.15':
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@nolyfill/is-core-module@1.0.39': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@rtsao/scc@1.1.0': {}
+
+  '@rushstack/eslint-patch@1.16.1': {}
+
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.5
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tailwindcss/node@4.2.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.2
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
+  '@tailwindcss/postcss@4.2.2':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      postcss: 8.5.10
+      tailwindcss: 4.2.2
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
+  '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/json5@0.0.29': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.13': {}
+
+  '@types/ms@2.1.0': {}
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/type-utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.58.2
+      eslint: 9.39.4(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.58.2
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.58.2(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/types': 8.58.2
+      debug: 4.4.3
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.58.2':
+    dependencies:
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
+
+  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@6.0.2)':
+    dependencies:
+      typescript: 6.0.2
+
+  '@typescript-eslint/type-utils@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.58.2': {}
+
+  '@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@6.0.2)
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.58.2':
+    dependencies:
+      '@typescript-eslint/types': 8.58.2
+      eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+    optional: true
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  aria-query@5.3.2: {}
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
+  array.prototype.findlast@1.2.5:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.findlastindex@1.2.6:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.tosorted@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
+  ast-types-flow@0.0.8: {}
+
+  astring@1.9.0: {}
+
+  async-function@1.0.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  axe-core@4.11.3: {}
+
+  axobject-query@4.1.0: {}
+
+  bail@2.0.2: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001788: {}
+
+  ccount@2.0.1: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
+
+  collapse-white-space@2.1.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  csstype@3.2.3: {}
+
+  damerau-levenshtein@1.0.8: {}
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  deep-is@0.1.4: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  doctrine@2.1.0:
+    dependencies:
+      esutils: 2.0.3
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  emoji-regex@9.2.2: {}
+
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.2
+
+  entities@6.0.1: {}
+
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.3
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.20
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-iterator-helpers@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-set-tostringtag: 2.1.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      iterator.prototype: 1.1.5
+      math-intrinsics: 1.1.0
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
+
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.16.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
+
+  eslint-config-next@15.5.15(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2):
+    dependencies:
+      '@next/eslint-plugin-next': 15.5.15
+      '@rushstack/eslint-patch': 1.16.1
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.6.1))
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
+  eslint-import-resolver-node@0.3.10:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.16.1
+      resolve: 2.0.0-next.6
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.4(jiti@2.6.1)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.3.2
+      eslint: 9.39.4(jiti@2.6.1)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.6
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
+
+  extend@3.0.2: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  github-slugger@2.0.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  has-bigints@1.1.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+
+  html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  inline-style-parser@0.2.7: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-bun-module@2.0.0:
+    dependencies:
+      semver: 7.7.4
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-decimal@2.0.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
+
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  iterator.prototype@1.1.5:
+    dependencies:
+      define-data-property: 1.1.4
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      has-symbols: 1.1.0
+      set-function-name: 2.0.2
+
+  jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
+
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      object.assign: 4.1.7
+      object.values: 1.2.1
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  longest-streak@3.1.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lucide-react@0.483.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-extensions@2.0.0: {}
+
+  markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  minimist@1.2.8: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  napi-postinstall@0.3.4: {}
+
+  natural-compare@1.4.0: {}
+
+  next-mdx-remote@6.0.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@mdx-js/mdx': 3.1.1
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      unist-util-remove: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      vfile-matter: 5.0.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
+  next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@next/env': 15.5.15
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001788
+      postcss: 8.4.31
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.15
+      '@next/swc-darwin-x64': 15.5.15
+      '@next/swc-linux-arm64-gnu': 15.5.15
+      '@next/swc-linux-arm64-musl': 15.5.15
+      '@next/swc-linux-x64-gnu': 15.5.15
+      '@next/swc-linux-x64-musl': 15.5.15
+      '@next/swc-win32-arm64-msvc': 15.5.15
+      '@next/swc-win32-x64-msvc': 15.5.15
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  node-exports-info@1.6.0:
+    dependencies:
+      array.prototype.flatmap: 1.3.3
+      es-errors: 1.3.0
+      object.entries: 1.1.9
+      semver: 6.3.1
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  object.entries@1.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  oniguruma-parser@0.12.1: {}
+
+  oniguruma-to-es@4.3.5:
+    dependencies:
+      oniguruma-parser: 0.12.1
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
+  parse-numeric-range@1.3.0: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  possible-typed-array-names@1.1.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  property-information@7.1.0: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-is@16.13.1: {}
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.5
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  react@19.2.5: {}
+
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
+  rehype-pretty-code@0.14.3(shiki@3.23.0):
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-string: 3.0.1
+      parse-numeric-range: 1.3.0
+      rehype-parse: 9.0.1
+      shiki: 3.23.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  resolve@2.0.0-next.6:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      node-exports-info: 1.6.0
+      object-keys: 1.1.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safe-array-concat@1.1.3:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  semver@7.7.4: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  stable-hash@0.0.5: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.matchall@4.0.12:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      regexp.prototype.flags: 1.5.4
+      set-function-name: 2.0.2
+      side-channel: 1.1.0
+
+  string.prototype.repeat@1.0.0:
+    dependencies:
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  strip-bom@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
+  styled-jsx@5.1.6(react@19.2.5):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.5
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@3.5.0: {}
+
+  tailwindcss@4.2.2: {}
+
+  tapable@2.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  ts-api-utils@2.5.0(typescript@6.0.2):
+    dependencies:
+      typescript: 6.0.2
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tslib@2.8.1: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
+  typescript@6.0.2: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-remove@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  unrs-resolver@1.11.1:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
+      '@unrs/resolver-binding-android-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-arm64': 1.11.1
+      '@unrs/resolver-binding-darwin-x64': 1.11.1
+      '@unrs/resolver-binding-freebsd-x64': 1.11.1
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
+      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
+      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
+      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
+  vfile-matter@5.0.1:
+    dependencies:
+      vfile: 6.0.3
+      yaml: 2.8.3
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  web-namespaces@2.0.1: {}
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.20
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yaml@2.8.3: {}
+
+  yocto-queue@0.1.0: {}
+
+  zwitch@2.0.4: {}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+  plugins: ["@tailwindcss/postcss"],
+};
+
+export default config;

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -1,0 +1,135 @@
+/**
+ * Build-time script: reads YAML recipe/strategy/taxonomy files,
+ * writes static JSON files for the API.
+ *
+ * API URLs (friendly, no /api/ prefix):
+ *   /models.json                    — all recipes index
+ *   /models/deepseek-v3.2.json      — single recipe
+ *   /strategies.json                — all strategies
+ *   /strategies/single_node_tp.json — single strategy
+ *   /taxonomy.json                  — controlled vocabulary
+ *   /quickstart/8x-h100.json       — hardware quickstart
+ *
+ * Run: node scripts/build-recipes-api.mjs
+ */
+
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+
+const ROOT = process.cwd();
+const PUBLIC = path.join(ROOT, "public");
+
+function readYaml(filePath) {
+  return yaml.load(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJson(relPath, data) {
+  const fullPath = path.join(PUBLIC, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, JSON.stringify(data, null, 2));
+}
+
+// Normalize dates (js-yaml parses YYYY-MM-DD as Date objects)
+function normalizeDates(obj) {
+  if (obj instanceof Date) return obj.toISOString().split("T")[0];
+  if (Array.isArray(obj)) return obj.map(normalizeDates);
+  if (obj && typeof obj === "object") {
+    return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, normalizeDates(v)]));
+  }
+  return obj;
+}
+
+// Recursively find all .yaml files under a directory
+function findYamlFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findYamlFiles(full));
+    } else if (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// ── Taxonomy ──
+const taxonomy = normalizeDates(readYaml(path.join(ROOT, "taxonomy.yaml")));
+writeJson("taxonomy.json", taxonomy);
+
+// ── Strategies ──
+const strategiesDir = path.join(ROOT, "strategies");
+const strategies = {};
+for (const file of fs.readdirSync(strategiesDir).filter((f) => f.endsWith(".yaml"))) {
+  const s = normalizeDates(readYaml(path.join(strategiesDir, file)));
+  strategies[s.name] = s;
+  writeJson(`strategies/${s.name}.json`, s);
+}
+writeJson("strategies.json", strategies);
+
+// ── Recipes ── (walks models/<hf_org>/<hf_repo>.yaml)
+const modelsDir = path.join(ROOT, "models");
+const recipes = [];
+for (const file of findYamlFiles(modelsDir)) {
+  const r = normalizeDates(readYaml(file));
+  // Derive HF identity from path
+  const rel = path.relative(modelsDir, file);
+  const parts = rel.split(path.sep);
+  if (parts.length >= 2) {
+    r.hf_org = parts[0];
+    r.hf_repo = parts[parts.length - 1].replace(/\.(yaml|yml)$/, "");
+    r.hf_id = `${r.hf_org}/${r.hf_repo}`;
+  }
+  recipes.push(r);
+  // JSON at /<org>/<repo>.json — mirrors HF URL scheme
+  writeJson(`${r.hf_org}/${r.hf_repo}.json`, r);
+}
+
+// /models.json — index (no guide field, compact)
+const index = recipes.map((r) => ({
+  hf_id: r.hf_id,
+  hf_org: r.hf_org,
+  hf_repo: r.hf_repo,
+  title: r.meta.title,
+  provider: r.meta.provider,
+  description: r.meta.description,
+  date_updated: r.meta.date_updated,
+  difficulty: r.meta.difficulty,
+  min_vllm_version: r.model.min_vllm_version,
+  architecture: r.model.architecture,
+  parameter_count: r.model.parameter_count,
+  active_parameters: r.model.active_parameters,
+  context_length: r.model.context_length,
+  tasks: r.meta.tasks,
+  performance_headline: r.meta.performance_headline,
+  variants: Object.fromEntries(
+    Object.entries(r.variants || {}).map(([k, v]) => [
+      k,
+      { precision: v.precision, vram_minimum_gb: v.vram_minimum_gb },
+    ])
+  ),
+  compatible_strategies: r.compatible_strategies,
+  features: Object.keys(r.features || {}),
+  opt_in_features: r.opt_in_features || [],
+  url: `/${r.hf_id}`,
+  json: `/${r.hf_id}.json`,
+}));
+writeJson("models.json", index);
+
+// ── Quickstart ──
+const quickstartDir = path.join(ROOT, "quickstart");
+if (fs.existsSync(quickstartDir)) {
+  for (const file of fs.readdirSync(quickstartDir).filter((f) => f.endsWith(".yaml"))) {
+    const q = normalizeDates(readYaml(path.join(quickstartDir, file)));
+    writeJson(`quickstart/${q.hardware_profile}.json`, q);
+  }
+}
+
+console.log(
+  `✓ JSON API: ${recipes.length} models, ${Object.keys(strategies).length} strategies`
+);
+console.log(`  /models.json`);
+console.log(`  /{hf_org}/{hf_repo}.json  (e.g. /moonshotai/Kimi-K2.5.json)`);
+console.log(`  /strategies.json`);
+console.log(`  /taxonomy.json`);

--- a/scripts/fetch-hf-dates.mjs
+++ b/scripts/fetch-hf-dates.mjs
@@ -1,0 +1,69 @@
+/**
+ * Build-time: fetch `created_at` from HuggingFace for each recipe's base model_id,
+ * write to a manifest at public/hf-dates.json so the UI can sort by release date.
+ *
+ * Cached between builds (reads existing manifest, only fetches missing entries).
+ */
+
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+
+const ROOT = process.cwd();
+const MANIFEST = path.join(ROOT, "public", "hf-dates.json");
+
+// Load existing manifest (cache)
+let cache = {};
+if (fs.existsSync(MANIFEST)) {
+  try { cache = JSON.parse(fs.readFileSync(MANIFEST, "utf8")); } catch {}
+}
+
+function findYamlFiles(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...findYamlFiles(full));
+    else if (e.name.endsWith(".yaml") || e.name.endsWith(".yml")) out.push(full);
+  }
+  return out;
+}
+
+async function fetchCreatedAt(modelId) {
+  try {
+    const res = await fetch(`https://huggingface.co/api/models/${modelId}`, {
+      headers: { "User-Agent": "vllm-recipes-build/1.0" },
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.createdAt || data.created_at || null;
+  } catch {
+    return null;
+  }
+}
+
+const files = findYamlFiles(path.join(ROOT, "models"));
+const hfIds = files.map((f) => {
+  const rel = path.relative(path.join(ROOT, "models"), f);
+  const parts = rel.split(path.sep);
+  const repo = parts[parts.length - 1].replace(/\.(yaml|yml)$/, "");
+  return `${parts[0]}/${repo}`;
+});
+
+let fetched = 0, cached = 0, failed = 0;
+for (const id of hfIds) {
+  if (cache[id]) { cached++; continue; }
+  const ts = await fetchCreatedAt(id);
+  if (ts) {
+    cache[id] = ts;
+    fetched++;
+  } else {
+    failed++;
+  }
+  // Gentle rate limit
+  await new Promise((r) => setTimeout(r, 100));
+}
+
+fs.mkdirSync(path.dirname(MANIFEST), { recursive: true });
+fs.writeFileSync(MANIFEST, JSON.stringify(cache, null, 2));
+
+console.log(`✓ HF dates: ${fetched} fetched, ${cached} cached, ${failed} failed (${hfIds.length} total)`);

--- a/scripts/fetch-provider-logos.mjs
+++ b/scripts/fetch-provider-logos.mjs
@@ -1,0 +1,59 @@
+/**
+ * Build-time: fetch HF org avatars to public/providers/<hf_org>.<ext>.
+ *
+ * Driven by src/lib/providers.js — it has an explicit list of HF orgs.
+ * Each org has a logo path like "/providers/<hf_org>.png" — this script
+ * populates that file at build time so Vercel's CDN serves them globally.
+ *
+ * Skips orgs already downloaded (in case of incremental builds).
+ */
+
+import fs from "fs";
+import path from "path";
+import { PROVIDERS } from "../src/lib/providers.js";
+
+const OUT = "public/providers";
+fs.mkdirSync(OUT, { recursive: true });
+
+async function fetchOrgAvatarUrl(org) {
+  const res = await fetch(`https://huggingface.co/${org}`, {
+    headers: { "User-Agent": "vllm-recipes-build/1.0" },
+  });
+  const html = await res.text();
+  const match = html.match(/cdn-avatars\.huggingface\.co\/[^"&]+/);
+  return match ? `https://${match[0]}` : null;
+}
+
+let fetched = 0;
+let skipped = 0;
+let failed = 0;
+
+for (const [org, meta] of Object.entries(PROVIDERS)) {
+  if (!meta.logo) continue;
+  const localPath = path.join("public", meta.logo);
+  if (fs.existsSync(localPath)) {
+    skipped++;
+    continue;
+  }
+  try {
+    const avatarUrl = await fetchOrgAvatarUrl(org);
+    if (!avatarUrl) {
+      console.warn(`⚠ no avatar found for ${org}`);
+      failed++;
+      continue;
+    }
+    const imgRes = await fetch(avatarUrl);
+    const buffer = Buffer.from(await imgRes.arrayBuffer());
+    fs.writeFileSync(localPath, buffer);
+    console.log(`✓ ${org} (${buffer.length}B)`);
+    fetched++;
+  } catch (e) {
+    console.warn(`✗ ${org}: ${e.message}`);
+    failed++;
+  }
+}
+
+console.log(`\n${fetched} fetched, ${skipped} cached, ${failed} failed`);
+if (failed > 0) {
+  console.warn("Some logos failed — continuing build anyway");
+}

--- a/scripts/hf-info.sh
+++ b/scripts/hf-info.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Helper: fetch HF model metadata as compact JSON for migration scripts.
+# Usage: ./scripts/hf-info.sh moonshotai/Kimi-K2.5
+#
+# Extracts the key fields needed for recipe YAML:
+#   - id, author, last_modified
+#   - config.architectures, config.model_type
+#   - safetensors.parameters (total + dtype breakdown)
+#   - pipeline_tag, tags
+#   - library_name
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <hf_org/repo>" >&2
+  exit 1
+fi
+
+MODEL="$1"
+HF_BIN="${HF_BIN:-~/.local/bin/hf}"
+
+"$HF_BIN" models info "$MODEL" 2>/dev/null | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+cfg = d.get('config', {}) or {}
+st = d.get('safetensors', {}) or {}
+params = st.get('parameters', {}) or {}
+total = st.get('total', 0)
+print(json.dumps({
+    'id': d.get('id'),
+    'author': d.get('author'),
+    'last_modified': d.get('last_modified'),
+    'architectures': cfg.get('architectures', []),
+    'model_type': cfg.get('model_type'),
+    'pipeline_tag': d.get('pipeline_tag'),
+    'library_name': d.get('library_name'),
+    'tags': d.get('tags', []),
+    'total_parameters': total,
+    'param_dtypes': params,
+    'disabled': d.get('disabled'),
+    'gated': d.get('gated'),
+    'likes': d.get('likes'),
+    'downloads': d.get('downloads'),
+}, indent=2))
+"

--- a/src/app/[org]/[repo]/page.js
+++ b/src/app/[org]/[repo]/page.js
@@ -1,0 +1,211 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getAllRecipes, getRecipeByHfId } from "@/lib/recipes";
+import { recipeHref } from "@/lib/recipe-utils";
+import { loadStrategies } from "@/lib/strategies";
+import { loadTaxonomy } from "@/lib/taxonomy";
+import { getProviderLogo } from "@/lib/providers";
+import { CommandBuilder } from "@/components/recipes/CommandBuilder";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSlug from "rehype-slug";
+import { Badge } from "@/components/ui/badge";
+import { Cpu, Layers, Pencil, Bug, ExternalLink } from "lucide-react";
+
+export async function generateStaticParams() {
+  return getAllRecipes().map((r) => ({
+    org: r.hf_org,
+    repo: r.hf_repo,
+  }));
+}
+
+export async function generateMetadata({ params }) {
+  const { org, repo } = await params;
+  const recipe = getRecipeByHfId(org, repo);
+  if (!recipe) return {};
+  return { title: recipe.meta.title, description: recipe.meta.description };
+}
+
+export default async function RecipePage({ params }) {
+  const { org, repo } = await params;
+  const recipe = getRecipeByHfId(org, repo);
+  if (!recipe) notFound();
+
+  const strategies = loadStrategies();
+  const taxonomy = loadTaxonomy();
+  const guide = recipe.guide || "";
+  const logo = getProviderLogo(recipe.hf_org);
+
+  const configRows = Object.entries(recipe.variants || {}).map(([key, v]) => ({
+    name: key === "default" ? "Default" : key.toUpperCase(),
+    precision: v.precision?.toUpperCase() || "—",
+    vram: `${v.vram_minimum_gb} GB`,
+    description: v.description || "",
+  }));
+
+  const allRecipes = getAllRecipes();
+  // related_recipes can be either "org/repo" HF id or the old slug format
+  const related = (recipe.meta.related_recipes || [])
+    .map((s) => allRecipes.find((r) => r.hf_id === s || r.meta.slug === s))
+    .filter(Boolean);
+
+  return (
+    <main className="py-6 w-full min-w-0">
+      {/* ── Model header ── */}
+      <header className="mb-8">
+        <div className="flex items-start gap-4 mb-4">
+          {logo && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={logo} alt={recipe.meta.provider} width={44} height={44} className="rounded-xl mt-0.5 shrink-0" />
+          )}
+          <div className="min-w-0 flex-1">
+            <h1 className="text-2xl sm:text-3xl font-bold tracking-tight font-mono break-all">
+              <span className="text-muted-foreground font-normal">{recipe.hf_org}/</span>
+              {recipe.hf_repo}
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{recipe.meta.description}</p>
+            <a
+              href={`https://huggingface.co/${recipe.hf_id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-vllm-blue transition-colors mt-2"
+            >
+              View on HuggingFace
+              <ExternalLink size={10} />
+            </a>
+          </div>
+        </div>
+
+        {/* Tags — single row, no duplication */}
+        <div className="flex flex-wrap gap-1.5">
+          <Badge variant="outline" className="gap-1 text-xs capitalize">
+            {recipe.model.architecture === "moe" ? <Layers size={11} /> : <Cpu size={11} />}
+            {recipe.model.architecture}
+          </Badge>
+          <Badge variant="outline" className="text-xs">
+            {recipe.model.parameter_count}
+            {recipe.model.active_parameters && recipe.model.active_parameters !== recipe.model.parameter_count
+              ? ` / ${recipe.model.active_parameters}`
+              : ""}
+          </Badge>
+          <Badge variant="outline" className="text-xs">{(recipe.model.context_length || 0).toLocaleString()} ctx</Badge>
+          <a
+            href="https://vllm.ai/#quick-start"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Install vLLM"
+            className="inline-flex items-center rounded-md border border-border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap transition-colors hover:border-vllm-blue/50 hover:text-vllm-blue"
+          >
+            vLLM {recipe.model.min_vllm_version}+
+            <ExternalLink size={10} className="ml-1 opacity-50" />
+          </a>
+          {recipe.meta.tasks?.map((t) => (
+            <Badge key={t} variant="secondary" className="text-xs capitalize">{t}</Badge>
+          ))}
+        </div>
+      </header>
+
+      {/* ── Command Builder ── */}
+      <section className="mb-10">
+        <Suspense fallback={<div className="h-40 rounded-2xl bg-muted animate-pulse" />}>
+          <CommandBuilder recipe={recipe} strategies={strategies} taxonomy={taxonomy} />
+        </Suspense>
+      </section>
+
+      {/* ── Reference sections ── */}
+      <section className="space-y-2">
+        {guide && (
+          <Accordion title="Guide" defaultOpen>
+            <div className="guide-content">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeSlug]}
+              >
+                {guide}
+              </Markdown>
+            </div>
+          </Accordion>
+        )}
+
+        {configRows.length > 1 && (
+          <Accordion title="Configuration Matrix">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground text-xs">
+                    <th className="pb-2 pr-6 font-medium">Variant</th>
+                    <th className="pb-2 pr-6 font-medium">Precision</th>
+                    <th className="pb-2 pr-6 font-medium">Min VRAM</th>
+                    <th className="pb-2 font-medium">Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {configRows.map((row) => (
+                    <tr key={row.name} className="border-b border-border/40">
+                      <td className="py-2 pr-6 font-mono text-xs">{row.name}</td>
+                      <td className="py-2 pr-6 text-xs">{row.precision}</td>
+                      <td className="py-2 pr-6 text-xs tabular-nums">{row.vram}</td>
+                      <td className="py-2 text-xs text-muted-foreground">{row.description}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Accordion>
+        )}
+      </section>
+
+      {/* ── Footer ── */}
+      <footer className="mt-10 pt-4 border-t border-border text-sm text-muted-foreground flex flex-wrap gap-x-4 gap-y-2">
+        <span>Updated {recipe.meta.date_updated}</span>
+        <a
+          href={`https://github.com/vllm-project/recipes/edit/main/models/${recipe.hf_org}/${recipe.hf_repo}.yaml`}
+          className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
+        >
+          <Pencil size={12} /> Edit recipe
+        </a>
+        <a
+          href="https://github.com/vllm-project/recipes/issues"
+          className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
+        >
+          <Bug size={12} /> Report issue
+        </a>
+        {related.length > 0 && (
+          <span className="basis-full mt-1">
+            Related:{" "}
+            {related.map((r, i) => (
+              <span key={r.meta.slug}>
+                {i > 0 && " · "}
+                <Link href={recipeHref(r)} className="text-vllm-blue hover:underline">{r.meta.title}</Link>
+              </span>
+            ))}
+          </span>
+        )}
+      </footer>
+    </main>
+  );
+}
+
+function Accordion({ title, children, defaultOpen = false }) {
+  return (
+    <details className="group rounded-xl border border-border overflow-hidden" open={defaultOpen || undefined}>
+      <summary className="px-5 py-3 cursor-pointer text-sm font-semibold select-none hover:bg-muted/20 transition-colors flex items-center justify-between">
+        {title}
+        <ChevronIcon />
+      </summary>
+      <div className="px-5 pb-5 border-t border-border/40 pt-4">{children}</div>
+    </details>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-muted-foreground transition-transform duration-200 group-open:rotate-180"
+      fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+}

--- a/src/app/[org]/layout.js
+++ b/src/app/[org]/layout.js
@@ -1,0 +1,36 @@
+import { getAllRecipes } from "@/lib/recipes";
+import { ModelSidebar } from "@/components/recipes/ModelSidebar";
+
+export default async function OrgLayout({ children }) {
+  const recipes = getAllRecipes();
+
+  // Group by HF org, sort alphabetically (case-insensitive) for predictable navigation
+  const byOrg = {};
+  for (const r of recipes) {
+    const org = r.hf_org || "unknown";
+    if (!byOrg[org]) byOrg[org] = [];
+    byOrg[org].push(r);
+  }
+  const sorted = Object.entries(byOrg).sort((a, b) =>
+    a[0].toLowerCase().localeCompare(b[0].toLowerCase())
+  );
+  // Sort models within each org by HF release date (newest first).
+  // Fallback to repo-name alphabetical when date missing/equal.
+  for (const [, models] of sorted) {
+    models.sort((a, b) => {
+      const da = a.hf_released ? new Date(a.hf_released).getTime() : 0;
+      const db = b.hf_released ? new Date(b.hf_released).getTime() : 0;
+      if (da !== db) return db - da;
+      return (a.hf_repo || "").localeCompare(b.hf_repo || "");
+    });
+  }
+
+  return (
+    <div className="max-w-[1480px] mx-auto px-4 sm:px-6 flex gap-6">
+      <ModelSidebar recipesByOrg={sorted} />
+      <div className="flex-1 min-w-0">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[org]/page.js
+++ b/src/app/[org]/page.js
@@ -1,0 +1,151 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getAllRecipes } from "@/lib/recipes";
+import { getProviderLogo, getProviderDisplayName } from "@/lib/providers";
+import { recipeHref } from "@/lib/recipe-utils";
+import { Badge } from "@/components/ui/badge";
+import { ExternalLink, Type, Eye, Sparkles, Cpu, Hash } from "lucide-react";
+
+export async function generateStaticParams() {
+  const recipes = getAllRecipes();
+  const orgs = [...new Set(recipes.map((r) => r.hf_org))];
+  return orgs.map((org) => ({ org }));
+}
+
+export async function generateMetadata({ params }) {
+  const { org } = await params;
+  const displayName = getProviderDisplayName(org);
+  return {
+    title: displayName,
+    description: `vLLM recipes for ${displayName} models`,
+  };
+}
+
+// Task → icon + display label
+const TASK_META = {
+  text:       { icon: Type,     label: "Text" },
+  multimodal: { icon: Eye,      label: "Multimodal" },
+  omni:       { icon: Sparkles, label: "Omni" },
+  embedding:  { icon: Hash,     label: "Embedding" },
+};
+const TASK_ORDER = ["text", "multimodal", "omni", "embedding"];
+
+export default async function OrgPage({ params }) {
+  const { org } = await params;
+  const all = getAllRecipes();
+  const models = all.filter((r) => r.hf_org === org);
+  if (models.length === 0) notFound();
+
+  const logo = getProviderLogo(org);
+  const displayName = getProviderDisplayName(org);
+
+  // Group by primary task (first in meta.tasks, or "other" if empty)
+  const groups = {};
+  for (const m of models) {
+    const task = (m.meta.tasks || [])[0] || "other";
+    if (!groups[task]) groups[task] = [];
+    groups[task].push(m);
+  }
+  const orderedGroups = TASK_ORDER
+    .filter((t) => groups[t])
+    .map((t) => [t, groups[t]]);
+  // Any task not in TASK_ORDER gets appended at the end
+  for (const t of Object.keys(groups)) {
+    if (!TASK_ORDER.includes(t)) orderedGroups.push([t, groups[t]]);
+  }
+
+  return (
+    <main className="py-8">
+      <header className="mb-8 flex items-center gap-4">
+        {logo ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={logo} alt="" width={56} height={56} className="rounded-xl shrink-0" />
+        ) : (
+          <div className="w-14 h-14 rounded-xl bg-muted flex items-center justify-center text-2xl font-bold text-muted-foreground">
+            {displayName.charAt(0)}
+          </div>
+        )}
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{displayName}</h1>
+          <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
+            <span className="font-mono text-xs">{org}</span>
+            <span>·</span>
+            <span>{models.length} recipe{models.length > 1 ? "s" : ""}</span>
+            <a
+              href={`https://huggingface.co/${org}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs hover:text-foreground transition-colors"
+            >
+              HuggingFace
+              <ExternalLink size={10} />
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <div className="space-y-8">
+        {orderedGroups.map(([task, list]) => {
+          const tmeta = TASK_META[task];
+          const Icon = tmeta?.icon || Cpu;
+          return (
+            <section key={task}>
+              <div className="flex items-center gap-2 mb-3">
+                <Icon size={14} className="text-muted-foreground" />
+                <h2 className="text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+                  {tmeta?.label || task}
+                </h2>
+                <span className="text-xs text-muted-foreground/60 tabular-nums">{list.length}</span>
+              </div>
+              <div className="border border-border rounded-xl divide-y divide-border/60 overflow-hidden">
+                {list.map((r) => (
+                  <ModelRow key={r.hf_id} recipe={r} />
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </main>
+  );
+}
+
+function ModelRow({ recipe }) {
+  const { meta, model, variants, hf_repo } = recipe;
+
+  return (
+    <Link
+      href={recipeHref(recipe)}
+      className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3 hover:bg-muted/40 transition-all group"
+    >
+      <div className="min-w-[220px] shrink-0">
+        <div className="text-sm font-semibold font-mono group-hover:text-vllm-blue transition-colors">
+          {hf_repo || meta.title}
+        </div>
+        <div className="text-xs text-muted-foreground font-mono">
+          {model.parameter_count}
+          {model.active_parameters && model.active_parameters !== model.parameter_count
+            ? ` / ${model.active_parameters}`
+            : ""}
+        </div>
+      </div>
+
+      <Badge variant="outline" className="text-[10px] capitalize">{model.architecture}</Badge>
+
+      <div className="flex gap-1 flex-wrap">
+        {Object.entries(variants || {}).map(([name, v]) => (
+          <span
+            key={name}
+            className="inline-flex items-center gap-0.5 rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono"
+          >
+            <span className="font-semibold">{v.precision?.toUpperCase()}</span>
+            <span className="text-muted-foreground">{v.vram_minimum_gb}G</span>
+          </span>
+        ))}
+      </div>
+
+      <span className="text-[10px] text-muted-foreground ml-auto shrink-0 tabular-nums">v{model.min_vllm_version}+</span>
+      <span className="text-muted-foreground/40 group-hover:text-vllm-blue group-hover:translate-x-0.5 transition-all">&rarr;</span>
+    </Link>
+  );
+}

--- a/src/app/[org]/page.js
+++ b/src/app/[org]/page.js
@@ -46,6 +46,14 @@ export default async function OrgPage({ params }) {
     if (!groups[task]) groups[task] = [];
     groups[task].push(m);
   }
+  // Within each group, sort by HF release date desc (fallback: date_updated desc)
+  const modelTs = (m) => {
+    const t = m.hf_released ? Date.parse(m.hf_released) : NaN;
+    return Number.isFinite(t) ? t : Date.parse(m.meta.date_updated) || 0;
+  };
+  for (const list of Object.values(groups)) {
+    list.sort((a, b) => modelTs(b) - modelTs(a));
+  }
   const orderedGroups = TASK_ORDER
     .filter((t) => groups[t])
     .map((t) => [t, groups[t]]);

--- a/src/app/error.js
+++ b/src/app/error.js
@@ -1,0 +1,16 @@
+"use client";
+
+export default function Error({ error, reset }) {
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-20 text-center">
+      <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
+      <p className="text-muted-foreground mb-4">{error?.message || "An unexpected error occurred."}</p>
+      <button
+        onClick={reset}
+        className="text-sm text-vllm-blue hover:underline"
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,258 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-inter), Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  --font-mono: var(--font-jetbrains), "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  /* vLLM Brand Colors */
+  --color-vllm-yellow: #fdb517;
+  --color-vllm-blue: #30a2ff;
+  --color-vllm-yellow-hover: #e5a315;
+  --color-vllm-blue-hover: #2891e6;
+
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
+:root {
+  --radius: 0.625rem;
+  --code-bg: oklch(0.97 0.005 265);
+  --code-fg: oklch(0.25 0.04 265);
+  --code-block-bg: oklch(0.95 0.007 265);
+  --code-block-fg: oklch(0.2 0.04 265);
+  --command-bg: oklch(0.965 0.005 265);
+  --command-fg: oklch(0.18 0.04 265);
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.129 0.042 264.695);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.129 0.042 264.695);
+  --primary: oklch(0.208 0.042 265.755);
+  --primary-foreground: oklch(0.984 0.003 247.858);
+  --secondary: oklch(0.968 0.007 247.896);
+  --secondary-foreground: oklch(0.208 0.042 265.755);
+  --muted: oklch(0.968 0.007 247.896);
+  --muted-foreground: oklch(0.554 0.046 257.417);
+  --accent: oklch(0.968 0.007 247.896);
+  --accent-foreground: oklch(0.208 0.042 265.755);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.929 0.013 255.508);
+  --input: oklch(0.929 0.013 255.508);
+  --ring: oklch(0.704 0.04 256.788);
+}
+
+.dark {
+  /* Warmer, slightly lighter code palette — avoid pure-black command block.
+     Command < code-block < code (inline) ≤ card, for a subtle depth ladder
+     against --background oklch(0.129 ...) without any slab reading as black. */
+  --code-bg: oklch(0.245 0.016 258);
+  --code-fg: oklch(0.92 0.008 245);
+  --code-block-bg: oklch(0.2 0.018 260);
+  --code-block-fg: oklch(0.93 0.008 245);
+  --command-bg: oklch(0.175 0.018 258);
+  --command-fg: oklch(0.95 0.008 245);
+  --background: oklch(0.129 0.042 264.695);
+  --foreground: oklch(0.984 0.003 247.858);
+  --card: oklch(0.208 0.042 265.755);
+  --card-foreground: oklch(0.984 0.003 247.858);
+  --primary: oklch(0.929 0.013 255.508);
+  --primary-foreground: oklch(0.208 0.042 265.755);
+  --secondary: oklch(0.279 0.041 260.031);
+  --secondary-foreground: oklch(0.984 0.003 247.858);
+  --muted: oklch(0.279 0.041 260.031);
+  --muted-foreground: oklch(0.704 0.04 256.788);
+  --accent: oklch(0.279 0.041 260.031);
+  --accent-foreground: oklch(0.984 0.003 247.858);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.551 0.027 264.364);
+}
+
+/* Scrollbars — soften dark mode (default WebKit scrollbar reads as white) */
+.dark {
+  color-scheme: dark;
+  scrollbar-color: oklch(0.3 0.015 260) oklch(0.14 0.018 260);
+  scrollbar-width: thin;
+}
+.dark ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.dark ::-webkit-scrollbar-track {
+  background: oklch(0.14 0.018 260);
+}
+.dark ::-webkit-scrollbar-thumb {
+  background: oklch(0.3 0.015 260);
+  border-radius: 6px;
+  border: 2px solid oklch(0.14 0.018 260);
+}
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.38 0.015 260);
+}
+.dark ::-webkit-scrollbar-corner {
+  background: oklch(0.14 0.018 260);
+}
+
+/* Terminal-style code blocks for command builder */
+.command-block {
+  background: var(--command-bg) !important;
+  color: var(--command-fg);
+  border-radius: var(--radius-lg);
+  font-size: 0.9375rem;
+  line-height: 1.7;
+}
+
+.command-block .line {
+  padding: 0 1rem;
+}
+
+/* Theme-aware syntax highlighting (rehype-pretty-code dual themes via CSS vars) */
+html.dark .shiki,
+html.dark .shiki span {
+  color: var(--shiki-dark);
+  background-color: var(--shiki-dark-bg);
+  font-style: var(--shiki-dark-font-style);
+  font-weight: var(--shiki-dark-font-weight);
+  text-decoration: var(--shiki-dark-text-decoration);
+}
+
+/* ── Guide / Markdown typography ── */
+.guide-content {
+  font-size: 0.9375rem;
+  line-height: 1.75;
+  color: var(--foreground);
+}
+
+.guide-content h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  letter-spacing: -0.01em;
+}
+
+.guide-content h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.guide-content p {
+  margin-bottom: 0.75rem;
+  max-width: 72ch;
+}
+
+.guide-content ul, .guide-content ol {
+  margin-bottom: 0.75rem;
+  padding-left: 1.5rem;
+  max-width: 72ch;
+}
+
+.guide-content h2, .guide-content h3 {
+  max-width: 72ch;
+}
+
+.guide-content ul { list-style-type: disc; }
+.guide-content ol { list-style-type: decimal; }
+
+.guide-content li {
+  margin-bottom: 0.25rem;
+}
+
+.guide-content li::marker {
+  color: var(--muted-foreground);
+}
+
+.guide-content a {
+  color: var(--color-vllm-blue);
+  text-decoration: none;
+}
+.guide-content a:hover {
+  text-decoration: underline;
+}
+
+.guide-content strong {
+  font-weight: 600;
+}
+
+.guide-content code {
+  font-family: var(--font-mono);
+  font-size: 0.825em;
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+}
+
+.guide-content pre {
+  background: var(--code-block-bg);
+  color: var(--code-block-fg);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  margin-bottom: 1rem;
+  font-size: 0.8125rem;
+  line-height: 1.7;
+}
+
+.guide-content pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+.guide-content blockquote {
+  border-left: 3px solid var(--border);
+  padding-left: 1rem;
+  color: var(--muted-foreground);
+  margin-bottom: 0.75rem;
+}
+
+.guide-content table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.guide-content th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 2px solid var(--border);
+  color: var(--muted-foreground);
+}
+
+.guide-content td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.guide-content hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 1.5rem 0;
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,0 +1,112 @@
+import { Inter, JetBrains_Mono } from "next/font/google";
+import Link from "next/link";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { SearchBox } from "@/components/recipes/SearchBox";
+import { getAllRecipes } from "@/lib/recipes";
+import "./globals.css";
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin", "latin-ext"],
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains",
+  subsets: ["latin", "latin-ext"],
+  display: "swap",
+});
+
+export const metadata = {
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "https://recipes.vllm.ai"),
+  title: {
+    default: "vLLM Recipes",
+    template: "%s | vLLM Recipes",
+  },
+  description: "Deploy any model on any hardware with vLLM. Interactive command builder for model serving.",
+  icons: {
+    icon: { url: "https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-only-light.ico" },
+  },
+};
+
+export default async function RootLayout({ children }) {
+  // Recipes are small (~50 KB) — fine to load into every page for the
+  // global search box. Server-rendered, cached across requests.
+  const recipes = getAllRecipes();
+  // Drop the heavy `guide` field before sending to the client
+  const searchRecipes = recipes.map((r) => ({
+    hf_org: r.hf_org,
+    hf_repo: r.hf_repo,
+    hf_id: r.hf_id,
+    meta: {
+      title: r.meta.title,
+      provider: r.meta.provider,
+      description: r.meta.description,
+      tasks: r.meta.tasks,
+    },
+    model: {
+      architecture: r.model.architecture,
+      parameter_count: r.model.parameter_count,
+    },
+  }));
+
+  return (
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+      <body className="antialiased bg-background text-foreground min-h-screen flex flex-col">
+        {/* Global header */}
+        <header className="border-b border-border bg-background/95 backdrop-blur-sm sticky top-0 z-30">
+          <div className="max-w-[1480px] mx-auto px-4 sm:px-6 h-16 flex items-center gap-4">
+            <Link href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity group shrink-0">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-text-light.png"
+                alt="vLLM"
+                width={96}
+                height={36}
+                className="h-8 w-auto dark:hidden"
+              />
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="https://docs.vllm.ai/en/latest/assets/logos/vllm-logo-text-dark.png"
+                alt="vLLM"
+                width={96}
+                height={36}
+                className="h-8 w-auto hidden dark:block"
+              />
+              <span className="text-muted-foreground/50 font-light text-xl leading-none">/</span>
+              <span className="font-semibold text-base group-hover:text-vllm-blue transition-colors">Recipes</span>
+            </Link>
+
+            {/* Search — flex-1 so it expands to fill available space */}
+            <div className="flex-1 flex justify-center max-w-xl mx-auto">
+              <SearchBox recipes={searchRecipes} />
+            </div>
+
+            <nav className="flex items-center gap-4 text-sm text-muted-foreground shrink-0">
+              <a href="https://docs.vllm.ai" className="hover:text-foreground transition-colors hidden sm:inline">Docs</a>
+              <a href="https://github.com/vllm-project/recipes" className="hover:text-foreground transition-colors hidden sm:inline">GitHub</a>
+              <ThemeToggle />
+            </nav>
+          </div>
+        </header>
+
+        {/* Content */}
+        <div className="flex-1">
+          {children}
+        </div>
+
+        {/* Global footer */}
+        <footer className="border-t border-border mt-auto">
+          <div className="max-w-[1480px] mx-auto px-4 sm:px-6 py-5 text-xs text-muted-foreground flex flex-wrap gap-x-5 gap-y-2">
+            <a href="https://github.com/vllm-project/recipes" className="hover:text-foreground transition-colors">GitHub</a>
+            <a href="https://github.com/vllm-project/recipes/issues" className="hover:text-foreground transition-colors">Request a recipe</a>
+            <a href="https://docs.vllm.ai" className="hover:text-foreground transition-colors">Documentation</a>
+            <a href="https://vllm.ai/#compatibility" className="hover:text-foreground transition-colors">Supported Models & Hardware</a>
+            <a href="https://vllm.ai/#quick-start" className="hover:text-foreground transition-colors">Install vLLM</a>
+            <a href="/models.json" className="hover:text-foreground transition-colors">JSON API</a>
+          </div>
+        </footer>
+      </body>
+    </html>
+  );
+}

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-20 text-center">
+      <h1 className="text-2xl font-bold mb-2">404</h1>
+      <p className="text-muted-foreground mb-4">This page could not be found.</p>
+      <Link href="/" className="text-sm text-vllm-blue hover:underline">
+        Back to recipes
+      </Link>
+    </main>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,0 +1,37 @@
+import { Suspense } from "react";
+import { getAllRecipes } from "@/lib/recipes";
+import { RecipeCardGrid } from "@/components/recipes/RecipeCardGrid";
+
+export const metadata = {
+  title: "vLLM Recipes",
+  description: "How do I run model X on hardware Y? Pick a model, get a working vllm serve command.",
+};
+
+export default async function HomePage() {
+  const recipes = getAllRecipes();
+
+  return (
+    <main className="max-w-[1480px] mx-auto px-4 sm:px-6 py-8">
+      {/* ── Hero (compact) ── */}
+      <header className="mb-6">
+        <p className="text-sm text-muted-foreground max-w-3xl">
+          Pick a model, adjust for your GPUs, copy the <code className="font-mono text-[12px] bg-muted/50 px-1 py-0.5 rounded">vllm serve</code> line that runs.{" "}
+          Community-maintained recipes for NVIDIA H100/H200/B200/B300, Grace-Blackwell, and AMD MI300X/MI325X/MI355X.{" "}
+          <a
+            href="https://vllm.ai/#compatibility"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-vllm-blue hover:underline"
+          >
+            Full vLLM compatibility →
+          </a>
+        </p>
+      </header>
+
+      {/* ── Recipe catalog ── */}
+      <Suspense fallback={<div className="text-sm text-muted-foreground py-8">Loading...</div>}>
+        <RecipeCardGrid recipes={recipes} />
+      </Suspense>
+    </main>
+  );
+}

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package } from "lucide-react";
 import { resolveCommand, recommendStrategy, isPrecisionCompatible, pickDefaultHardware, pdFitsSingleNode } from "@/lib/command-synthesis";
@@ -72,6 +73,26 @@ function CopyButton({ text, className = "" }) {
 function PopoverButton({ label, code, icon: Icon }) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [rect, setRect] = useState(null);
+  const btnRef = useRef(null);
+
+  // When the popover opens, measure the button position so we can place the
+  // popover at a fixed viewport coordinate — the parent command card uses
+  // `overflow-hidden` for rounded-corner clipping, which would otherwise
+  // crop an absolute-positioned popover.
+  useEffect(() => {
+    if (!open) return;
+    const update = () => {
+      if (btnRef.current) setRect(btnRef.current.getBoundingClientRect());
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(code);
@@ -79,39 +100,46 @@ function PopoverButton({ label, code, icon: Icon }) {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const popover = open && rect && typeof document !== "undefined" ? createPortal(
+    <>
+      <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+      <div
+        className="fixed z-50 w-[440px] max-w-[90vw] rounded-xl border border-border bg-card shadow-xl overflow-hidden"
+        style={{ top: rect.bottom + 8, left: Math.max(8, rect.right - 440) }}
+      >
+        <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
+          <span className="text-xs font-semibold flex items-center gap-1.5">
+            <Icon size={12} /> {label}
+          </span>
+          <button
+            onClick={handleCopy}
+            className={`text-[11px] flex items-center gap-1 px-2 py-0.5 rounded transition-colors ${
+              copied ? "text-green-600 dark:text-green-400" : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {copied ? <><Check size={10} /> Copied</> : <><Copy size={10} /> Copy</>}
+          </button>
+        </div>
+        <pre className="px-3 py-2.5 text-xs font-mono leading-relaxed whitespace-pre overflow-x-auto bg-[var(--code-block-bg)] text-[var(--code-block-fg)]">
+          {code}
+        </pre>
+      </div>
+    </>,
+    document.body
+  ) : null;
+
   return (
-    <div className="relative">
+    <>
       <button
+        ref={btnRef}
         onClick={() => setOpen(!open)}
         className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-foreground/5 text-foreground/60 hover:bg-foreground/10 hover:text-foreground/90 transition-colors"
       >
         <Icon size={11} />
         {label}
       </button>
-      {open && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 top-full mt-2 z-50 w-[440px] max-w-[90vw] rounded-xl border border-border bg-card shadow-xl overflow-hidden">
-            <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
-              <span className="text-xs font-semibold flex items-center gap-1.5">
-                <Icon size={12} /> {label}
-              </span>
-              <button
-                onClick={handleCopy}
-                className={`text-[11px] flex items-center gap-1 px-2 py-0.5 rounded transition-colors ${
-                  copied ? "text-green-600 dark:text-green-400" : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                {copied ? <><Check size={10} /> Copied</> : <><Copy size={10} /> Copy</>}
-              </button>
-            </div>
-            <pre className="px-3 py-2.5 text-xs font-mono leading-relaxed whitespace-pre overflow-x-auto bg-[var(--code-block-bg)] text-[var(--code-block-fg)]">
-              {code}
-            </pre>
-          </div>
-        </>
-      )}
-    </div>
+      {popover}
+    </>
   );
 }
 
@@ -397,6 +425,13 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
 
   return (
     <div className="space-y-4">
+      {/* ── Install ── */}
+      <InstallBlock
+        recipe={recipe}
+        hwProfile={hwProfile}
+        result={result}
+      />
+
       {/* ── Dependencies / extra install ── */}
       {dependencies.length > 0 && <DependenciesBlock deps={dependencies} />}
 
@@ -685,7 +720,7 @@ function SingleCommandBlock({ command, env, verifyCmd, benchCmd, statusHeader })
         {statusHeader || <span className="text-[11px] text-[var(--command-fg)]/50 font-mono">vllm serve</span>}
         <div className="flex items-center gap-1.5">
           <CopyButton text={fullScript} />
-          <PopoverButton label="Verify" code={verifyCmd} icon={Terminal} />
+          <PopoverButton label="cURL" code={verifyCmd} icon={Terminal} />
           <PopoverButton label="Bench" code={benchCmd} icon={Gauge} />
         </div>
       </div>
@@ -697,6 +732,101 @@ function SingleCommandBlock({ command, env, verifyCmd, benchCmd, statusHeader })
       <pre className="px-4 py-3 text-[13px] text-[var(--command-fg)] font-mono leading-relaxed whitespace-pre overflow-x-auto">
         {command}
       </pre>
+    </div>
+  );
+}
+
+function InstallBlock({ recipe, hwProfile, result }) {
+  // Collapsible block above the command output showing pip/uv and Docker
+  // install one-liners. Hardware-aware — swaps NVIDIA / AMD ROCm variants.
+  // The "vLLM X.Y+" link still lives in the page header; this is the
+  // copyable, no-click-out install surface.
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState("pip");
+  const isAmd = hwProfile?.brand === "AMD";
+  const minV = recipe.model?.min_vllm_version;
+  const modelId = recipe.variants?.default?.model_id || recipe.model?.model_id || "MODEL";
+
+  const pipCmd = isAmd
+    ? `uv venv --python 3.12
+source .venv/bin/activate
+uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm`
+    : `uv venv
+source .venv/bin/activate
+uv pip install -U vllm --torch-backend auto`;
+
+  // Docker one-liner: only meaningful for single-node. Wraps the generated
+  // vllm serve command as the docker entrypoint's args.
+  const serveBody =
+    result?.deployType === "single_node" && result?.command
+      ? result.command.replace(/^vllm serve \S+\s*\\?\n?\s*/, "")
+      : "";
+  const dockerImage = isAmd ? "vllm/vllm-openai-rocm" : "vllm/vllm-openai";
+  const dockerGpuFlags = isAmd
+    ? "--device=/dev/kfd --device=/dev/dri \\\n  --security-opt seccomp=unconfined --group-add video"
+    : "--gpus all";
+  const envFlags = Object.entries(result?.env || {})
+    .map(([k, v]) => `-e ${k}=${v}`)
+    .join(" \\\n  ");
+  const dockerCmd = `docker run ${dockerGpuFlags} \\
+  --ipc=host -p 8000:8000 \\
+  -v ~/.cache/huggingface:/root/.cache/huggingface \\${envFlags ? `\n  ${envFlags} \\` : ""}
+  ${dockerImage} ${modelId}${serveBody ? ` \\\n  ${serveBody}` : ""}`;
+
+  const tabs = [
+    { id: "pip",    label: isAmd ? "pip / uv (ROCm)" : "pip / uv",       code: pipCmd    },
+    { id: "docker", label: isAmd ? "Docker (ROCm)"   : "Docker",         code: dockerCmd },
+  ];
+  const active = tabs.find((t) => t.id === tab) || tabs[0];
+
+  return (
+    <div className="rounded-2xl overflow-hidden bg-[var(--command-bg)] border border-border">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-white/[0.02] transition-colors"
+      >
+        <Package size={12} className="text-[var(--command-fg)]/50 shrink-0" />
+        <span className="text-[11px] font-semibold text-[var(--command-fg)]/70 uppercase tracking-widest">Install</span>
+        <span className="text-[11px] text-[var(--command-fg)]/40 font-mono">
+          vLLM {minV}+ · {isAmd ? "ROCm" : "CUDA"}
+        </span>
+        <span className="text-[11px] text-[var(--command-fg)]/40 ml-auto">
+          {open ? "hide" : "pip / Docker"}
+        </span>
+        <ChevronDown
+          size={14}
+          className={`text-[var(--command-fg)]/50 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open && (
+        <div className="border-t border-[var(--command-fg)]/10">
+          <div className="flex items-center justify-between px-4 pt-3">
+            <div className="flex gap-0.5 bg-foreground/5 rounded-md p-0.5">
+              {tabs.map((t) => (
+                <button
+                  key={t.id}
+                  onClick={() => setTab(t.id)}
+                  className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
+                    tab === t.id ? "bg-foreground/10 text-[var(--command-fg)]" : "text-[var(--command-fg)]/50 hover:text-[var(--command-fg)]/80"
+                  }`}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+            <CopyButton text={active.code} />
+          </div>
+          <pre className="px-4 py-3 text-[13px] text-[var(--command-fg)] font-mono leading-relaxed whitespace-pre overflow-x-auto">
+            {active.code}
+          </pre>
+          {tab === "docker" && result?.deployType !== "single_node" && (
+            <div className="px-4 pb-3 text-[11px] text-[var(--command-fg)]/45 leading-snug">
+              # Docker template shows single-node args. For multi-node / PD cluster, use the
+              # per-role commands below and wrap each in its own docker run.
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -763,7 +893,7 @@ function MultiNodeBlock({ result, verifyCmd, benchCmd, statusHeader }) {
           <CopyButton text={fullScript} />
           {tab === "head" && (
             <>
-              <PopoverButton label="Verify" code={verifyCmd} icon={Terminal} />
+              <PopoverButton label="cURL" code={verifyCmd} icon={Terminal} />
               <PopoverButton label="Bench" code={benchCmd} icon={Gauge} />
             </>
           )}
@@ -820,7 +950,7 @@ function PdClusterBlock({ result, verifyCmd, benchCmd, statusHeader }) {
           <CopyButton text={fullScript} />
           {active.isRouter && (
             <>
-              <PopoverButton label="Verify" code={verifyCmd} icon={Terminal} />
+              <PopoverButton label="cURL" code={verifyCmd} icon={Terminal} />
               <PopoverButton label="Bench" code={benchCmd} icon={Gauge} />
             </>
           )}

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -720,21 +720,31 @@ function SingleCommandBlock({ command, env, verifyCmd, benchCmd, statusHeader })
 function InstallBlock({ recipe, hwProfile, result, variant }) {
   // Collapsible block above the command output showing pip/uv and Docker
   // install one-liners. Hardware-aware — swaps NVIDIA / AMD ROCm variants.
-  // The "vLLM X.Y+" link still lives in the page header; this is the
-  // copyable, no-click-out install surface.
+  // Per-recipe overrides via `model.install.{pip,docker}`:
+  //   false              → hide that tab entirely
+  //   { command, note }  → override the generated one-liner and/or show a note
+  const install = recipe.model?.install || {};
+  const pipCfg = install.pip;
+  const dockerCfg = install.docker;
+  const pipHidden = pipCfg === false;
+  const dockerHidden = dockerCfg === false;
+
+  const defaultTab = pipHidden ? "docker" : "pip";
   const [open, setOpen] = useState(false);
-  const [tab, setTab] = useState("pip");
+  const [tab, setTab] = useState(defaultTab);
   const isAmd = hwProfile?.brand === "AMD";
   const minV = recipe.model?.min_vllm_version;
   const modelId = variant?.model_id || recipe.model?.model_id || "MODEL";
 
-  const pipCmd = isAmd
+  const defaultPipCmd = isAmd
     ? `uv venv --python 3.12
 source .venv/bin/activate
 uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm`
     : `uv venv
 source .venv/bin/activate
 uv pip install -U vllm --torch-backend auto`;
+  const pipCmd = pipCfg?.command || defaultPipCmd;
+  const pipNote = pipCfg?.note;
 
   // Docker one-liner: only meaningful for single-node. Wraps the generated
   // vllm serve command as the docker entrypoint's args.
@@ -753,16 +763,26 @@ uv pip install -U vllm --torch-backend auto`;
   const envFlags = Object.entries(result?.env || {})
     .map(([k, v]) => `-e ${k}=${v}`)
     .join(" \\\n  ");
-  const dockerCmd = `docker run ${dockerGpuFlags} \\
+  const defaultDockerCmd = `docker run ${dockerGpuFlags} \\
   --ipc=host -p 8000:8000 \\
   -v ~/.cache/huggingface:/root/.cache/huggingface \\${envFlags ? `\n  ${envFlags} \\` : ""}
   ${dockerImage} ${modelId}${serveBody ? ` \\\n  ${serveBody}` : ""}`;
+  const dockerCmd = dockerCfg?.command || defaultDockerCmd;
+  const dockerNote = dockerCfg?.note;
 
   const tabs = [
-    { id: "pip",    label: isAmd ? "pip / uv (ROCm)" : "pip / uv",       code: pipCmd    },
-    { id: "docker", label: isAmd ? "Docker (ROCm)"   : "Docker",         code: dockerCmd },
-  ];
+    !pipHidden && {
+      id: "pip", label: isAmd ? "pip / uv (ROCm)" : "pip / uv", code: pipCmd, note: pipNote,
+    },
+    !dockerHidden && {
+      id: "docker", label: isAmd ? "Docker (ROCm)" : "Docker", code: dockerCmd, note: dockerNote,
+    },
+  ].filter(Boolean);
+
+  // Guard: if both hidden, render nothing.
+  if (tabs.length === 0) return null;
   const active = tabs.find((t) => t.id === tab) || tabs[0];
+  const summary = tabs.map((t) => (t.id === "pip" ? "pip" : "Docker")).join(" / ");
 
   return (
     <div className="rounded-2xl overflow-hidden bg-[var(--command-bg)] border border-border">
@@ -776,7 +796,7 @@ uv pip install -U vllm --torch-backend auto`;
           vLLM {minV}+ · {isAmd ? "ROCm" : "CUDA"}
         </span>
         <span className="text-[11px] text-[var(--command-fg)]/40 ml-auto">
-          {open ? "hide" : "pip / Docker"}
+          {open ? "hide" : summary}
         </span>
         <ChevronDown
           size={14}
@@ -801,6 +821,11 @@ uv pip install -U vllm --torch-backend auto`;
             </div>
             <CopyButton text={active.code} />
           </div>
+          {active.note && (
+            <div className="px-4 pt-2 text-[11px] text-[var(--command-fg)]/55 leading-snug">
+              # {active.note}
+            </div>
+          )}
           <pre className="px-4 py-3 text-[13px] text-[var(--command-fg)] font-mono leading-relaxed whitespace-pre overflow-x-auto">
             {active.code}
           </pre>

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -418,6 +418,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
         recipe={recipe}
         hwProfile={hwProfile}
         result={result}
+        variant={currentVariant}
       />
 
       {/* ── Dependencies / extra install ── */}
@@ -716,7 +717,7 @@ function SingleCommandBlock({ command, env, verifyCmd, benchCmd, statusHeader })
   );
 }
 
-function InstallBlock({ recipe, hwProfile, result }) {
+function InstallBlock({ recipe, hwProfile, result, variant }) {
   // Collapsible block above the command output showing pip/uv and Docker
   // install one-liners. Hardware-aware — swaps NVIDIA / AMD ROCm variants.
   // The "vLLM X.Y+" link still lives in the page header; this is the
@@ -725,7 +726,7 @@ function InstallBlock({ recipe, hwProfile, result }) {
   const [tab, setTab] = useState("pip");
   const isAmd = hwProfile?.brand === "AMD";
   const minV = recipe.model?.min_vllm_version;
-  const modelId = recipe.variants?.default?.model_id || recipe.model?.model_id || "MODEL";
+  const modelId = variant?.model_id || recipe.model?.model_id || "MODEL";
 
   const pipCmd = isAmd
     ? `uv venv --python 3.12
@@ -741,7 +742,11 @@ uv pip install -U vllm --torch-backend auto`;
     result?.deployType === "single_node" && result?.command
       ? result.command.replace(/^vllm serve \S+\s*\\?\n?\s*/, "")
       : "";
-  const dockerImage = isAmd ? "vllm/vllm-openai-rocm" : "vllm/vllm-openai";
+  // Per-recipe Docker image/tag override. Precedence: variant → model → default.
+  // Use full `image:tag`, e.g. `vllm/vllm-openai:glm51` when the model needs a
+  // pinned build before its support lands in :latest.
+  const dockerOverride = variant?.docker_image || recipe.model?.docker_image;
+  const dockerImage = dockerOverride || (isAmd ? "vllm/vllm-openai-rocm" : "vllm/vllm-openai");
   const dockerGpuFlags = isAmd
     ? "--device=/dev/kfd --device=/dev/dri \\\n  --security-opt seccomp=unconfined --group-add video"
     : "--gpus all";

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -1,0 +1,790 @@
+"use client";
+
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package } from "lucide-react";
+import { resolveCommand, recommendStrategy, isPrecisionCompatible, pickDefaultHardware, pdFitsSingleNode } from "@/lib/command-synthesis";
+
+// Advanced tuning presets — optional tunable flags the user can opt into.
+// (vLLM defaults like chunked prefill, prefix caching, CUDA graphs, async
+// scheduling are already on — no need to surface them here.)
+// `gatedBy(recipe, activeStrategy)` hides an option when the recipe or current
+// strategy can't support it. This keeps casual users from selecting invalid
+// combos (e.g. EP on a dense model) while still exposing parallelism knobs.
+const ADVANCED_OPTIONS = [
+  {
+    id: "max_batched_8k",
+    label: "max-num-batched-tokens = 8192",
+    description: "Tunable batch budget; 8192 is a common sweet spot",
+    args: ["--max-num-batched-tokens", "8192"],
+  },
+  {
+    id: "max_num_seqs_256",
+    label: "max-num-seqs = 256",
+    description: "Max concurrent sequences per batch; lower for latency, higher for throughput",
+    args: ["--max-num-seqs", "256"],
+  },
+  {
+    id: "gpu_mem_095",
+    label: "gpu-memory-utilization = 0.95",
+    description: "Push KV cache further; use with caution on shared GPUs",
+    args: ["--gpu-memory-utilization", "0.95"],
+  },
+  {
+    id: "max_model_len_auto",
+    label: "max-model-len = auto",
+    description: "Auto-size context window to what KV cache can hold on your hardware",
+    args: ["--max-model-len", "auto"],
+  },
+  {
+    id: "dcp_8",
+    label: "decode-context-parallel-size = 8",
+    description:
+      "Shard the KV cache at decode time across TP ranks. MLA-attention models only (DeepSeek, Kimi-K2). Max DCP = tensor-parallel-size ÷ num_kv_heads.",
+    args: ["--decode-context-parallel-size", "8"],
+    gatedBy: (recipe) => recipe?.model?.supports_dcp === true,
+  },
+];
+const ADVANCED_BY_ID = Object.fromEntries(ADVANCED_OPTIONS.map((o) => [o.id, o]));
+import { loadPreferences, savePreference } from "@/lib/preferences";
+
+function CopyButton({ text, className = "" }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+  return (
+    <button
+      onClick={handleCopy}
+      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+        copied
+          ? "bg-green-500/20 text-green-600 dark:text-green-400"
+          : "bg-foreground/10 text-foreground/60 hover:bg-foreground/15 hover:text-foreground/90"
+      } ${className}`}
+    >
+      {copied ? <><Check size={12} /> Copied</> : <><Copy size={12} /> Copy</>}
+    </button>
+  );
+}
+
+function PopoverButton({ label, code, icon: Icon }) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-foreground/5 text-foreground/60 hover:bg-foreground/10 hover:text-foreground/90 transition-colors"
+      >
+        <Icon size={11} />
+        {label}
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-full mt-2 z-50 w-[440px] max-w-[90vw] rounded-xl border border-border bg-card shadow-xl overflow-hidden">
+            <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/30">
+              <span className="text-xs font-semibold flex items-center gap-1.5">
+                <Icon size={12} /> {label}
+              </span>
+              <button
+                onClick={handleCopy}
+                className={`text-[11px] flex items-center gap-1 px-2 py-0.5 rounded transition-colors ${
+                  copied ? "text-green-600 dark:text-green-400" : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {copied ? <><Check size={10} /> Copied</> : <><Copy size={10} /> Copy</>}
+              </button>
+            </div>
+            <pre className="px-3 py-2.5 text-xs font-mono leading-relaxed whitespace-pre overflow-x-auto bg-[var(--code-block-bg)] text-[var(--code-block-fg)]">
+              {code}
+            </pre>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function CommandBuilder({ recipe, strategies, taxonomy }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // ── State ──
+  const [variant, setVariant] = useState(searchParams.get("variant") || "default");
+
+  // Compute default hardware: URL param > stored preference (if compatible) > smallest compatible profile
+  // Smart default hardware: picks a profile compatible with the URL's variant
+  // (respecting both VRAM and precision constraints — e.g., NVFP4 → B200).
+  const defaultHw = useMemo(() => {
+    const urlVariant = searchParams.get("variant") || "default";
+    const v = recipe.variants?.[urlVariant] || recipe.variants?.default || {};
+    return pickDefaultHardware(taxonomy.hardware_profiles, v);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recipe, taxonomy]);
+
+  const [hwId, setHwId] = useState(searchParams.get("hardware") || defaultHw);
+
+  // After mount: restore an NVIDIA hardware preference from localStorage.
+  // (AMD is opt-in per session, never the page-load default — H200 stays canonical.)
+  useEffect(() => {
+    if (!searchParams.get("hardware")) {
+      const prefs = loadPreferences();
+      if (prefs.hardware) {
+        const v = recipe.variants?.[variant] || recipe.variants?.default || {};
+        const prefProfile = taxonomy.hardware_profiles?.[prefs.hardware];
+        if (prefProfile?.brand === "NVIDIA" && isPrecisionCompatible(prefProfile, v)) {
+          setHwId(prefs.hardware);
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Recipes without a multi_node_* / pd_cluster strategy can't scale beyond one
+  // node — force nodeCount to 1 in that case, even if the URL says otherwise.
+  const supportsMultiNode = (recipe.compatible_strategies || []).some(
+    (s) => s.startsWith("multi_node_") || s === "pd_cluster"
+  );
+  const [nodeCount, setNodeCount] = useState(() => {
+    const n = parseInt(searchParams.get("nodes") || "1", 10);
+    if (!supportsMultiNode) return 1;
+    return [1, 2].includes(n) ? n : 1;
+  });
+  const [strategyOverride, setStrategyOverride] = useState(searchParams.get("strategy") || "");
+  const [features, setFeatures] = useState(() => {
+    const fp = searchParams.get("features");
+    if (fp) return fp.split(",").filter(Boolean);
+    return Object.keys(recipe.features || {}).filter((f) => !(recipe.opt_in_features || []).includes(f));
+  });
+
+  // Advanced tuning flags (defaults off) — toggled independently from features
+  const [advanced, setAdvanced] = useState(() => {
+    const ap = searchParams.get("advanced");
+    return ap ? ap.split(",").filter(Boolean) : [];
+  });
+
+  // ── Derived ──
+  const currentVariant = recipe.variants?.[variant] || recipe.variants?.default || {};
+
+  // All hardware profiles grouped by brand, sorted by architectural generation
+  // within brand (oldest → newest; matches the semianalysis GPU timeline).
+  const hwByBrand = useMemo(() => {
+    const NVIDIA_ORDER = ["h100", "h200", "b200", "gb200", "b300", "gb300"];
+    const AMD_ORDER = ["mi300x", "mi325x", "mi355x"];
+    const rankIn = (list, id) => {
+      const i = list.indexOf(id);
+      return i === -1 ? 9999 : i;
+    };
+    const groups = {};
+    for (const [id, p] of Object.entries(taxonomy.hardware_profiles || {})) {
+      const brand = p.brand || "Other";
+      if (!groups[brand]) groups[brand] = [];
+      groups[brand].push([id, p]);
+    }
+    for (const [brand, profiles] of Object.entries(groups)) {
+      const list = brand === "NVIDIA" ? NVIDIA_ORDER : brand === "AMD" ? AMD_ORDER : [];
+      profiles.sort((a, b) => {
+        const ra = rankIn(list, a[0]);
+        const rb = rankIn(list, b[0]);
+        if (ra !== rb) return ra - rb;
+        return (a[1].vram_gb || 0) - (b[1].vram_gb || 0);
+      });
+    }
+    const brandOrder = ["NVIDIA", "AMD"];
+    return Object.entries(groups).sort(
+      ([a], [b]) => {
+        const ai = brandOrder.indexOf(a);
+        const bi = brandOrder.indexOf(b);
+        if (ai === -1 && bi === -1) return a.localeCompare(b);
+        if (ai === -1) return 1;
+        if (bi === -1) return -1;
+        return ai - bi;
+      }
+    );
+  }, [taxonomy]);
+
+  const hwProfile = taxonomy.hardware_profiles?.[hwId] || {};
+
+  const recommended = useMemo(() => recommendStrategy(recipe, hwProfile, nodeCount), [recipe, hwProfile, nodeCount]);
+
+  // If the overridden strategy is pd_cluster in single-node mode but the
+  // current hardware can't hold 2× the model, silently fall back to the
+  // recommended strategy so the rendered command is always runnable.
+  const strategyOverrideValid = useMemo(() => {
+    if (!strategyOverride) return true;
+    if (strategyOverride === "pd_cluster" && nodeCount === 1) {
+      return pdFitsSingleNode(hwProfile, currentVariant);
+    }
+    return true;
+  }, [strategyOverride, nodeCount, hwProfile, currentVariant]);
+  const activeStrategy = strategyOverrideValid ? (strategyOverride || recommended) : recommended;
+
+  const compatibleStrategies = useMemo(() => {
+    return (recipe.compatible_strategies || []).filter((s) => {
+      const strat = strategies[s];
+      if (!strat) return false;
+      if (nodeCount === 1 && strat.deploy_type === "multi_node") return false;
+      if (nodeCount > 1 && strat.deploy_type === "single_node") return false;
+      return true;
+    });
+  }, [recipe, strategies, nodeCount]);
+
+  const result = useMemo(
+    () => {
+      const advArgs = advanced.flatMap((id) => ADVANCED_BY_ID[id]?.args || []);
+      return resolveCommand(recipe, variant, activeStrategy, hwId, features, strategies, taxonomy, advArgs, nodeCount);
+    },
+    [recipe, variant, activeStrategy, hwId, features, advanced, strategies, taxonomy, nodeCount]
+  );
+
+  // Visual feedback when any rendered command changes. Covers single-node
+  // (result.command), multi-node (headCommand), and pd_cluster (prefill.command).
+  const commandFingerprint = result.command
+    || result.headCommand
+    || result.prefill?.command
+    || "";
+  const [changed, setChanged] = useState(false);
+  useEffect(() => {
+    setChanged(true);
+    const t = setTimeout(() => setChanged(false), 600);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [commandFingerprint]);
+
+  // ── URL sync ──
+  const syncUrl = useCallback(
+    (updates) => {
+      const sp = new URLSearchParams(searchParams.toString());
+      for (const [k, v] of Object.entries(updates)) {
+        if (v && v !== "default" && v !== recommended) sp.set(k, v);
+        else sp.delete(k);
+      }
+      const qs = sp.toString();
+      router.replace(qs ? `?${qs}` : pathname, { scroll: false });
+    },
+    [searchParams, router, recommended, pathname]
+  );
+
+  // ── Handlers ──
+  const selectVariant = (key) => {
+    setVariant(key);
+    syncUrl({ variant: key });
+    // Only swap hardware when precision demands it (e.g. NVFP4 needs Blackwell).
+    // VRAM is not a blocker because multi-node TP/DP can always supply more.
+    const v = recipe.variants?.[key] || {};
+    const currentProfile = taxonomy.hardware_profiles?.[hwId] || {};
+    if (!isPrecisionCompatible(currentProfile, v)) {
+      const next = pickDefaultHardware(taxonomy.hardware_profiles, v);
+      setHwId(next);
+      syncUrl({ hardware: next });
+    }
+  };
+
+  const selectHardware = (id) => {
+    setHwId(id);
+    setStrategyOverride("");
+    syncUrl({ hardware: id, strategy: "" });
+    savePreference("hardware", id);
+  };
+
+  const selectStrategy = (s) => {
+    setStrategyOverride(s);
+    syncUrl({ strategy: s });
+  };
+
+  const selectNodes = (n) => {
+    setNodeCount(n);
+    setStrategyOverride("");
+    syncUrl({ nodes: n === 1 ? "" : String(n), strategy: "" });
+  };
+
+  const toggleFeature = (f) => {
+    const next = features.includes(f) ? features.filter((x) => x !== f) : [...features, f];
+    setFeatures(next);
+    syncUrl({ features: next.length > 0 ? next.join(",") : "" });
+  };
+
+  const toggleAdvanced = (id) => {
+    const next = advanced.includes(id) ? advanced.filter((x) => x !== id) : [...advanced, id];
+    setAdvanced(next);
+    syncUrl({ advanced: next.length > 0 ? next.join(",") : "" });
+  };
+
+  const isPd = result.deployType === "pd_cluster";
+  const isMultiNode = result.deployType === "multi_node";
+  const modelId = recipe.variants?.[variant]?.model_id || recipe.model?.model_id || "model";
+
+  // PD clients hit the router (port 30000), everyone else hits `vllm serve` on 8000.
+  const clientPort = isPd ? 30000 : 8000;
+
+  const verifyCmd = `curl http://localhost:${clientPort}/v1/chat/completions \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${modelId}",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'`;
+
+  const benchCmd = `vllm bench serve \\
+  --model ${modelId} \\
+  --host localhost \\
+  --port ${clientPort} \\
+  --dataset-name random \\
+  --random-input-len 1024 \\
+  --random-output-len 1024 \\
+  --num-prompts 100 \\
+  --max-concurrency 32`;
+
+  const dependencies = recipe.dependencies || [];
+
+  // Omni models are served via vLLM-Omni (offline Python inference), not `vllm serve`.
+  // Skip the command/strategy/feature UI and just show install deps + a pointer to the guide.
+  const isOmni = (recipe.meta?.tasks || []).includes("omni");
+  if (isOmni) {
+    return (
+      <div className="space-y-4">
+        {dependencies.length > 0 && <DependenciesBlock deps={dependencies} />}
+        <div className="rounded-2xl border border-border bg-muted/20 px-5 py-4 text-sm">
+          <div className="font-medium mb-1 flex items-center gap-2">
+            <Sparkles size={14} className="text-vllm-yellow" />
+            Served via vLLM-Omni (offline inference)
+          </div>
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            This model runs as an offline Python workflow, not a long-running <code className="font-mono text-[11px] px-1 py-0.5 rounded bg-foreground/5">vllm serve</code> endpoint.
+            See the <strong>Guide</strong> below for the exact inference script and parameters.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* ── Dependencies / extra install ── */}
+      {dependencies.length > 0 && <DependenciesBlock deps={dependencies} />}
+
+      {/* ── Command output ── */}
+      <div
+        className={`rounded-2xl overflow-hidden bg-[var(--command-bg)] border border-border transition-shadow ${
+          changed ? "ring-2 ring-vllm-blue/30" : ""
+        }`}
+      >
+        {isPd ? (
+          <PdClusterBlock result={result} verifyCmd={verifyCmd} benchCmd={benchCmd} />
+        ) : isMultiNode ? (
+          <MultiNodeBlock result={result} verifyCmd={verifyCmd} benchCmd={benchCmd} />
+        ) : (
+          <SingleCommandBlock
+            command={result.command}
+            env={result.env}
+            verifyCmd={verifyCmd}
+            benchCmd={benchCmd}
+          />
+        )}
+      </div>
+
+      {/* ── Configuration ── */}
+      <div className="rounded-xl border border-border divide-y divide-border">
+        {/* Hardware (first — user's fixed constraint, grouped by brand) */}
+        <ConfigRow label="Hardware">
+          <div className="space-y-1.5">
+            {hwByBrand.map(([brand, profiles]) => (
+              <div key={brand} className="flex flex-wrap items-center gap-2">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70 w-14 shrink-0">
+                  {brand}
+                </span>
+                <PillGroup>
+                  {profiles.map(([id, p]) => {
+                    const precisionOk = isPrecisionCompatible(p, currentVariant);
+                    // When single-node PD is the active strategy, the hardware must fit
+                    // 2× the model (prefill + decode pools share one node).
+                    const pdSingleNodeCheck = activeStrategy === "pd_cluster" && nodeCount === 1;
+                    const pdOk = !pdSingleNodeCheck || pdFitsSingleNode(p, currentVariant);
+                    const disabled = !precisionOk || !pdOk;
+                    const reason = !precisionOk
+                      ? `${currentVariant.precision?.toUpperCase()} requires NVIDIA Blackwell`
+                      : !pdOk
+                      ? `Single-node PD needs 2× model VRAM (${2 * (currentVariant.vram_minimum_gb || 0)} GB). Switch to Multi-node or pick a larger GPU.`
+                      : p.description;
+                    return (
+                      <Pill
+                        key={id}
+                        active={hwId === id}
+                        disabled={disabled}
+                        onClick={() => !disabled && selectHardware(id)}
+                        title={reason}
+                      >
+                        <span className="font-semibold">{p.display_name}</span>
+                        {p.vram_gb > 0 && p.gpu_count > 0 && (
+                          <span className="text-muted-foreground ml-1.5 font-mono">
+                            {p.gpu_count}×{Math.round(p.vram_gb / p.gpu_count)}G
+                          </span>
+                        )}
+                      </Pill>
+                    );
+                  })}
+                </PillGroup>
+              </div>
+            ))}
+          </div>
+        </ConfigRow>
+
+        {/* Variant */}
+        <ConfigRow label="Variant">
+          <PillGroup>
+            {Object.entries(recipe.variants || {}).map(([key, v]) => (
+              <Pill
+                key={key}
+                active={variant === key}
+                onClick={() => selectVariant(key)}
+                title={`Min ${v.vram_minimum_gb} GB total VRAM — scale out via multi-node if needed`}
+              >
+                <span className="font-mono font-semibold">{v.precision?.toUpperCase()}</span>
+                <span className="text-muted-foreground ml-1.5 font-mono">{v.vram_minimum_gb} GB</span>
+              </Pill>
+            ))}
+          </PillGroup>
+        </ConfigRow>
+
+        {/* Strategy */}
+        <ConfigRow label="Strategy">
+          <PillGroup>
+            {compatibleStrategies.map((s) => {
+              const isPdSingleNode = s === "pd_cluster" && nodeCount === 1;
+              const pdBlocked = isPdSingleNode && !pdFitsSingleNode(hwProfile, currentVariant);
+              const disabled = pdBlocked;
+              return (
+                <Pill
+                  key={s}
+                  active={activeStrategy === s}
+                  disabled={disabled}
+                  onClick={() => !disabled && selectStrategy(s)}
+                  title={
+                    pdBlocked
+                      ? `Single-node PD needs 2× model VRAM (${2 * (currentVariant.vram_minimum_gb || 0)} GB). Switch to Multi-node or a larger GPU.`
+                      : strategies[s]?.description
+                  }
+                >
+                  <span className="font-semibold">{strategies[s]?.display_name || s}</span>
+                  {s === recommended && !disabled && (
+                    <Sparkles size={10} className="text-vllm-yellow ml-1" />
+                  )}
+                </Pill>
+              );
+            })}
+          </PillGroup>
+          {strategies[activeStrategy]?.description && (
+            <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
+              {strategies[activeStrategy].description.split("\n")[0]}
+            </p>
+          )}
+        </ConfigRow>
+
+        {/* Nodes */}
+        <ConfigRow label="Nodes">
+          <PillGroup>
+            {[1, 2].map((n) => {
+              // Multi-node pill is disabled when the recipe declares no
+              // multi_node_* (or pd_cluster) strategy. Small dense models
+              // commonly omit these.
+              const disabled = n > 1 && !supportsMultiNode;
+              return (
+                <Pill
+                  key={n}
+                  active={nodeCount === n}
+                  disabled={disabled}
+                  onClick={() => !disabled && selectNodes(n)}
+                  title={
+                    disabled
+                      ? "This recipe does not declare a multi-node strategy. Fits in a single node."
+                      : n === 1
+                      ? "Single-node deployment (one HGX box)"
+                      : `2 nodes × ${hwProfile.gpu_count || 8} GPUs = ${2 * (hwProfile.gpu_count || 8)} GPUs total. Scale further by replicating the worker command with higher --node-rank / --data-parallel-start-rank.`
+                  }
+                >
+                  <span className="font-semibold">{n === 1 ? "Single node" : "Multi-node (example: 2)"}</span>
+                  {n > 1 && !disabled && (
+                    <span className="text-muted-foreground ml-1.5 font-mono">
+                      {2 * (hwProfile.gpu_count || 8)}×GPU
+                    </span>
+                  )}
+                </Pill>
+              );
+            })}
+          </PillGroup>
+        </ConfigRow>
+
+        {/* Features */}
+        {Object.keys(recipe.features || {}).length > 0 && (
+          <ConfigRow label="Features">
+            <PillGroup>
+              {Object.entries(recipe.features || {}).map(([key]) => (
+                <Pill
+                  key={key}
+                  active={features.includes(key)}
+                  onClick={() => toggleFeature(key)}
+                >
+                  {key.replace(/_/g, " ")}
+                </Pill>
+              ))}
+            </PillGroup>
+          </ConfigRow>
+        )}
+
+        {/* Advanced (collapsed by default) */}
+        <details className="group">
+          <summary className="px-4 py-3 cursor-pointer text-[10px] font-semibold text-muted-foreground uppercase tracking-widest hover:bg-muted/30 transition-colors flex items-center gap-2 select-none list-none">
+            <span>Advanced</span>
+            <span className="text-muted-foreground/50 normal-case tracking-normal font-normal">
+              {advanced.length > 0 ? `(${advanced.length} enabled)` : "— performance tuning"}
+            </span>
+            <ChevronDown size={12} className="ml-auto group-open:rotate-180 transition-transform" />
+          </summary>
+          <div className="px-4 pb-4 pt-1 border-t border-border/60">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {ADVANCED_OPTIONS.filter((opt) => !opt.gatedBy || opt.gatedBy(recipe, activeStrategy)).map((opt) => (
+                <label
+                  key={opt.id}
+                  className={`flex items-start gap-2.5 p-2 rounded-lg border cursor-pointer transition-colors ${
+                    advanced.includes(opt.id)
+                      ? "border-vllm-blue/40 bg-vllm-blue/5"
+                      : "border-border hover:bg-muted/30"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={advanced.includes(opt.id)}
+                    onChange={() => toggleAdvanced(opt.id)}
+                    className="accent-vllm-blue mt-0.5"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-xs font-medium">{opt.label}</div>
+                    <div className="text-[10px] text-muted-foreground mt-0.5 leading-snug">{opt.description}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+        </details>
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-components ──
+
+function ConfigRow({ label, children }) {
+  return (
+    <div className="px-4 py-3 flex flex-col sm:flex-row sm:items-start gap-2 sm:gap-4">
+      <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest sm:w-20 sm:pt-1.5 shrink-0">
+        {label}
+      </div>
+      <div className="flex-1 min-w-0">{children}</div>
+    </div>
+  );
+}
+
+function PillGroup({ children }) {
+  return <div className="flex flex-wrap gap-1.5">{children}</div>;
+}
+
+function Pill({ active, onClick, title, dimmed, disabled, children }) {
+  // disabled takes precedence over active — an "active but disabled" pill should
+  // clearly look disabled (e.g. PD that was pre-selected but no longer fits).
+  const style = disabled
+    ? "border-dashed border-border/40 text-muted-foreground/30 cursor-not-allowed bg-muted/20 line-through decoration-muted-foreground/30"
+    : active
+    ? "border-vllm-blue bg-vllm-blue/5 text-foreground ring-1 ring-vllm-blue/20 shadow-sm"
+    : dimmed
+    ? "border-dashed border-border/60 text-muted-foreground/50 hover:text-muted-foreground hover:border-muted-foreground/30"
+    : "border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground/40 hover:bg-muted/30";
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      disabled={disabled}
+      aria-disabled={disabled}
+      className={`inline-flex items-center rounded-lg border px-2.5 py-1.5 text-xs transition-all ${style}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function envToExports(env) {
+  return Object.entries(env || {})
+    .map(([k, v]) => `export ${k}=${v}`)
+    .join("\n");
+}
+
+function SingleCommandBlock({ command, env, verifyCmd, benchCmd }) {
+  const envLines = envToExports(env);
+  const fullScript = envLines ? `${envLines}\n\n${command}` : command;
+  return (
+    <div>
+      <div className="flex items-center justify-between px-4 pt-3">
+        <span className="text-[11px] text-[var(--command-fg)]/50 font-mono">vllm serve</span>
+        <div className="flex items-center gap-1.5">
+          <CopyButton text={fullScript} />
+          <PopoverButton label="Verify" code={verifyCmd} icon={Terminal} />
+          <PopoverButton label="Bench" code={benchCmd} icon={Gauge} />
+        </div>
+      </div>
+      {envLines && (
+        <pre className="px-4 pt-3 pb-1 text-[12px] text-[var(--command-fg)]/70 font-mono leading-relaxed whitespace-pre overflow-x-auto">
+          {envLines}
+        </pre>
+      )}
+      <pre className="px-4 py-3 text-[13px] text-[var(--command-fg)] font-mono leading-relaxed whitespace-pre overflow-x-auto">
+        {command}
+      </pre>
+    </div>
+  );
+}
+
+function DependenciesBlock({ deps }) {
+  const allCommands = deps.map((d) => d.command).join("\n");
+  const requiredCount = deps.filter((d) => !d.optional).length;
+  const optionalCount = deps.length - requiredCount;
+  return (
+    <div className="rounded-2xl overflow-hidden bg-[var(--command-bg)] border border-border">
+      <div className="flex items-center justify-between px-4 pt-3">
+        <span className="text-[11px] text-[var(--command-fg)]/50 font-mono inline-flex items-center gap-1.5">
+          <Package size={11} /> extra install
+          {requiredCount > 0 && <span className="text-[var(--command-fg)]/40">· {requiredCount} required</span>}
+          {optionalCount > 0 && <span className="text-[var(--command-fg)]/40">· {optionalCount} optional</span>}
+        </span>
+        <CopyButton text={allCommands} />
+      </div>
+      <div className="px-4 py-3 text-[13px] font-mono leading-relaxed overflow-x-auto space-y-2">
+        {deps.map((d, i) => (
+          <div key={i}>
+            {d.note && (
+              <div className="text-[var(--command-fg)]/45 text-[11px] leading-snug mb-0.5">
+                # {d.note}{d.optional ? " (optional)" : ""}
+              </div>
+            )}
+            <div className="text-[var(--command-fg)] whitespace-pre">{d.command}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MultiNodeBlock({ result, verifyCmd, benchCmd }) {
+  const [tab, setTab] = useState("head");
+  const tabs = [
+    { id: "head", label: "Head", command: result.headCommand },
+    { id: "worker", label: "Node 1", command: result.workerCommand },
+  ];
+  const active = tabs.find((t) => t.id === tab) || tabs[0];
+  const envLines = envToExports(result.env);
+  const fullScript = envLines ? `${envLines}\n\n${active.command}` : active.command;
+  return (
+    <div>
+      <div className="flex items-center justify-between px-4 pt-3">
+        <div className="flex gap-0.5 bg-foreground/5 rounded-md p-0.5">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
+                tab === t.id ? "bg-foreground/10 text-[var(--command-fg)]" : "text-[var(--command-fg)]/50 hover:text-[var(--command-fg)]/80"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <CopyButton text={fullScript} />
+          {tab === "head" && (
+            <>
+              <PopoverButton label="Verify" code={verifyCmd} icon={Terminal} />
+              <PopoverButton label="Bench" code={benchCmd} icon={Gauge} />
+            </>
+          )}
+        </div>
+      </div>
+      {envLines && (
+        <pre className="px-4 pt-3 pb-1 text-[12px] text-[var(--command-fg)]/70 font-mono leading-relaxed whitespace-pre overflow-x-auto">
+          {envLines}
+        </pre>
+      )}
+      <pre className="px-4 py-3 text-[13px] text-[var(--command-fg)] font-mono leading-relaxed whitespace-pre overflow-x-auto">
+        {active.command}
+      </pre>
+      <div className="px-4 pb-3 text-[11px] text-[var(--command-fg)]/45 font-mono leading-snug">
+        # Set $HEAD_IP to the rank-0 node's IP before launch. Scale to N nodes by replicating
+        # this worker command with --node-rank = i (TP/TEP) or --data-parallel-start-rank = i × local_gpus (DEP).
+      </div>
+    </div>
+  );
+}
+
+function PdClusterBlock({ result, verifyCmd, benchCmd }) {
+  // Tabs: Prefill · Decode · Router (same shape whether single-node or multi-node;
+  // only the CUDA_VISIBLE_DEVICES split and TP size differ).
+  const [tab, setTab] = useState("prefill");
+  const tabs = [
+    { id: "prefill", label: "Prefill", command: result.prefill.command, env: result.prefill.env },
+    { id: "decode",  label: "Decode",  command: result.decode.command,  env: result.decode.env },
+    { id: "router",  label: "Router",  command: result.router.command, env: {}, install: result.router.install, isRouter: true },
+  ];
+  const active = tabs.find((t) => t.id === tab) || tabs[0];
+  const envLines = envToExports(active.env);
+  const fullScript = envLines ? `${envLines}\n\n${active.command}` : active.command;
+  return (
+    <div>
+      <div className="flex items-center justify-between px-4 pt-3 gap-3">
+        <div className="flex flex-wrap gap-0.5 bg-foreground/5 rounded-md p-0.5">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`px-2.5 py-1 text-xs font-medium rounded transition-colors whitespace-nowrap ${
+                tab === t.id ? "bg-foreground/10 text-[var(--command-fg)]" : "text-[var(--command-fg)]/50 hover:text-[var(--command-fg)]/80"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <CopyButton text={fullScript} />
+          {active.isRouter && (
+            <>
+              <PopoverButton label="Verify" code={verifyCmd} icon={Terminal} />
+              <PopoverButton label="Bench" code={benchCmd} icon={Gauge} />
+            </>
+          )}
+        </div>
+      </div>
+      {active.isRouter && active.install && (
+        <div className="px-4 pt-3 text-[11px] text-[var(--command-fg)]/50 font-mono leading-snug">
+          # Dependency: {active.install}
+        </div>
+      )}
+      {envLines && (
+        <pre className="px-4 pt-3 pb-1 text-[12px] text-[var(--command-fg)]/70 font-mono leading-relaxed whitespace-pre overflow-x-auto">
+          {envLines}
+        </pre>
+      )}
+      <pre className="px-4 py-3 text-[13px] text-[var(--command-fg)] font-mono leading-relaxed whitespace-pre overflow-x-auto">
+        {active.command}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -376,31 +376,19 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
 
   const dependencies = recipe.dependencies || [];
 
-  // Status caption for the command block header — replaces the redundant
-  // "vllm serve" label with something actually useful (support level for
-  // the selected hardware).
-  const hwStatus = recipe.meta?.hardware?.[hwId]; // "verified" | "supported" | undefined
-  const hwName = hwProfile?.display_name || hwId;
+  // Status caption for the command block header.
+  // Only `verified` is a positive signal worth surfacing; anything else
+  // falls back to a neutral "vllm serve" label (treat as "assumed to work").
+  const hwStatus = recipe.meta?.hardware?.[hwId]; // "verified" | undefined
+  const hwFullName = hwProfile?.brand
+    ? `${hwProfile.brand} ${hwProfile.display_name || hwId}`
+    : (hwProfile?.display_name || hwId);
   const statusHeader = hwStatus === "verified" ? (
     <span className="text-[11px] font-medium text-green-500 inline-flex items-center gap-1.5">
       <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500" />
-      Verified on {hwName}
+      Verified on {hwFullName}
     </span>
-  ) : hwStatus === "supported" ? (
-    <span className="text-[11px] font-medium text-vllm-blue inline-flex items-center gap-1.5">
-      <span className="inline-block w-1.5 h-1.5 rounded-full bg-vllm-blue/80" />
-      Supported on {hwName}
-      <span className="text-[var(--command-fg)]/40">· not verified</span>
-    </span>
-  ) : (
-    <span
-      className="text-[11px] font-medium text-[var(--command-fg)]/50 inline-flex items-center gap-1.5"
-      title="Recipe does not declare this hardware. Flags are generic vLLM defaults and may need tuning."
-    >
-      <span className="inline-block w-1.5 h-1.5 rounded-full ring-1 ring-inset ring-[var(--command-fg)]/30" />
-      Untested on {hwName}
-    </span>
-  );
+  ) : null;
 
   // Omni models are served via vLLM-Omni (offline Python inference), not `vllm serve`.
   // Skip the command/strategy/feature UI and just show install deps + a pointer to the guide.
@@ -474,19 +462,16 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                     const pdSingleNodeCheck = activeStrategy === "pd_cluster" && nodeCount === 1;
                     const pdOk = !pdSingleNodeCheck || pdFitsSingleNode(p, currentVariant);
                     const disabled = !precisionOk || !pdOk;
-                    // Support status: verified > supported > untested (not in meta.hardware).
+                    // Only `verified` carries a label; everything else = silent default.
                     const status = recipe.meta?.hardware?.[id];
-                    const statusLabel =
-                      status === "verified"
-                        ? "Verified — author has tested this hardware end-to-end"
-                        : status === "supported"
-                        ? "Supported — author claims it works, not verified in this repo"
-                        : "Untested — recipe does not claim this hardware; flags are generic vLLM defaults";
+                    const verifiedNote = status === "verified"
+                      ? "\n\nVerified — author has tested this hardware end-to-end"
+                      : "";
                     const reason = !precisionOk
                       ? `${currentVariant.precision?.toUpperCase()} requires NVIDIA Blackwell`
                       : !pdOk
                       ? `Single-node PD needs 2× model VRAM (${2 * (currentVariant.vram_minimum_gb || 0)} GB). Switch to Multi-node or pick a larger GPU.`
-                      : `${p.description}\n\n${statusLabel}`;
+                      : `${p.description}${verifiedNote}`;
                     return (
                       <Pill
                         key={id}
@@ -671,15 +656,10 @@ function PillGroup({ children }) {
 }
 
 function HwStatusDot({ status }) {
-  // Small colored dot on hardware pills to signal support level.
-  // verified = filled green; supported = filled blue; otherwise = hollow grey.
-  const color =
-    status === "verified"
-      ? "bg-green-500"
-      : status === "supported"
-      ? "bg-vllm-blue/70"
-      : "bg-transparent ring-1 ring-inset ring-muted-foreground/40";
-  return <span className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 shrink-0 ${color}`} aria-hidden />;
+  // Only `verified` is a meaningful signal. Everything else (including
+  // undeclared GPUs) renders no dot — the pill looks clean.
+  if (status !== "verified") return null;
+  return <span className="inline-block w-1.5 h-1.5 rounded-full mr-1.5 shrink-0 bg-green-500" aria-hidden />;
 }
 
 function Pill({ active, onClick, title, dimmed, disabled, children }) {

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -348,6 +348,32 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
 
   const dependencies = recipe.dependencies || [];
 
+  // Status caption for the command block header — replaces the redundant
+  // "vllm serve" label with something actually useful (support level for
+  // the selected hardware).
+  const hwStatus = recipe.meta?.hardware?.[hwId]; // "verified" | "supported" | undefined
+  const hwName = hwProfile?.display_name || hwId;
+  const statusHeader = hwStatus === "verified" ? (
+    <span className="text-[11px] font-medium text-green-500 inline-flex items-center gap-1.5">
+      <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500" />
+      Verified on {hwName}
+    </span>
+  ) : hwStatus === "supported" ? (
+    <span className="text-[11px] font-medium text-vllm-blue inline-flex items-center gap-1.5">
+      <span className="inline-block w-1.5 h-1.5 rounded-full bg-vllm-blue/80" />
+      Supported on {hwName}
+      <span className="text-[var(--command-fg)]/40">· not verified</span>
+    </span>
+  ) : (
+    <span
+      className="text-[11px] font-medium text-[var(--command-fg)]/50 inline-flex items-center gap-1.5"
+      title="Recipe does not declare this hardware. Flags are generic vLLM defaults and may need tuning."
+    >
+      <span className="inline-block w-1.5 h-1.5 rounded-full ring-1 ring-inset ring-[var(--command-fg)]/30" />
+      Untested on {hwName}
+    </span>
+  );
+
   // Omni models are served via vLLM-Omni (offline Python inference), not `vllm serve`.
   // Skip the command/strategy/feature UI and just show install deps + a pointer to the guide.
   const isOmni = (recipe.meta?.tasks || []).includes("omni");
@@ -381,15 +407,16 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
         }`}
       >
         {isPd ? (
-          <PdClusterBlock result={result} verifyCmd={verifyCmd} benchCmd={benchCmd} />
+          <PdClusterBlock result={result} verifyCmd={verifyCmd} benchCmd={benchCmd} statusHeader={statusHeader} />
         ) : isMultiNode ? (
-          <MultiNodeBlock result={result} verifyCmd={verifyCmd} benchCmd={benchCmd} />
+          <MultiNodeBlock result={result} verifyCmd={verifyCmd} benchCmd={benchCmd} statusHeader={statusHeader} />
         ) : (
           <SingleCommandBlock
             command={result.command}
             env={result.env}
             verifyCmd={verifyCmd}
             benchCmd={benchCmd}
+            statusHeader={statusHeader}
           />
         )}
       </div>
@@ -412,11 +439,19 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                     const pdSingleNodeCheck = activeStrategy === "pd_cluster" && nodeCount === 1;
                     const pdOk = !pdSingleNodeCheck || pdFitsSingleNode(p, currentVariant);
                     const disabled = !precisionOk || !pdOk;
+                    // Support status: verified > supported > untested (not in meta.hardware).
+                    const status = recipe.meta?.hardware?.[id];
+                    const statusLabel =
+                      status === "verified"
+                        ? "Verified — author has tested this hardware end-to-end"
+                        : status === "supported"
+                        ? "Supported — author claims it works, not verified in this repo"
+                        : "Untested — recipe does not claim this hardware; flags are generic vLLM defaults";
                     const reason = !precisionOk
                       ? `${currentVariant.precision?.toUpperCase()} requires NVIDIA Blackwell`
                       : !pdOk
                       ? `Single-node PD needs 2× model VRAM (${2 * (currentVariant.vram_minimum_gb || 0)} GB). Switch to Multi-node or pick a larger GPU.`
-                      : p.description;
+                      : `${p.description}\n\n${statusLabel}`;
                     return (
                       <Pill
                         key={id}
@@ -425,6 +460,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                         onClick={() => !disabled && selectHardware(id)}
                         title={reason}
                       >
+                        <HwStatusDot status={status} />
                         <span className="font-semibold">{p.display_name}</span>
                         {p.vram_gb > 0 && p.gpu_count > 0 && (
                           <span className="text-muted-foreground ml-1.5 font-mono">
@@ -599,6 +635,18 @@ function PillGroup({ children }) {
   return <div className="flex flex-wrap gap-1.5">{children}</div>;
 }
 
+function HwStatusDot({ status }) {
+  // Small colored dot on hardware pills to signal support level.
+  // verified = filled green; supported = filled blue; otherwise = hollow grey.
+  const color =
+    status === "verified"
+      ? "bg-green-500"
+      : status === "supported"
+      ? "bg-vllm-blue/70"
+      : "bg-transparent ring-1 ring-inset ring-muted-foreground/40";
+  return <span className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 shrink-0 ${color}`} aria-hidden />;
+}
+
 function Pill({ active, onClick, title, dimmed, disabled, children }) {
   // disabled takes precedence over active — an "active but disabled" pill should
   // clearly look disabled (e.g. PD that was pre-selected but no longer fits).
@@ -628,13 +676,13 @@ function envToExports(env) {
     .join("\n");
 }
 
-function SingleCommandBlock({ command, env, verifyCmd, benchCmd }) {
+function SingleCommandBlock({ command, env, verifyCmd, benchCmd, statusHeader }) {
   const envLines = envToExports(env);
   const fullScript = envLines ? `${envLines}\n\n${command}` : command;
   return (
     <div>
-      <div className="flex items-center justify-between px-4 pt-3">
-        <span className="text-[11px] text-[var(--command-fg)]/50 font-mono">vllm serve</span>
+      <div className="flex items-center justify-between px-4 pt-3 gap-3">
+        {statusHeader || <span className="text-[11px] text-[var(--command-fg)]/50 font-mono">vllm serve</span>}
         <div className="flex items-center gap-1.5">
           <CopyButton text={fullScript} />
           <PopoverButton label="Verify" code={verifyCmd} icon={Terminal} />
@@ -683,7 +731,7 @@ function DependenciesBlock({ deps }) {
   );
 }
 
-function MultiNodeBlock({ result, verifyCmd, benchCmd }) {
+function MultiNodeBlock({ result, verifyCmd, benchCmd, statusHeader }) {
   const [tab, setTab] = useState("head");
   const tabs = [
     { id: "head", label: "Head", command: result.headCommand },
@@ -694,7 +742,10 @@ function MultiNodeBlock({ result, verifyCmd, benchCmd }) {
   const fullScript = envLines ? `${envLines}\n\n${active.command}` : active.command;
   return (
     <div>
-      <div className="flex items-center justify-between px-4 pt-3">
+      {statusHeader && (
+        <div className="px-4 pt-3 pb-1">{statusHeader}</div>
+      )}
+      <div className="flex items-center justify-between px-4 pt-2">
         <div className="flex gap-0.5 bg-foreground/5 rounded-md p-0.5">
           {tabs.map((t) => (
             <button
@@ -734,7 +785,7 @@ function MultiNodeBlock({ result, verifyCmd, benchCmd }) {
   );
 }
 
-function PdClusterBlock({ result, verifyCmd, benchCmd }) {
+function PdClusterBlock({ result, verifyCmd, benchCmd, statusHeader }) {
   // Tabs: Prefill · Decode · Router (same shape whether single-node or multi-node;
   // only the CUDA_VISIBLE_DEVICES split and TP size differ).
   const [tab, setTab] = useState("prefill");
@@ -748,7 +799,10 @@ function PdClusterBlock({ result, verifyCmd, benchCmd }) {
   const fullScript = envLines ? `${envLines}\n\n${active.command}` : active.command;
   return (
     <div>
-      <div className="flex items-center justify-between px-4 pt-3 gap-3">
+      {statusHeader && (
+        <div className="px-4 pt-3 pb-1">{statusHeader}</div>
+      )}
+      <div className="flex items-center justify-between px-4 pt-2 gap-3">
         <div className="flex flex-wrap gap-0.5 bg-foreground/5 rounded-md p-0.5">
           {tabs.map((t) => (
             <button

--- a/src/components/recipes/ModelSidebar.jsx
+++ b/src/components/recipes/ModelSidebar.jsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { getProviderLogo, getProviderDisplayName } from "@/lib/providers";
+import { recipeHref } from "@/lib/recipe-utils";
+import { ChevronRight, Type, Eye, Sparkles, Hash, Cpu } from "lucide-react";
+
+const TASK_ICON = {
+  text:       Type,
+  multimodal: Eye,
+  omni:       Sparkles,
+  embedding:  Hash,
+};
+
+export function ModelSidebar({ recipesByOrg }) {
+  const pathname = usePathname();
+  const parts = pathname.split("/").filter(Boolean);
+  const currentOrg = parts[0] || "";
+  const currentRepo = parts[1] || "";
+
+  const [expanded, setExpanded] = useState(null);
+
+  useEffect(() => {
+    const found = recipesByOrg.find(([org]) => org === currentOrg);
+    if (found) setExpanded(found[0]);
+  }, [currentOrg, recipesByOrg]);
+
+  const toggle = (org) => setExpanded(expanded === org ? null : org);
+
+  return (
+    <nav className="w-64 shrink-0 hidden lg:block">
+      <div className="sticky top-16 pt-4 space-y-0.5 max-h-[calc(100vh-5rem)] overflow-y-auto scrollbar-thin">
+        <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground px-3 pb-2">
+          Providers
+        </div>
+        {recipesByOrg.map(([org, models]) => {
+          const logo = getProviderLogo(org);
+          const displayName = getProviderDisplayName(org);
+          const isExpanded = expanded === org;
+          const isOrgPage = org === currentOrg && !currentRepo;
+          const hasActiveModel = org === currentOrg && currentRepo;
+
+          return (
+            <div key={org}>
+              <div
+                className={`flex items-center gap-1 rounded-lg transition-colors ${
+                  isOrgPage
+                    ? "bg-vllm-blue/10 text-vllm-blue"
+                    : hasActiveModel
+                    ? "bg-muted/60 text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted/40"
+                }`}
+              >
+                <Link
+                  href={`/${org}`}
+                  className="flex items-center gap-2.5 px-3 py-2 flex-1 min-w-0"
+                >
+                  {logo ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={logo} alt="" width={18} height={18} className="rounded shrink-0" />
+                  ) : (
+                    <div className="w-[18px] h-[18px] rounded bg-muted flex items-center justify-center text-[10px] font-bold text-muted-foreground shrink-0">
+                      {displayName.charAt(0)}
+                    </div>
+                  )}
+                  <span className={`flex-1 text-sm truncate ${isOrgPage ? "font-semibold" : "font-medium"}`}>
+                    {displayName}
+                  </span>
+                </Link>
+                <button
+                  onClick={() => toggle(org)}
+                  aria-label={isExpanded ? "Collapse" : "Expand"}
+                  className="px-2 py-2 hover:bg-muted/60 rounded-r-lg transition-colors shrink-0"
+                >
+                  <ChevronRight
+                    size={12}
+                    className={`text-muted-foreground/60 transition-transform duration-200 ${isExpanded ? "rotate-90" : ""}`}
+                  />
+                </button>
+              </div>
+
+              {isExpanded && (
+                <div className="ml-[29px] border-l border-border/60 pl-2.5 py-0.5 space-y-px">
+                  {models.map((m) => {
+                    const isActive = m.hf_repo === currentRepo && m.hf_org === currentOrg;
+                    const primaryTask = (m.meta.tasks || [])[0];
+                    const Icon = TASK_ICON[primaryTask] || Cpu;
+                    return (
+                      <Link
+                        key={m.hf_id}
+                        href={recipeHref(m)}
+                        className={`flex items-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-mono transition-colors ${
+                          isActive
+                            ? "bg-vllm-blue/10 text-vllm-blue font-semibold"
+                            : "text-muted-foreground hover:text-foreground hover:bg-muted/30"
+                        }`}
+                        title={primaryTask}
+                      >
+                        <Icon size={10} className="shrink-0 opacity-60" />
+                        <span className="truncate">{m.hf_repo || m.meta.title}</span>
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/recipes/RecipeCardGrid.jsx
+++ b/src/components/recipes/RecipeCardGrid.jsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { Type, Eye, Sparkles, Hash, Layers, Cpu } from "lucide-react";
+import { getProviderLogo, getProviderDisplayName } from "@/lib/providers";
+
+const TASK_ICON = { text: Type, multimodal: Eye, omni: Sparkles, embedding: Hash };
+
+const LATEST_COUNT = 8;
+
+export function RecipeCardGrid({ recipes }) {
+  const byOrg = useMemo(() => {
+    const groups = {};
+    for (const r of recipes) {
+      const org = r.hf_org || "unknown";
+      if (!groups[org]) groups[org] = [];
+      groups[org].push(r);
+    }
+    return Object.entries(groups).sort((a, b) =>
+      a[0].toLowerCase().localeCompare(b[0].toLowerCase())
+    );
+  }, [recipes]);
+
+  const latest = useMemo(() => {
+    // Sort by HF release date — newest models first. Tiebreak on recipe
+    // date_updated, then id.
+    return [...recipes]
+      .sort((a, b) => {
+        const ra = a.hf_released ? new Date(a.hf_released).getTime() : 0;
+        const rb = b.hf_released ? new Date(b.hf_released).getTime() : 0;
+        if (ra !== rb) return rb - ra;
+        const da = a.meta?.date_updated ? new Date(a.meta.date_updated).getTime() : 0;
+        const db = b.meta?.date_updated ? new Date(b.meta.date_updated).getTime() : 0;
+        if (da !== db) return db - da;
+        return (a.hf_id || "").localeCompare(b.hf_id || "");
+      })
+      .slice(0, LATEST_COUNT);
+  }, [recipes]);
+
+  return (
+    <div className="space-y-10">
+      {/* Latest recipes — primary freshness signal */}
+      <section>
+        <div className="flex items-baseline gap-2 mb-3 pb-2 border-b border-border">
+          <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">Latest recipes</span>
+          <span className="text-[10px] text-muted-foreground/60">newest {latest.length}</span>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          {latest.map((r) => <RecipeCard key={r.hf_id} recipe={r} />)}
+        </div>
+      </section>
+
+      {/* Providers — secondary nav */}
+      <section>
+        <div className="flex items-baseline gap-2 mb-3 pb-2 border-b border-border">
+          <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">Browse by provider</span>
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+          {byOrg.map(([org, models]) => <ProviderTile key={org} org={org} models={models} />)}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function RecipeCard({ recipe }) {
+  const v = recipe.variants?.default || {};
+  const tasks = recipe.meta?.tasks || [];
+  const logo = getProviderLogo(recipe.hf_org);
+  const isOmni = tasks.includes("omni");
+  const isMoe = recipe.model?.architecture === "moe";
+  const ctx = recipe.model?.context_length || 0;
+  const ctxLabel = ctx >= 1_000_000 ? `${Math.round(ctx / 1_000_000)}M` : ctx >= 1000 ? `${Math.round(ctx / 1000)}K` : String(ctx);
+  const params = recipe.model?.parameter_count || "";
+  const active = recipe.model?.active_parameters;
+  const paramsLabel = isMoe && active && active !== params ? `${params}/${active}` : params;
+  return (
+    <Link
+      href={`/${recipe.hf_id}`}
+      className="group rounded-xl border border-border bg-card hover:border-vllm-blue/40 hover:shadow-sm hover:-translate-y-0.5 transition-all p-3.5 flex flex-col gap-2.5 min-h-[140px]"
+    >
+      {/* Header: logo + title */}
+      <div className="flex items-start gap-2.5">
+        {logo ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={logo} alt="" width={28} height={28} className="rounded-md mt-0.5 shrink-0" />
+        ) : (
+          <div className="w-7 h-7 rounded-md bg-muted flex items-center justify-center text-xs font-bold text-muted-foreground shrink-0">
+            {(recipe.meta?.provider || recipe.hf_org).charAt(0)}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="font-semibold text-sm leading-tight group-hover:text-vllm-blue transition-colors line-clamp-1 break-all">
+            {recipe.hf_repo}
+          </div>
+          <div className="font-mono text-[10px] text-muted-foreground/70 truncate mt-0.5">
+            {recipe.hf_org}
+          </div>
+        </div>
+      </div>
+
+      {/* Spec row */}
+      <div className="flex flex-wrap gap-1.5 text-[10px]">
+        <Badge>
+          {isMoe ? <Layers size={9} /> : <Cpu size={9} />}
+          <span className="font-mono">{paramsLabel}</span>
+        </Badge>
+        {v.precision && (
+          <Badge>
+            <span className="font-mono uppercase">{v.precision}</span>
+          </Badge>
+        )}
+        {ctx > 0 && (
+          <Badge>
+            <span className="font-mono">{ctxLabel} ctx</span>
+          </Badge>
+        )}
+        {tasks.map((t) => {
+          const Icon = TASK_ICON[t] || Hash;
+          return (
+            <Badge key={t} subtle>
+              <Icon size={9} />
+              <span className="capitalize">{t}</span>
+            </Badge>
+          );
+        })}
+      </div>
+
+      {/* Footer: hint or description */}
+      <div className="mt-auto text-[11px] text-muted-foreground line-clamp-2 leading-snug">
+        {recipe.meta?.performance_headline || recipe.meta?.description || ""}
+      </div>
+      {isOmni && (
+        <div className="text-[10px] text-vllm-yellow/80 font-medium">via vLLM-Omni</div>
+      )}
+    </Link>
+  );
+}
+
+function Badge({ children, subtle }) {
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 ${
+      subtle
+        ? "border-border/60 text-muted-foreground/70"
+        : "border-border text-muted-foreground"
+    }`}>
+      {children}
+    </span>
+  );
+}
+
+function ProviderTile({ org, models }) {
+  const logo = getProviderLogo(org);
+  const displayName = getProviderDisplayName(org);
+  return (
+    <Link
+      href={`/${org}`}
+      className="group rounded-xl border border-border p-3 flex flex-col gap-2 bg-card hover:border-vllm-blue/40 hover:shadow-sm hover:-translate-y-0.5 transition-all"
+    >
+      <div className="flex items-center gap-2.5">
+        {logo ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={logo} alt="" width={28} height={28} className="rounded-md shrink-0" />
+        ) : (
+          <div className="w-7 h-7 rounded-md bg-muted flex items-center justify-center text-xs font-bold text-muted-foreground shrink-0">
+            {displayName.charAt(0)}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="font-semibold text-sm truncate group-hover:text-vllm-blue transition-colors leading-tight">
+            {displayName}
+          </div>
+          <div className="font-mono text-[10px] text-muted-foreground/70 truncate">{org}</div>
+        </div>
+      </div>
+      <div className="flex items-baseline justify-between mt-auto">
+        <span className="text-[11px] text-muted-foreground">
+          <span className="font-semibold text-foreground tabular-nums">{models.length}</span>{" "}
+          {models.length === 1 ? "recipe" : "recipes"}
+        </span>
+        <span className="text-muted-foreground/40 group-hover:text-vllm-blue group-hover:translate-x-0.5 transition-all text-xs">→</span>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/recipes/RecipeFinder.jsx
+++ b/src/components/recipes/RecipeFinder.jsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+
+export function RecipeFinder({ recipes, taxonomy }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const taskFilter = searchParams.get("task") || "";
+  const providerFilter = searchParams.get("provider") || "";
+  const hasFilters = taskFilter || providerFilter;
+
+  const setFilter = (key, value) => {
+    const sp = new URLSearchParams(searchParams.toString());
+    if (value) sp.set(key, value);
+    else sp.delete(key);
+    const qs = sp.toString();
+    router.replace(qs ? `?${qs}` : window.location.pathname, { scroll: false });
+  };
+
+  const toggleTask = (t) => setFilter("task", taskFilter === t ? "" : t);
+
+  const providers = useMemo(
+    () => [...new Set(recipes.map((r) => r.meta.provider))].sort(),
+    [recipes]
+  );
+
+  // Collect tasks with counts
+  const taskCounts = useMemo(() => {
+    const counts = {};
+    for (const r of recipes) {
+      for (const t of r.meta.tasks || []) {
+        counts[t] = (counts[t] || 0) + 1;
+      }
+    }
+    return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  }, [recipes]);
+
+  // Count filtered
+  const filteredCount = useMemo(() => {
+    return recipes.filter((r) => {
+      if (providerFilter && r.meta.provider !== providerFilter) return false;
+      if (taskFilter && !(r.meta.tasks || []).includes(taskFilter)) return false;
+      return true;
+    }).length;
+  }, [recipes, taskFilter, providerFilter]);
+
+  return (
+    <div className="space-y-2.5">
+      {/* Task tags */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {taskCounts.map(([task, count]) => {
+          const active = taskFilter === task;
+          return (
+            <button
+              key={task}
+              onClick={() => toggleTask(task)}
+              className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+                active
+                  ? "bg-vllm-blue text-white"
+                  : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+              }`}
+            >
+              {task.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+              <span className={active ? "text-white/70" : "text-muted-foreground"}>{count}</span>
+            </button>
+          );
+        })}
+
+        {/* Provider dropdown — compact, at the end */}
+        <select
+          value={providerFilter}
+          onChange={(e) => setFilter("provider", e.target.value)}
+          className="rounded-full border border-border bg-background px-2.5 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-vllm-blue/40 ml-1"
+        >
+          <option value="">All Providers</option>
+          {providers.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+
+        {hasFilters && (
+          <button
+            onClick={() => router.replace(window.location.pathname, { scroll: false })}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors ml-1"
+          >
+            Clear
+          </button>
+        )}
+
+        <span className="text-xs text-muted-foreground ml-auto">
+          {hasFilters ? `${filteredCount} / ${recipes.length}` : recipes.length}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/recipes/SearchBox.jsx
+++ b/src/components/recipes/SearchBox.jsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useRef, useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Search, ArrowRight, Building2 } from "lucide-react";
+import { recipeHref } from "@/lib/recipe-utils";
+import { getProviderLogo, getProviderDisplayName, PROVIDERS } from "@/lib/providers";
+
+export function SearchBox({ recipes }) {
+  const [query, setQuery] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef(null);
+  const router = useRouter();
+
+  // Build a unified results list: first matching providers, then matching recipes
+  const results = useMemo(() => {
+    if (!query.trim()) return [];
+    const q = query.toLowerCase();
+
+    // Count recipes per org (for display on provider entry)
+    const orgCount = {};
+    for (const r of recipes) orgCount[r.hf_org] = (orgCount[r.hf_org] || 0) + 1;
+
+    // Find matching providers (by hf_org or display_name)
+    const providerMatches = Object.entries(PROVIDERS)
+      .filter(([org, meta]) => {
+        if (!orgCount[org]) return false; // only providers that have recipes
+        const hay = `${org} ${meta.display_name}`.toLowerCase();
+        return hay.includes(q);
+      })
+      // Dedupe case variants (e.g. "google" and "Google" both match)
+      .filter((entry, i, arr) => arr.findIndex((e) => e[1].display_name === entry[1].display_name) === i)
+      .slice(0, 3)
+      .map(([org, meta]) => ({
+        type: "provider",
+        org,
+        displayName: meta.display_name,
+        count: orgCount[org],
+        href: `/${org}`,
+      }));
+
+    // Find matching recipes
+    const recipeMatches = recipes
+      .filter((r) => {
+        const hay = [
+          r.meta.title,
+          r.hf_repo,
+          r.hf_org,
+          r.meta.provider,
+          r.meta.description,
+          ...(r.meta.tasks || []),
+          r.model.architecture,
+          r.model.parameter_count,
+        ]
+          .join(" ")
+          .toLowerCase();
+        return hay.includes(q);
+      })
+      .slice(0, 6)
+      .map((r) => ({ type: "recipe", recipe: r, href: recipeHref(r) }));
+
+    return [...providerMatches, ...recipeMatches];
+  }, [query, recipes]);
+
+  useEffect(() => {
+    function onKeyDown(e) {
+      if ((e.metaKey && e.key === "k") || (e.key === "/" && document.activeElement === document.body)) {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const handleKeyDown = (e) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter" && results[selectedIndex]) {
+      router.push(results[selectedIndex].href);
+      setQuery("");
+      inputRef.current?.blur();
+    } else if (e.key === "Escape") {
+      setQuery("");
+      inputRef.current?.blur();
+    }
+  };
+
+  const showDropdown = focused && query.trim() && results.length > 0;
+
+  return (
+    <div className="relative w-full max-w-md">
+      <div className="relative">
+        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0); }}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setTimeout(() => setFocused(false), 200)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search models or providers...  ⌘K"
+          className="w-full rounded-lg border border-border bg-background pl-9 pr-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-vllm-blue/40"
+        />
+      </div>
+
+      {showDropdown && (
+        <div className="absolute top-full mt-1 left-0 right-0 bg-card border border-border rounded-lg shadow-lg overflow-hidden z-50">
+          {results.map((r, i) => {
+            const active = i === selectedIndex;
+            return r.type === "provider" ? (
+              <ProviderResult key={`p-${r.org}`} entry={r} active={active} onClick={() => router.push(r.href)} />
+            ) : (
+              <RecipeResult key={`r-${r.recipe.hf_id}`} entry={r} active={active} onClick={() => router.push(r.href)} />
+            );
+          })}
+        </div>
+      )}
+
+      {focused && query.trim() && results.length === 0 && (
+        <div className="absolute top-full mt-1 left-0 right-0 bg-card border border-border rounded-lg shadow-lg p-4 text-sm text-muted-foreground z-50">
+          No matches for &ldquo;{query}&rdquo;
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProviderResult({ entry, active, onClick }) {
+  const logo = getProviderLogo(entry.org);
+  return (
+    <button
+      onMouseDown={onClick}
+      className={`w-full text-left px-3 py-2.5 flex items-center gap-3 text-sm transition-colors border-l-2 ${
+        active ? "bg-muted border-vllm-blue" : "border-transparent hover:bg-muted/50"
+      }`}
+    >
+      {logo ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={logo} alt="" width={22} height={22} className="rounded shrink-0" />
+      ) : (
+        <div className="w-[22px] h-[22px] rounded bg-muted flex items-center justify-center">
+          <Building2 size={12} className="text-muted-foreground" />
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="font-medium truncate flex items-center gap-2">
+          {entry.displayName}
+          <span className="text-[10px] font-normal text-muted-foreground font-mono">{entry.org}</span>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          Provider · {entry.count} recipe{entry.count !== 1 ? "s" : ""}
+        </div>
+      </div>
+      <ArrowRight size={14} className="text-muted-foreground shrink-0" />
+    </button>
+  );
+}
+
+function RecipeResult({ entry, active, onClick }) {
+  const r = entry.recipe;
+  return (
+    <button
+      onMouseDown={onClick}
+      className={`w-full text-left px-3 py-2.5 flex items-center gap-3 text-sm transition-colors border-l-2 ${
+        active ? "bg-muted border-vllm-blue" : "border-transparent hover:bg-muted/50"
+      }`}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="font-medium truncate font-mono text-[13px]">
+          {r.hf_repo || r.meta.title}
+        </div>
+        <div className="text-xs text-muted-foreground truncate">
+          {r.meta.provider} · {r.model.parameter_count} · {r.model.architecture}
+        </div>
+      </div>
+      <ArrowRight size={14} className="text-muted-foreground shrink-0" />
+    </button>
+  );
+}

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 transition-colors overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "text-foreground",
+        accent: "border-transparent bg-vllm-yellow/15 text-vllm-yellow-hover font-semibold",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Badge({ className, variant, asChild = false, ...props }) {
+  const Comp = asChild ? Slot : "span";
+  return <Comp className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }) {
+  return (
+    <div
+      className={cn("bg-card text-card-foreground flex flex-col gap-4 rounded-xl border p-5 shadow-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }) {
+  return <div className={cn("flex flex-col gap-1", className)} {...props} />;
+}
+
+function CardTitle({ className, ...props }) {
+  return <div className={cn("leading-none font-semibold", className)} {...props} />;
+}
+
+function CardDescription({ className, ...props }) {
+  return <div className={cn("text-muted-foreground text-sm", className)} {...props} />;
+}
+
+function CardContent({ className, ...props }) {
+  return <div className={cn("", className)} {...props} />;
+}
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/theme-toggle.jsx
+++ b/src/components/ui/theme-toggle.jsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState("light");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const stored = localStorage.getItem("theme");
+    if (stored) {
+      setTheme(stored);
+      document.documentElement.classList.toggle("dark", stored === "dark");
+    } else {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      setTheme(prefersDark ? "dark" : "light");
+      document.documentElement.classList.toggle("dark", prefersDark);
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+    document.documentElement.classList.toggle("dark", newTheme === "dark");
+  };
+
+  if (!mounted) {
+    return <button className="p-2 rounded-lg hover:bg-muted transition-colors" aria-label="Toggle theme"><div className="w-4 h-4" /></button>;
+  }
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-lg hover:bg-muted transition-colors cursor-pointer"
+      aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+    >
+      {theme === "light" ? <Moon className="w-4 h-4 text-foreground" /> : <Sun className="w-4 h-4 text-foreground" />}
+    </button>
+  );
+}

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -290,7 +290,21 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
   function formatCommand(args) {
     const filtered = args.filter(Boolean);
     if (filtered.length === 0) return `vllm serve ${modelId}`;
-    return `vllm serve ${modelId} \\\n  ${filtered.join(" \\\n  ")}`;
+    // Pair each --flag with its immediate value on the same line so the output
+    // reads like the human-written command in the recipe guide, not
+    // --flag\n value\n --flag\n value\n ...
+    const lines = [];
+    for (let i = 0; i < filtered.length; i++) {
+      const cur = filtered[i];
+      const next = filtered[i + 1];
+      if (cur.startsWith("-") && next !== undefined && !next.startsWith("-")) {
+        lines.push(`${cur} ${next}`);
+        i++;
+      } else {
+        lines.push(cur);
+      }
+    }
+    return `vllm serve ${modelId} \\\n  ${lines.join(" \\\n  ")}`;
   }
 
   const deployType = strategy.deploy_type || "single_node";

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -1,0 +1,348 @@
+/**
+ * Core command synthesis: Recipe + Variant + Strategy + Hardware + Features → vllm serve command.
+ * Pure functions, no I/O.
+ */
+
+/**
+ * Normalize gpu_generation to a single string for hardware_overrides lookup.
+ */
+function normalizeGeneration(gen) {
+  if (Array.isArray(gen)) {
+    // ada/blackwell consumer cards → use first
+    return gen[0];
+  }
+  return gen;
+}
+
+/**
+ * Given a recipe and hardware profile, recommend the default strategy.
+ *
+ * Tensor Parallel is the default for every model — it's the most widely
+ * tested, works for both dense and MoE. TEP / DEP / PD-cluster are
+ * advanced strategies that users can opt into explicitly.
+ */
+export function recommendStrategy(recipe, hwProfile, nodeCount = 1) {
+  const compatible = recipe.compatible_strategies || [];
+  if (nodeCount > 1) {
+    if (compatible.includes("multi_node_tp")) return "multi_node_tp";
+    if (compatible.includes("multi_node_dep")) return "multi_node_dep";
+    if (compatible.includes("multi_node_tep")) return "multi_node_tep";
+  }
+  if (compatible.includes("single_node_tp")) return "single_node_tp";
+  return compatible[0] || "single_node_tp";
+}
+
+/**
+ * Precision → allowed hardware constraint.
+ * NVFP4 is NVIDIA Blackwell-only (sm_100+). FP4 generic is also Blackwell-only
+ * in practice. AWQ/GPTQ/INT quants run on most NVIDIA+AMD hardware.
+ */
+const PRECISION_HARDWARE_CONSTRAINTS = {
+  nvfp4: { brand: "NVIDIA", generation: "blackwell" },
+  fp4: { brand: "NVIDIA", generation: "blackwell" },
+};
+
+function matchesConstraint(profile, constraint) {
+  if (!constraint) return true;
+  if (constraint.brand && profile.brand !== constraint.brand) return false;
+  if (constraint.generation) {
+    const profileGen = profile.generation || profile.gpu_generation;
+    const gens = Array.isArray(profileGen) ? profileGen : [profileGen];
+    if (!gens.includes(constraint.generation)) return false;
+  }
+  return true;
+}
+
+/**
+ * Check whether a hardware profile is compatible with a variant based on
+ * precision constraints (e.g., NVFP4 requires Blackwell). Does NOT check VRAM.
+ */
+export function isPrecisionCompatible(profile, variant) {
+  const constraint = PRECISION_HARDWARE_CONSTRAINTS[variant?.precision];
+  return matchesConstraint(profile, constraint);
+}
+
+/**
+ * List hardware profiles compatible with a variant by precision constraint
+ * only. VRAM is NOT a blocking constraint — users can scale out via multi-node
+ * TP/DP, so any profile that satisfies the precision requirement is valid.
+ */
+export function listCompatibleHardware(hwProfiles, variant) {
+  return Object.entries(hwProfiles)
+    .filter(([, p]) => isPrecisionCompatible(p, variant))
+    .map(([id]) => id);
+}
+
+/**
+ * Single-node PD splits the node 50/50 between prefill and decode. Each half
+ * holds a full model across its TP group, so the node must fit 2× the model's
+ * VRAM. Also requires at least 2 GPUs to split.
+ */
+export function pdFitsSingleNode(hwProfile, variant) {
+  if (!hwProfile || !variant) return false;
+  const gpuCount = typeof hwProfile.gpu_count === "number" ? hwProfile.gpu_count : 0;
+  if (gpuCount < 2) return false;
+  const nodeVram = typeof hwProfile.vram_gb === "number" ? hwProfile.vram_gb : 0;
+  const modelVram = variant.vram_minimum_gb || 0;
+  return nodeVram >= 2 * modelVram;
+}
+
+/**
+ * Given a variant, pick the preferred default hardware:
+ * - If variant requires Blackwell (e.g., NVFP4), prefer B200 then GB200
+ * - Otherwise H200 is the canonical default
+ */
+export function pickDefaultHardware(hwProfiles, variant) {
+  const constraint = PRECISION_HARDWARE_CONSTRAINTS[variant?.precision];
+  const compatible = Object.entries(hwProfiles).filter(([, p]) => matchesConstraint(p, constraint));
+
+  if (constraint?.generation === "blackwell") {
+    if (compatible.some(([id]) => id === "b200")) return "b200";
+    if (compatible.some(([id]) => id === "gb200")) return "gb200";
+  }
+
+  if (compatible.some(([id]) => id === "h200")) return "h200";
+  // Fallback: NVIDIA-first, then alphabetical
+  const brandOrder = { NVIDIA: 0, AMD: 1 };
+  compatible.sort((a, b) => {
+    const ba = brandOrder[a[1].brand] ?? 9;
+    const bb = brandOrder[b[1].brand] ?? 9;
+    if (ba !== bb) return ba - bb;
+    return a[0].localeCompare(b[0]);
+  });
+  return compatible[0]?.[0] || "h200";
+}
+
+/**
+ * Resolve a complete vllm serve command from recipe + user selections.
+ *
+ * Returns: { command, env, deployType } for single_node/multi_node,
+ *          { prefillCommand, decodeCommand, routerConfig, env, deployType } for pd_cluster.
+ */
+export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, enabledFeatures, strategies, taxonomy, advancedArgs = [], nodeCount = 1) {
+  const variant = recipe.variants?.[variantKey] || recipe.variants?.default || {};
+  const strategy = strategies[strategyName] || {};
+  const hwProfile = taxonomy.hardware_profiles?.[hwProfileId] || {};
+  const gen = normalizeGeneration(hwProfile.generation || hwProfile.gpu_generation);
+  const gpuCount = typeof hwProfile.gpu_count === "number" ? hwProfile.gpu_count : 1;
+  const totalGpus = gpuCount * Math.max(1, nodeCount);
+
+  const modelId = variant.model_id || recipe.model?.model_id || "unknown";
+
+  // Helper to merge args
+  function buildArgs(roleOverride, nodeRole) {
+    const args = [];
+
+    // Order:
+    // 1. base_args         (trust-remote-code, required flags)
+    // 2. variant           (quantization flags)
+    // 3. strategy cluster  (parallelism — strategy.vllm_args + -tp/-dp grouped together)
+    // 4. strategy_override (recipe's per-strategy tweaks)
+    // 5. hardware_override (per-generation tweaks)
+    // 6. advanced          (user-picked perf flags)
+    // 7. features          (tool_calling, reasoning, mtp — last for readability)
+
+    // 1. base_args
+    if (recipe.model?.base_args) args.push(...recipe.model.base_args);
+
+    // 2. Variant extra args
+    if (variantKey !== "default" && variant.extra_args) args.push(...variant.extra_args);
+
+    // 3. Strategy args + parallel size (grouped together so -tp/-dp sits next to -ep etc.)
+    if (strategy.deploy_type !== "pd_cluster") {
+      if (strategy.vllm_args) args.push(...strategy.vllm_args);
+    } else if (roleOverride && strategy[roleOverride]?.vllm_args) {
+      args.push(...strategy[roleOverride].vllm_args);
+    }
+    const parallelFlag = strategy.parallel_flag || "--tensor-parallel-size";
+    const isMulti = strategy.deploy_type === "multi_node" && nodeCount > 1;
+    const isPdMulti = strategy.deploy_type === "pd_cluster" && nodeCount > 1;
+
+    if (isMulti && parallelFlag === "--data-parallel-size") {
+      // Multi-node DEP: DP across all GPUs, each worker owns N local ranks.
+      args.push("--data-parallel-size", String(totalGpus));
+      args.push("--data-parallel-size-local", String(gpuCount));
+      args.push("--data-parallel-address", "$HEAD_IP");
+      if (nodeRole === "worker") {
+        // Example worker = node 1 (start rank offset by one node's worth of GPUs).
+        args.push("--data-parallel-start-rank", String(gpuCount));
+      }
+    } else if (isMulti && strategy.parallelism === "tp_pp") {
+      // TP inside each node, PP across nodes. Cross-node traffic flows through
+      // the PP stage boundaries only — much less bandwidth than pure TP across
+      // nodes. Suited for very large models on commodity inter-node links.
+      args.push("--tensor-parallel-size", String(gpuCount));
+      args.push("--pipeline-parallel-size", String(nodeCount));
+      args.push("--nnodes", String(nodeCount));
+      args.push("--node-rank", nodeRole === "worker" ? "1" : "0");
+      args.push("--master-addr", "$HEAD_IP");
+      if (nodeRole === "worker") args.push("--headless");
+    } else if (isMulti) {
+      // Multi-node TP/TEP via vLLM multiprocessing (mp) backend:
+      // TP spans all GPUs in the cluster; every node runs the same command,
+      // varying only --node-rank and (for rank > 0) --headless.
+      args.push("--tensor-parallel-size", String(totalGpus));
+      args.push("--nnodes", String(nodeCount));
+      args.push("--node-rank", nodeRole === "worker" ? "1" : "0");
+      args.push("--master-addr", "$HEAD_IP");
+      if (nodeRole === "worker") args.push("--headless");
+    } else if (strategy.deploy_type === "pd_cluster") {
+      // PD splits the node between prefill and decode.
+      // - Single-node: 50/50 split, each role uses TP=gpuCount/2, pinned via
+      //   CUDA_VISIBLE_DEVICES (set in buildEnv).
+      // - Multi-node (2 nodes): one full node per role, TP=gpuCount per role.
+      const tpPerRole = isPdMulti ? gpuCount : Math.floor(gpuCount / 2);
+      args.push("--tensor-parallel-size", String(Math.max(1, tpPerRole)));
+    } else {
+      args.push(parallelFlag, String(gpuCount));
+    }
+
+    // 4. Strategy overrides from recipe
+    //    Accept both `extra_args` (recipe convention) and `vllm_args` (strategy
+    //    YAML convention) — some recipes mirror the strategy's role schema.
+    const so = recipe.strategy_overrides?.[strategyName];
+    if (so) {
+      if (roleOverride) {
+        const roleOv = so[roleOverride];
+        if (roleOv?.extra_args) args.push(...roleOv.extra_args);
+        if (roleOv?.vllm_args)  args.push(...roleOv.vllm_args);
+      } else {
+        if (so.extra_args) args.push(...so.extra_args);
+        if (so.vllm_args)  args.push(...so.vllm_args);
+      }
+    }
+
+    // 5. Hardware overrides
+    const ho = recipe.hardware_overrides?.[gen];
+    if (ho?.extra_args) args.push(...ho.extra_args);
+
+    // 6. Advanced tuning args (from UI's Advanced panel)
+    if (advancedArgs && advancedArgs.length) args.push(...advancedArgs);
+
+    // 7. Features last — tool_calling, reasoning, mtp, etc.
+    for (const f of enabledFeatures || []) {
+      const feat = recipe.features?.[f];
+      if (feat?.args) args.push(...feat.args);
+    }
+
+    return args;
+  }
+
+  // Helper to merge env
+  function buildEnv(roleOverride) {
+    const env = {};
+
+    // Base env
+    Object.assign(env, recipe.model?.base_env || {});
+
+    // Variant env
+    if (variantKey !== "default" && variant.extra_env) Object.assign(env, variant.extra_env);
+
+    // Strategy env
+    if (strategy.deploy_type !== "pd_cluster") {
+      Object.assign(env, strategy.env || {});
+    } else if (roleOverride && strategy[roleOverride]?.env) {
+      Object.assign(env, strategy[roleOverride].env);
+    }
+
+    // PD: pin GPUs per role via CUDA_VISIBLE_DEVICES
+    // - Single-node: first half (prefill) / second half (decode)
+    // - Multi-node: each role owns a whole node, so list all its GPUs
+    if (strategy.deploy_type === "pd_cluster" && roleOverride) {
+      const multi = nodeCount > 1;
+      if (multi) {
+        const all = Array.from({ length: gpuCount }, (_, i) => i).join(",");
+        env.CUDA_VISIBLE_DEVICES = all;
+      } else {
+        const half = Math.floor(gpuCount / 2);
+        if (half > 0) {
+          const ids = roleOverride === "prefill"
+            ? Array.from({ length: half }, (_, i) => i)
+            : Array.from({ length: gpuCount - half }, (_, i) => half + i);
+          env.CUDA_VISIBLE_DEVICES = ids.join(",");
+        }
+      }
+    }
+
+    // Strategy overrides env
+    const so = recipe.strategy_overrides?.[strategyName];
+    if (so) {
+      if (so.env) Object.assign(env, so.env);
+      if (roleOverride && so[roleOverride]?.env) Object.assign(env, so[roleOverride].env);
+      if (!roleOverride && so.extra_env) Object.assign(env, so.extra_env);
+    }
+
+    // Hardware overrides env
+    const ho = recipe.hardware_overrides?.[gen];
+    if (ho?.extra_env) Object.assign(env, ho.extra_env);
+
+    return env;
+  }
+
+  function formatCommand(args) {
+    const filtered = args.filter(Boolean);
+    if (filtered.length === 0) return `vllm serve ${modelId}`;
+    return `vllm serve ${modelId} \\\n  ${filtered.join(" \\\n  ")}`;
+  }
+
+  const deployType = strategy.deploy_type || "single_node";
+
+  if (deployType === "pd_cluster") {
+    // Single-node PD splits one node 50/50 (prefill TP=gpuCount/2 + decode TP=gpuCount/2).
+    // Multi-node PD dedicates one node per role (prefill TP=gpuCount + decode TP=gpuCount).
+    // Either way the router sees 1 prefill + 1 decode endpoint — scale by replicating.
+    const policy = strategy.router?.policy || "round_robin";
+    // `--intra-node-data-parallel-size` is the DP size inside one pool.
+    // Our default PD layout is TP-only per role (DP=1), so the router sees
+    // a single DP rank per endpoint. Users running DP+EP should raise this
+    // to match their `--data-parallel-size`.
+    // Port convention: prefill on 8001, decode on 8002 (keeps them distinct
+    // when co-located on a single node). The router listens on 30000.
+    const routerLines = [
+      `vllm-router --policy ${policy} \\`,
+      `    --vllm-pd-disaggregation \\`,
+      `    --prefill http://PREFILL_ADDR:8001 \\`,
+      `    --decode http://DECODE_ADDR:8002 \\`,
+      `    --host 127.0.0.1 \\`,
+      `    --port 30000 \\`,
+      `    --intra-node-data-parallel-size 1`,
+    ];
+    const routerCommand = routerLines.join("\n");
+
+    return {
+      deployType,
+      nodeCount,
+      prefill: {
+        command: formatCommand(buildArgs("prefill", null)),
+        env: buildEnv("prefill"),
+      },
+      decode: {
+        command: formatCommand(buildArgs("decode", null)),
+        env: buildEnv("decode"),
+      },
+      router: {
+        command: routerCommand,
+        install: "uv pip install vllm-router",
+      },
+      routerConfig: strategy.router || { policy: "round_robin" },
+    };
+  }
+
+  if (deployType === "multi_node" && nodeCount > 1) {
+    // Every multi-node strategy renders the same shape: head + worker tabs.
+    // Workers use --headless (TP/TEP) or --data-parallel-start-rank offset (DEP).
+    return {
+      deployType: "multi_node",
+      nodeCount,
+      headCommand: formatCommand(buildArgs(null, "head")),
+      workerCommand: formatCommand(buildArgs(null, "worker")),
+      env: buildEnv(null),
+    };
+  }
+
+  return {
+    deployType,
+    command: formatCommand(buildArgs(null, null)),
+    env: buildEnv(null),
+  };
+}

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -213,7 +213,12 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
     }
 
     // 5. Hardware overrides
-    const ho = recipe.hardware_overrides?.[gen];
+    //    Precedence: generation-specific (hopper/blackwell/amd) > brand-wide (nvidia).
+    //    `nvidia:` lets a recipe apply the same overrides to every NVIDIA GPU
+    //    without duplicating hopper and blackwell blocks.
+    const isNvidia = hwProfile?.brand === "NVIDIA";
+    const ho = recipe.hardware_overrides?.[gen]
+      || (isNvidia ? recipe.hardware_overrides?.nvidia : null);
     if (ho?.extra_args) args.push(...ho.extra_args);
 
     // 6. Advanced tuning args (from UI's Advanced panel)
@@ -272,9 +277,12 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
       if (!roleOverride && so.extra_env) Object.assign(env, so.extra_env);
     }
 
-    // Hardware overrides env
-    const ho = recipe.hardware_overrides?.[gen];
-    if (ho?.extra_env) Object.assign(env, ho.extra_env);
+    // Hardware overrides env — same precedence as args block: generation key
+    // first, then brand-wide `nvidia:` for NVIDIA GPUs.
+    const envIsNvidia = hwProfile?.brand === "NVIDIA";
+    const envHo = recipe.hardware_overrides?.[gen]
+      || (envIsNvidia ? recipe.hardware_overrides?.nvidia : null);
+    if (envHo?.extra_env) Object.assign(env, envHo.extra_env);
 
     return env;
   }

--- a/src/lib/preferences.js
+++ b/src/lib/preferences.js
@@ -1,0 +1,29 @@
+/**
+ * User preferences persisted across sessions via localStorage.
+ * Used by CommandBuilder to remember the user's preferred hardware.
+ */
+
+const KEY = "vllm-recipes-prefs";
+
+export function loadPreferences() {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function savePreference(key, value) {
+  if (typeof window === "undefined") return;
+  try {
+    const prefs = loadPreferences();
+    if (value === undefined || value === null || value === "") {
+      delete prefs[key];
+    } else {
+      prefs[key] = value;
+    }
+    localStorage.setItem(KEY, JSON.stringify(prefs));
+  } catch {}
+}

--- a/src/lib/providers.js
+++ b/src/lib/providers.js
@@ -1,0 +1,46 @@
+/**
+ * Provider metadata keyed by HuggingFace org.
+ *
+ * logo: path to local avatar served from /public/providers/.
+ * Logos are downloaded at build time by scripts/fetch-provider-logos.mjs
+ * (fetched from HuggingFace) — so the file URL always comes from our own
+ * domain, making it globally accessible even where HF CDN is blocked.
+ *
+ * Extensions (png vs jpeg) match what HF serves for each org.
+ */
+export const PROVIDERS = {
+  "deepseek-ai":     { display_name: "DeepSeek",                logo: "/providers/deepseek-ai.png" },
+  "Qwen":            { display_name: "Qwen",                    logo: "/providers/Qwen.png" },
+  "moonshotai":      { display_name: "Moonshot AI",             logo: "/providers/moonshotai.jpeg" },
+  "meta-llama":      { display_name: "Meta",                    logo: "/providers/meta-llama.png" },
+  "Google":          { display_name: "Google",                  logo: "/providers/Google.png" },
+  "google":          { display_name: "Google",                  logo: "/providers/Google.png" },
+  "microsoft":       { display_name: "Microsoft",               logo: "/providers/microsoft.png" },
+  "mistralai":       { display_name: "Mistral AI",              logo: "/providers/mistralai.png" },
+  "nvidia":          { display_name: "NVIDIA",                  logo: "/providers/nvidia.png" },
+  "openai":          { display_name: "OpenAI",                  logo: "/providers/openai.png" },
+  "MiniMaxAI":       { display_name: "MiniMax",                 logo: "/providers/MiniMaxAI.jpeg" },
+  "zai-org":         { display_name: "GLM (Z-AI)",              logo: "/providers/zai-org.png" },
+  "baidu":           { display_name: "Ernie (Baidu)",           logo: "/providers/baidu.png" },
+  "arcee-ai":        { display_name: "Arcee AI",                logo: "/providers/arcee-ai.png" },
+  "inclusionAI":     { display_name: "inclusionAI",             logo: "/providers/inclusionAI.jpeg" },
+  "OpenGVLab":       { display_name: "InternVL (OpenGVLab)",    logo: "/providers/OpenGVLab.jpeg" },
+  "internlm":        { display_name: "InternLM",                logo: "/providers/internlm.png" },
+  "jinaai":          { display_name: "Jina AI",                 logo: "/providers/jinaai.png" },
+  "PaddlePaddle":    { display_name: "PaddlePaddle",            logo: "/providers/PaddlePaddle.png" },
+  "ByteDance-Seed":  { display_name: "Seed (ByteDance)",        logo: "/providers/ByteDance-Seed.png" },
+  "tencent":         { display_name: "Tencent Hunyuan",         logo: "/providers/tencent.png" },
+  "XiaomiMiMo":      { display_name: "Xiaomi MiMo",             logo: "/providers/XiaomiMiMo.jpeg" },
+  "Wan-AI":          { display_name: "Wan AI",                  logo: "/providers/Wan-AI.png" },
+  "meituan-longcat": { display_name: "Meituan LongCat",         logo: "/providers/meituan-longcat.png" },
+  "stabilityai":     { display_name: "Stability AI",            logo: "/providers/stabilityai.png" },
+  "stepfun-ai":      { display_name: "StepFun",                 logo: "/providers/stepfun-ai.png" },
+};
+
+export function getProviderLogo(hfOrg) {
+  return PROVIDERS[hfOrg]?.logo || null;
+}
+
+export function getProviderDisplayName(hfOrg) {
+  return PROVIDERS[hfOrg]?.display_name || hfOrg;
+}

--- a/src/lib/recipe-utils.js
+++ b/src/lib/recipe-utils.js
@@ -1,0 +1,16 @@
+/**
+ * Shared utilities — safe to import from client components (no fs/path/yaml).
+ */
+
+/**
+ * URL for a recipe — matches HuggingFace org/repo path.
+ * e.g. /deepseek-ai/DeepSeek-V3.2 (swap huggingface.co → recipes.vllm.ai)
+ */
+export function recipeHref(recipe) {
+  if (recipe.hf_org && recipe.hf_repo) {
+    return `/${recipe.hf_org}/${recipe.hf_repo}`;
+  }
+  // Fallback for recipes that somehow lack hf_id derivation
+  const org = recipe.meta.provider.toLowerCase().replace(/\s+/g, "-");
+  return `/${org}/${recipe.meta.title}`;
+}

--- a/src/lib/recipes.js
+++ b/src/lib/recipes.js
@@ -1,0 +1,71 @@
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+
+let cache = null;
+
+const MODELS_DIR = path.join(process.cwd(), "models");
+const HF_DATES_PATH = path.join(process.cwd(), "public", "hf-dates.json");
+
+// HF release dates per hf_id (populated at build by scripts/fetch-hf-dates.mjs)
+let hfDates = null;
+function loadHfDates() {
+  if (hfDates !== null) return hfDates;
+  try {
+    hfDates = JSON.parse(fs.readFileSync(HF_DATES_PATH, "utf8"));
+  } catch {
+    hfDates = {};
+  }
+  return hfDates;
+}
+
+function parseRecipe(filePath) {
+  const raw = yaml.load(fs.readFileSync(filePath, "utf8"));
+  // js-yaml auto-parses YYYY-MM-DD into Date objects — normalize to string
+  if (raw.meta?.date_updated instanceof Date) {
+    raw.meta.date_updated = raw.meta.date_updated.toISOString().split("T")[0];
+  }
+  // Derive HF identity from file path: models/<org>/<repo>.yaml
+  const rel = path.relative(MODELS_DIR, filePath);
+  const parts = rel.split(path.sep);
+  if (parts.length >= 2) {
+    raw.hf_org = parts[0];
+    raw.hf_repo = parts[parts.length - 1].replace(/\.(yaml|yml)$/, "");
+    raw.hf_id = `${raw.hf_org}/${raw.hf_repo}`;
+    // Attach HF release date (ISO string) from build-time manifest
+    const dates = loadHfDates();
+    raw.hf_released = dates[raw.hf_id] || null;
+  }
+  return raw;
+}
+
+function findYamlFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findYamlFiles(full));
+    } else if (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+export function getAllRecipes() {
+  if (cache) return cache;
+  const files = findYamlFiles(MODELS_DIR);
+  cache = files
+    .map(parseRecipe)
+    .sort((a, b) => {
+      const da = new Date(a.meta.date_updated);
+      const db = new Date(b.meta.date_updated);
+      return db - da;
+    });
+  return cache;
+}
+
+export function getRecipeByHfId(org, repo) {
+  const all = getAllRecipes();
+  return all.find((r) => r.hf_org === org && r.hf_repo === repo) || null;
+}

--- a/src/lib/strategies.js
+++ b/src/lib/strategies.js
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+
+let cache = null;
+
+const STRATEGIES_DIR = path.join(process.cwd(), "strategies");
+
+export function loadStrategies() {
+  if (cache) return cache;
+  cache = {};
+  const files = fs.readdirSync(STRATEGIES_DIR).filter((f) => f.endsWith(".yaml"));
+  for (const file of files) {
+    const s = yaml.load(fs.readFileSync(path.join(STRATEGIES_DIR, file), "utf8"));
+    cache[s.name] = s;
+  }
+  return cache;
+}
+
+export function loadStrategy(name) {
+  const all = loadStrategies();
+  return all[name] || null;
+}

--- a/src/lib/taxonomy.js
+++ b/src/lib/taxonomy.js
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+
+let cache = null;
+
+const TAXONOMY_PATH = path.join(process.cwd(), "taxonomy.yaml");
+
+export function loadTaxonomy() {
+  if (cache) return cache;
+  cache = yaml.load(fs.readFileSync(TAXONOMY_PATH, "utf8"));
+  return cache;
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}

--- a/strategies/multi_node_dep.yaml
+++ b/strategies/multi_node_dep.yaml
@@ -1,0 +1,20 @@
+name: multi_node_dep
+deploy_type: multi_node
+display_name: "Multi-Node Data + Expert Parallel"
+description: >
+  Multi-node DEP. Each node runs TEP over its local GPUs, with DP across nodes.
+  Best throughput for MoE models across multiple nodes. Pass -dp <total_workers>
+  at deploy time. Uses hybrid load balancing across DP workers.
+
+hardware_match:
+  min_gpus: 2
+  multi_node: true
+  architecture: moe
+
+vllm_args:
+  - "--enable-expert-parallel"
+  - "--data-parallel-hybrid-lb"
+
+parallel_flag: "--data-parallel-size"
+
+env: {}

--- a/strategies/multi_node_tep.yaml
+++ b/strategies/multi_node_tep.yaml
@@ -1,0 +1,20 @@
+name: multi_node_tep
+deploy_type: multi_node
+display_name: "Multi-Node Tensor + Expert Parallel"
+description: >
+  Multi-node TEP. Combines cross-node tensor parallel with expert parallel
+  for MoE models. All GPUs across nodes participate in TP, with EP splitting
+  expert layers. Requires InfiniBand interconnect.
+
+hardware_match:
+  min_gpus: 2
+  multi_node: true
+  architecture: moe
+
+vllm_args:
+  - "--enable-expert-parallel"
+  - "-cc.pass_config.fuse_allreduce_rms=False"
+
+parallel_flag: "--tensor-parallel-size"
+
+env: {}

--- a/strategies/multi_node_tp.yaml
+++ b/strategies/multi_node_tp.yaml
@@ -1,0 +1,19 @@
+name: multi_node_tp
+deploy_type: multi_node
+display_name: "Multi-Node Tensor Parallel"
+description: >
+  Multi-node TP. Splits the model across GPUs spanning multiple nodes.
+  TP is set to total GPU count across all nodes. Head node serves requests,
+  worker nodes run with --headless. Requires InfiniBand interconnect.
+
+hardware_match:
+  min_gpus: 2
+  multi_node: true
+
+vllm_args:
+  - "-cc.pass_config.fuse_allreduce_rms=False"
+
+parallel_flag: "--tensor-parallel-size"
+
+env:
+  VLLM_USE_NCCL_SYMM_MEM: "0"

--- a/strategies/multi_node_tp_pp.yaml
+++ b/strategies/multi_node_tp_pp.yaml
@@ -1,0 +1,24 @@
+name: multi_node_tp_pp
+deploy_type: multi_node
+display_name: "Multi-Node TP + Pipeline Parallel"
+description: >
+  Tensor parallel within each node, pipeline parallel across nodes.
+  TP stays inside the high-bandwidth intra-node NVLink/IB domain; PP
+  is what crosses the slower cross-node link. Good fit for very large
+  models (e.g. Kimi-K2 1T on 16×H800) where pure TP across nodes would
+  bottleneck on inter-node bandwidth.
+
+hardware_match:
+  min_gpus: 2
+  multi_node: true
+
+# New field read by command-synthesis: "tp_pp" → emit
+#   --tensor-parallel-size <gpu_count>  --pipeline-parallel-size <node_count>
+# instead of the default multi-node TP (tp = total_gpus).
+parallelism: tp_pp
+
+vllm_args: []
+
+parallel_flag: "--tensor-parallel-size"
+
+env: {}

--- a/strategies/pd_cluster.yaml
+++ b/strategies/pd_cluster.yaml
@@ -1,0 +1,54 @@
+name: pd_cluster
+deploy_type: pd_cluster
+display_name: "Prefill/Decode Disaggregation"
+description: >
+  Disaggregated prefill/decode cluster. Splits inference into separate
+  prefill and decode workers communicating via NIXL KV cache transfer.
+  Optimal for high-concurrency, low-latency production deployments.
+  Each role can be a single-node or multi-node DP/TP/EP pool, with its
+  own HTTP port, NIXL side-channel port, and DP coordinator.
+
+hardware_match:
+  min_gpus: 8
+  multi_node: true
+
+# Worker environment follows the Kimi-K2.5 NIXL/MoE pattern.
+# CUDA_VISIBLE_DEVICES is set per-rank when running one `vllm serve` per GPU
+# (data parallel); omit it if your launcher already pins GPUs.
+prefill:
+  vllm_args:
+    - "--port"
+    - "8001"
+    - "--kv-transfer-config"
+    - '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_load_failure_policy":"fail"}'
+    - "--enforce-eager"
+  env:
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    UCX_NET_DEVICES: "all"
+    VLLM_NIXL_SIDE_CHANNEL_PORT: "5557"
+    VLLM_NIXL_SIDE_CHANNEL_HOST: "$PREFILL_HOST_IP"
+
+decode:
+  vllm_args:
+    - "--port"
+    - "8002"
+    - "--kv-transfer-config"
+    - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_load_failure_policy":"fail"}'
+    - "--compilation-config"
+    - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+  env:
+    VLLM_USE_NCCL_SYMM_MEM: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    UCX_NET_DEVICES: "all"
+    VLLM_NIXL_SIDE_CHANNEL_PORT: "5558"
+    VLLM_NIXL_SIDE_CHANNEL_HOST: "$DECODE_HOST_IP"
+
+parallel_flag: "--tensor-parallel-size"
+
+router:
+  policy: round_robin

--- a/strategies/single_node_dep.yaml
+++ b/strategies/single_node_dep.yaml
@@ -1,0 +1,18 @@
+name: single_node_dep
+deploy_type: single_node
+display_name: "Data + Expert Parallel"
+description: >
+  Single-node DEP. Expert layers are shared across all GPUs via EP,
+  dense layers run independently in DP groups. Best throughput for
+  MoE models on 8-GPU single nodes. For MoE models only.
+
+hardware_match:
+  min_gpus: 2
+  max_gpus: 8
+  multi_node: false
+  architecture: moe
+
+vllm_args:
+  - "--enable-expert-parallel"
+
+parallel_flag: "--data-parallel-size"

--- a/strategies/single_node_tep.yaml
+++ b/strategies/single_node_tep.yaml
@@ -1,0 +1,18 @@
+name: single_node_tep
+deploy_type: single_node
+display_name: "Tensor + Expert Parallel"
+description: >
+  Single-node TEP. TP splits dense layers and EP splits expert layers
+  across local GPUs. TP must be set to GPU count to avoid OOM from
+  replicated dense layers. For MoE models only.
+
+hardware_match:
+  min_gpus: 2
+  max_gpus: 8
+  multi_node: false
+  architecture: moe
+
+vllm_args:
+  - "--enable-expert-parallel"
+
+parallel_flag: "--tensor-parallel-size"

--- a/strategies/single_node_tp.yaml
+++ b/strategies/single_node_tp.yaml
@@ -1,0 +1,16 @@
+name: single_node_tp
+deploy_type: single_node
+display_name: "Tensor Parallel"
+description: >
+  Single-node tensor parallel. Splits the model across all local GPUs.
+  TP size is set to the GPU count at deploy time.
+  The simplest multi-GPU strategy — works for all model architectures.
+
+hardware_match:
+  min_gpus: 1
+  max_gpus: 8
+  multi_node: false
+
+vllm_args: []
+
+parallel_flag: "--tensor-parallel-size"

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -1,0 +1,113 @@
+# taxonomy.yaml — Controlled vocabulary for vLLM recipes
+# All hardware_profiles, tasks, and strategies referenced in recipes must be defined here.
+
+hardware_profiles:
+  # ── NVIDIA Hopper ──
+  h100:
+    brand: NVIDIA
+    generation: hopper
+    display_name: "H100"
+    description: "NVIDIA H100 80GB NVLink (8-GPU node)"
+    gpu_count: 8
+    vram_gb: 640
+    multi_node: false
+
+  h200:
+    brand: NVIDIA
+    generation: hopper
+    display_name: "H200"
+    description: "NVIDIA H200 SXM 141 GB HBM3e · 8-GPU HGX node"
+    gpu_count: 8
+    vram_gb: 1128
+    multi_node: false
+
+  # ── NVIDIA Blackwell ──
+  # Specs follow semianalysis InferenceX GPU table (inferencex.semianalysis.com/gpu-specs).
+  b200:
+    brand: NVIDIA
+    generation: blackwell
+    display_name: "B200"
+    description: "NVIDIA B200 SXM 180 GB HBM3e · 8-GPU HGX B200 node"
+    gpu_count: 8
+    vram_gb: 1440
+    multi_node: false
+
+  gb200:
+    brand: NVIDIA
+    generation: blackwell
+    display_name: "GB200 NVL4"
+    description: "NVIDIA GB200 Grace-Blackwell compute tray · 192 GB HBM3e/GPU · 4 Blackwell GPUs (NVL72 tray unit)"
+    gpu_count: 4
+    vram_gb: 768
+    multi_node: false
+
+  # ── NVIDIA Blackwell Ultra ──
+  b300:
+    brand: NVIDIA
+    generation: blackwell
+    display_name: "B300"
+    description: "NVIDIA B300 SXM 268 GB HBM3e · 8-GPU HGX B300 node (Blackwell Ultra)"
+    gpu_count: 8
+    vram_gb: 2144
+    multi_node: false
+
+  gb300:
+    brand: NVIDIA
+    generation: blackwell
+    display_name: "GB300 NVL4"
+    description: "NVIDIA GB300 Grace-Blackwell Ultra compute tray · 288 GB HBM3e/GPU · 4 GPUs (NVL72 tray unit)"
+    gpu_count: 4
+    vram_gb: 1152
+    multi_node: false
+
+  # ── AMD Instinct ──
+  mi300x:
+    brand: AMD
+    generation: amd
+    display_name: "MI300X"
+    description: "AMD Instinct MI300X 192 GB HBM3 · 8-GPU OAM node (CDNA 3)"
+    gpu_count: 8
+    vram_gb: 1536
+    multi_node: false
+
+  mi325x:
+    brand: AMD
+    generation: amd
+    display_name: "MI325X"
+    description: "AMD Instinct MI325X 256 GB HBM3e · 8-GPU OAM node (CDNA 3)"
+    gpu_count: 8
+    vram_gb: 2048
+    multi_node: false
+
+  mi355x:
+    brand: AMD
+    generation: amd
+    display_name: "MI355X"
+    description: "AMD Instinct MI355X 288 GB HBM3e · 8-GPU OAM node (CDNA 4)"
+    gpu_count: 8
+    vram_gb: 2304
+    multi_node: false
+
+tasks:
+  - id: text
+    display_name: "Text"
+    description: "Text-only models: chat, reasoning, code generation, tool calling"
+  - id: multimodal
+    display_name: "Multimodal"
+    description: "Vision, audio, or other modalities beyond text"
+  - id: omni
+    display_name: "Omni"
+    description: "Any-to-any models: text + vision + audio + generation"
+  - id: embedding
+    display_name: "Embedding"
+    description: "Embedding, reranker, classifier, scoring models"
+
+strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tep
+  - multi_node_dep
+  - multi_node_tp_pp
+  - pd_cluster


### PR DESCRIPTION
## Summary

This PR refactors the recipes repo from static MkDocs pages into a structured YAML + Next.js system, with an interactive command builder and a JSON API.

## What changes

- **YAMLs as source of truth** — one file per model at `models/<hf_org>/<hf_repo>.yaml`, mirroring HuggingFace paths. Legacy Markdown under `DeepSeek/`, `Qwen/`, etc. is kept read-only for reference.
- **Interactive command builder** — users pick hardware, variant, strategy (TP / TEP / DEP, single- or multi-node, PD cluster), toggle features (tool calling, reasoning, speculative decoding), and get the exact `vllm serve` command. All state syncs to URL query params.
- **NVIDIA + AMD first-class** — one-click switch between Hopper / Blackwell and MI300X / MI355X, with the right flags and env applied via `hardware_overrides`.
- **Easy hardware extensibility** — new GPUs / accelerators plug in via `taxonomy.yaml` + per-recipe `hardware_overrides`, no page rewrites.
- **URL parity with HF** — swap `huggingface.co` → `recipes.vllm.ai` in any model URL to jump to its recipe (e.g. `recipes.vllm.ai/Qwen/Qwen3-235B`).
- **JSON API for agents** — every recipe is also published as JSON under `/<org>/<repo>.json`, plus `/taxonomy.json` and `/strategies/*.json`, so tools can consume recipes without scraping HTML.

## Architecture

models//.yaml  ──┐
strategies/.yaml          ─┼──► src/lib/.js  ──► Next.js pages + JSON API
taxonomy.yaml              ─┘

- `taxonomy.yaml` — controlled vocabulary: hardware profiles, tasks, strategy ids.
- `strategies/*.yaml` — 7 deployment strategies: `single_node_{tp,tep,dep}`, `multi_node_{tp,tep,dep,tp_pp}`, `pd_cluster`.
- `src/lib/command-synthesis.js` — pure functions that synthesize the final command from `(recipe, variant, strategy, hardware, features, nodeCount, advanced)`.
- `scripts/build-recipes-api.mjs` — emits the static JSON API at build time.

## Stats

- 110 files changed, ~20k insertions
- 15 commits (all authored locally, happy to squash on merge)
- SSG only, no runtime DB or server

## Adding a new model

One YAML PR at `models/<hf_org>/<hf_repo>.yaml`. Schema documented in `CLAUDE.md`; a `/add-recipe` skill walks contributors through HF metadata, variants, VRAM calc, and validation.