### PR TITLE
Add text_only/encoder_parallel features; switch to Radix tooltips

### DIFF
--- a/GLM/GLM5.md
+++ b/GLM/GLM5.md
@@ -186,7 +186,7 @@ Peak output token throughput (tok/s):    800.00
 Peak concurrent requests:                32.00     
 Total token throughput (tok/s):          4640.43   
 ---------------Time to First Token----------------
-Mean TTFT (ms):                          13395.44  
+Mean TTFT (ms):                          13395.44  ·
 Median TTFT (ms):                        14494.06  
 P99 TTFT (ms):                           22952.29  
 -----Time per Output Token (excl. 1st token)------

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -48,8 +48,18 @@ features:
     args:
       - "--reasoning-parser"
       - "gemma4"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/OpenGVLab/InternVL3_5-8B.yaml
+++ b/models/OpenGVLab/InternVL3_5-8B.yaml
@@ -26,9 +26,19 @@ model:
     - "--trust-remote-code"
   base_env: {}
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/OpenGVLab/InternVL3_5-8B.yaml
+++ b/models/OpenGVLab/InternVL3_5-8B.yaml
@@ -39,6 +39,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/PaddlePaddle/PaddleOCR-VL.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL.yaml
@@ -33,9 +33,19 @@ dependencies:
   - note: "Safetensors loader used by the doc-parser path"
     command: "uv pip install safetensors"
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/PaddlePaddle/PaddleOCR-VL.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL.yaml
@@ -46,6 +46,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
@@ -25,9 +25,19 @@ model:
   base_args: []
   base_env: {}
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/Qwen/Qwen3-ASR-1.7B.yaml
+++ b/models/Qwen/Qwen3-ASR-1.7B.yaml
@@ -24,19 +24,9 @@ dependencies:
   - note: "Audio extras — required for ASR input pre-processing (librosa, soundfile)"
     command: 'uv pip install -U "vllm[audio]"'
 
-features:
-  text_only:
-    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
-    args:
-      - "--language-model-only"
-  encoder_parallel:
-    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
-    args:
-      - "--mm-encoder-tp-mode"
-      - "data"
+features: {}
 
-opt_in_features:
-  - text_only
+opt_in_features: []
 
 variants:
   default:

--- a/models/Qwen/Qwen3-ASR-1.7B.yaml
+++ b/models/Qwen/Qwen3-ASR-1.7B.yaml
@@ -24,9 +24,19 @@ dependencies:
   - note: "Audio extras — required for ASR input pre-processing (librosa, soundfile)"
     command: 'uv pip install -U "vllm[audio]"'
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -33,9 +33,19 @@ dependencies:
     command: "uv pip install qwen-vl-utils==0.0.14"
     optional: true
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -6,7 +6,7 @@ meta:
   date_updated: 2026-04-16
   difficulty: intermediate
   tasks:
-    - text
+    - multimodal
   performance_headline: "Verified on 8x H200, 8x MI300X/MI355X, and GB200 nodes"
   related_recipes:
     - "Qwen/Qwen3.6-35B-A3B"
@@ -48,9 +48,19 @@ features:
     args:
       - "--speculative_config"
       - '{"method":"mtp","num_speculative_tokens":3}'
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
 opt_in_features:
   - spec_decoding
+  - text_only
 
 variants:
   default:

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -6,6 +6,7 @@ meta:
   date_updated: 2026-04-16
   difficulty: intermediate
   tasks:
+    - text
     - multimodal
   performance_headline: "Verified on 8x H200, 8x MI300X/MI355X, and GB200 nodes"
   related_recipes:

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -6,8 +6,8 @@ meta:
   date_updated: 2026-04-16
   difficulty: intermediate
   tasks:
-    - text
     - multimodal
+    - text
   performance_headline: "Verified on 8x H200, 8x MI300X/MI355X, and GB200 nodes"
   related_recipes:
     - "Qwen/Qwen3.6-35B-A3B"

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -6,8 +6,8 @@ meta:
   date_updated: 2026-04-18
   difficulty: beginner
   tasks:
-    - text
     - multimodal
+    - text
   performance_headline: "Compact Qwen3.6 MoE with 3B active parameters — single-GPU FP8 or 2-4 GPU BF16 serving"
   related_recipes:
     - "Qwen/Qwen3.5-397B-A17B"

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -6,7 +6,7 @@ meta:
   date_updated: 2026-04-18
   difficulty: beginner
   tasks:
-    - text
+    - multimodal
   performance_headline: "Compact Qwen3.6 MoE with 3B active parameters — single-GPU FP8 or 2-4 GPU BF16 serving"
   related_recipes:
     - "Qwen/Qwen3.5-397B-A17B"
@@ -45,9 +45,19 @@ features:
     args:
       - "--speculative-config"
       - '{"method":"mtp","num_speculative_tokens":2}'
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
 opt_in_features:
   - spec_decoding
+  - text_only
 
 variants:
   default:

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -6,6 +6,7 @@ meta:
   date_updated: 2026-04-18
   difficulty: beginner
   tasks:
+    - text
     - multimodal
   performance_headline: "Compact Qwen3.6 MoE with 3B active parameters — single-GPU FP8 or 2-4 GPU BF16 serving"
   related_recipes:

--- a/models/baidu/ERNIE-4.5-VL-28B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-VL-28B-A3B-PT.yaml
@@ -25,9 +25,19 @@ model:
     - "--trust-remote-code"
   base_env: {}
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/deepseek-ai/DeepSeek-OCR-2.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR-2.yaml
@@ -27,9 +27,19 @@ model:
     - "0"
   base_env: {}
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/deepseek-ai/DeepSeek-OCR-2.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR-2.yaml
@@ -40,6 +40,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/deepseek-ai/DeepSeek-OCR.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR.yaml
@@ -27,9 +27,19 @@ model:
     - "0"
   base_env: {}
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/deepseek-ai/DeepSeek-OCR.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR.yaml
@@ -40,6 +40,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/internlm/Intern-S1.yaml
+++ b/models/internlm/Intern-S1.yaml
@@ -37,8 +37,18 @@ features:
     args:
       - "--reasoning-parser"
       - "deepseek_r1"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/microsoft/Phi-4-mini-instruct.yaml
+++ b/models/microsoft/Phi-4-mini-instruct.yaml
@@ -35,6 +35,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/microsoft/Phi-4-mini-instruct.yaml
+++ b/models/microsoft/Phi-4-mini-instruct.yaml
@@ -22,9 +22,19 @@ model:
   base_args: []
   base_env: {}
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
+++ b/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
@@ -36,8 +36,18 @@ features:
       - "--enable-auto-tool-choice"
       - "--tool-call-parser"
       - "mistral"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
+++ b/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
@@ -48,6 +48,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
+++ b/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
@@ -54,6 +54,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
+++ b/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
@@ -42,8 +42,18 @@ features:
     args:
       - "--reasoning-parser"
       - "mistral"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
+++ b/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
@@ -36,8 +36,18 @@ features:
       - "--enable-auto-tool-choice"
       - "--tool-call-parser"
       - "mistral"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -6,8 +6,8 @@ meta:
   date_updated: 2026-04-16
   difficulty: intermediate
   tasks:
-    - text
     - multimodal
+    - text
   performance_headline: "Multimodal agentic MoE model with DeepSeek-V3 backbone and MLA attention"
   related_recipes: []
   hardware:

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -6,6 +6,7 @@ meta:
   date_updated: 2026-04-16
   difficulty: intermediate
   tasks:
+    - text
     - multimodal
   performance_headline: "Multimodal agentic MoE model with DeepSeek-V3 backbone and MLA attention"
   related_recipes: []

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -44,9 +44,19 @@ features:
     args:
       - "--speculative-config"
       - '{"model":"lightseekorg/kimi-k2.5-eagle3","method":"eagle3","num_speculative_tokens":3}'
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
 opt_in_features:
   - spec_decoding
+  - text_only
 
 variants:
   default:

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -6,6 +6,7 @@ meta:
   date_updated: 2026-04-20
   difficulty: intermediate
   tasks:
+    - text
     - multimodal
   performance_headline: "Multimodal agentic MoE model with DeepSeek-V3 backbone and MLA attention"
   related_recipes: []

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -36,8 +36,18 @@ features:
     args:
       - "--reasoning-parser"
       - "kimi_k2"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -6,8 +6,8 @@ meta:
   date_updated: 2026-04-20
   difficulty: intermediate
   tasks:
-    - text
     - multimodal
+    - text
   performance_headline: "Multimodal agentic MoE model with DeepSeek-V3 backbone and MLA attention"
   related_recipes: []
   hardware:

--- a/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
@@ -32,8 +32,18 @@ features:
     args:
       - "--video-pruning-rate"
       - "0.75"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
@@ -44,6 +44,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/tencent/HunyuanOCR.yaml
+++ b/models/tencent/HunyuanOCR.yaml
@@ -23,9 +23,19 @@ model:
     - "0"
   base_env: {}
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/tencent/HunyuanOCR.yaml
+++ b/models/tencent/HunyuanOCR.yaml
@@ -36,6 +36,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/zai-org/GLM-4.5V.yaml
+++ b/models/zai-org/GLM-4.5V.yaml
@@ -43,8 +43,18 @@ features:
     args:
       - "--reasoning-parser"
       - "glm45"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/zai-org/GLM-4.6V.yaml
+++ b/models/zai-org/GLM-4.6V.yaml
@@ -43,8 +43,18 @@ features:
     args:
       - "--reasoning-parser"
       - "glm45"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/zai-org/GLM-ASR-Nano-2512.yaml
+++ b/models/zai-org/GLM-ASR-Nano-2512.yaml
@@ -26,19 +26,9 @@ dependencies:
   - note: "Install transformers from source for GLM-ASR tokenizer support"
     command: "uv pip install git+https://github.com/huggingface/transformers.git"
 
-features:
-  text_only:
-    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
-    args:
-      - "--language-model-only"
-  encoder_parallel:
-    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
-    args:
-      - "--mm-encoder-tp-mode"
-      - "data"
+features: {}
 
-opt_in_features:
-  - text_only
+opt_in_features: []
 
 variants:
   default:

--- a/models/zai-org/GLM-ASR-Nano-2512.yaml
+++ b/models/zai-org/GLM-ASR-Nano-2512.yaml
@@ -26,9 +26,19 @@ dependencies:
   - note: "Install transformers from source for GLM-ASR tokenizer support"
     command: "uv pip install git+https://github.com/huggingface/transformers.git"
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/zai-org/GLM-Image.yaml
+++ b/models/zai-org/GLM-Image.yaml
@@ -32,9 +32,19 @@ dependencies:
   - note: "diffusers from source — required for the DiT decoder"
     command: "uv pip install git+https://github.com/huggingface/diffusers.git"
 
-features: {}
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/zai-org/GLM-Image.yaml
+++ b/models/zai-org/GLM-Image.yaml
@@ -6,7 +6,7 @@ meta:
   date_updated: 2026-04-17
   difficulty: intermediate
   tasks:
-    - multimodal
+    - omni
   performance_headline: "9B AR generator + 7B DiT decoder, state-of-the-art text rendering in generated images"
   related_recipes: []
   hardware:
@@ -32,19 +32,9 @@ dependencies:
   - note: "diffusers from source — required for the DiT decoder"
     command: "uv pip install git+https://github.com/huggingface/diffusers.git"
 
-features:
-  text_only:
-    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
-    args:
-      - "--language-model-only"
-  encoder_parallel:
-    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
-    args:
-      - "--mm-encoder-tp-mode"
-      - "data"
+features: {}
 
-opt_in_features:
-  - text_only
+opt_in_features: []
 
 variants:
   default:

--- a/models/zai-org/GLM-OCR.yaml
+++ b/models/zai-org/GLM-OCR.yaml
@@ -34,8 +34,18 @@ features:
       - "mtp"
       - "--speculative-config.num_speculative_tokens"
       - "1"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/zai-org/GLM-OCR.yaml
+++ b/models/zai-org/GLM-OCR.yaml
@@ -46,6 +46,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/models/zai-org/Glyph.yaml
+++ b/models/zai-org/Glyph.yaml
@@ -35,8 +35,18 @@ features:
     args:
       - "--reasoning-parser"
       - "glm45"
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
 
-opt_in_features: []
+opt_in_features:
+  - text_only
 
 variants:
   default:

--- a/models/zai-org/Glyph.yaml
+++ b/models/zai-org/Glyph.yaml
@@ -47,6 +47,7 @@ features:
 
 opt_in_features:
   - text_only
+  - encoder_parallel
 
 variants:
   default:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -136,6 +139,21 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -388,8 +406,116 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -405,6 +531,98 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -2459,6 +2677,23 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -2673,8 +2908,93 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-popper@1.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-portal@1.1.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-presence@1.1.5(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-primitive@2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
@@ -2685,6 +3005,83 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rtsao/scc@1.1.0': {}
 

--- a/src/app/[org]/page.js
+++ b/src/app/[org]/page.js
@@ -47,7 +47,7 @@ const TASK_META = {
   omni:       { icon: Sparkles, label: "Omni" },
   embedding:  { icon: Hash,     label: "Embedding" },
 };
-const TASK_ORDER = ["text", "multimodal", "omni", "embedding"];
+const TASK_ORDER = ["multimodal", "text", "omni", "embedding"];
 
 export default async function OrgPage({ params }) {
   const { org } = await params;
@@ -139,6 +139,9 @@ export default async function OrgPage({ params }) {
 
 function ModelRow({ recipe }) {
   const { meta, model, variants, hf_repo } = recipe;
+  // Secondary tasks (beyond the primary used for grouping) — surface as small
+  // icons so a model under "Text" that also does vision is discoverable.
+  const secondaryTasks = (meta.tasks || []).slice(1);
 
   return (
     <Link
@@ -158,6 +161,24 @@ function ModelRow({ recipe }) {
       </div>
 
       <Badge variant="outline" className="text-[10px] capitalize">{model.architecture}</Badge>
+
+      {secondaryTasks.length > 0 && (
+        <div className="flex items-center gap-1 text-muted-foreground/70">
+          {secondaryTasks.map((t) => {
+            const tm = TASK_META[t];
+            const TIcon = tm?.icon || Cpu;
+            return (
+              <span
+                key={t}
+                title={`Also: ${tm?.label || t}`}
+                className="inline-flex items-center"
+              >
+                <TIcon size={12} />
+              </span>
+            );
+          })}
+        </div>
+      )}
 
       <div className="flex gap-1 flex-wrap">
         {Object.entries(variants || {}).map(([name, v]) => (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,8 @@
   --color-primary: var(--primary);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -46,6 +48,10 @@
   --foreground: oklch(0.129 0.042 264.695);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.129 0.042 264.695);
+  /* Tooltip/popover surface follows the inline-code palette so floating UI
+     blends with the rest of the surface ladder (code / command / popover). */
+  --popover: var(--code-bg);
+  --popover-foreground: var(--code-fg);
   --primary: oklch(0.208 0.042 265.755);
   --primary-foreground: oklch(0.984 0.003 247.858);
   --secondary: oklch(0.968 0.007 247.896);
@@ -74,6 +80,8 @@
   --foreground: oklch(0.984 0.003 247.858);
   --card: oklch(0.208 0.042 265.755);
   --card-foreground: oklch(0.984 0.003 247.858);
+  --popover: var(--code-bg);
+  --popover-foreground: var(--code-fg);
   --primary: oklch(0.929 0.013 255.508);
   --primary-foreground: oklch(0.208 0.042 265.755);
   --secondary: oklch(0.279 0.041 260.031);

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package, Info } from "lucide-react";
 import { resolveCommand, recommendStrategy, isPrecisionCompatible, pickDefaultHardware } from "@/lib/command-synthesis";
+import { TooltipProvider, InfoTip } from "@/components/ui/tooltip";
 
 // Advanced tuning presets — optional tunable flags the user can opt into.
 // (vLLM defaults like chunked prefill, prefix caching, CUDA graphs, async
@@ -438,7 +439,13 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   };
 
   const toggleFeature = (f) => {
-    const next = features.includes(f) ? features.filter((x) => x !== f) : [...features, f];
+    // text_only (skip vision encoder) and encoder_parallel (DP the encoder)
+    // are mutually exclusive — enabling one clears the other.
+    const mutex = { text_only: "encoder_parallel", encoder_parallel: "text_only" };
+    const on = !features.includes(f);
+    const next = on
+      ? [...features.filter((x) => x !== mutex[f]), f]
+      : features.filter((x) => x !== f);
     setFeatures(next);
     syncUrl({ features: next.length > 0 ? next.join(",") : "" });
     // Persist as {key: on/off} map. A value that matches the recipe's default
@@ -451,6 +458,9 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     const matchesDefault = isOptIn ? !isOn : isOn;
     if (matchesDefault) delete fprefs[f];
     else fprefs[f] = isOn;
+    // If this toggle disabled a mutex partner, clear its stored pref too so
+    // reload doesn't resurrect the conflict.
+    if (on && mutex[f]) delete fprefs[mutex[f]];
     savePreference("features", Object.keys(fprefs).length ? fprefs : undefined);
   };
 
@@ -523,6 +533,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   }
 
   return (
+    <TooltipProvider>
     <div className="space-y-4">
       {/* ── Install ── */}
       <InstallBlock
@@ -776,6 +787,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
         </details>
       </div>
     </div>
+    </TooltipProvider>
   );
 }
 
@@ -806,13 +818,14 @@ function ConfigRow({ label, hint, children }) {
       <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest sm:w-20 sm:pt-1.5 shrink-0 inline-flex items-center gap-1">
         {label}
         {hint && (
-          <span
-            title={hint}
-            className="cursor-help text-muted-foreground/60 hover:text-muted-foreground transition-colors"
-            aria-label={hint}
-          >
-            <Info size={11} />
-          </span>
+          <InfoTip content={hint}>
+            <span
+              className="cursor-help text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+              aria-label={hint}
+            >
+              <Info size={11} />
+            </span>
+          </InfoTip>
         )}
       </div>
       <div className="flex-1 min-w-0">{children}</div>
@@ -841,17 +854,18 @@ function Pill({ active, onClick, title, dimmed, disabled, children }) {
     : dimmed
     ? "border-dashed border-border/60 text-muted-foreground/50 hover:text-muted-foreground hover:border-muted-foreground/30"
     : "border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground/40 hover:bg-muted/30";
-  return (
+  const btn = (
     <button
       onClick={onClick}
-      title={title}
       disabled={disabled}
       aria-disabled={disabled}
+      aria-label={typeof title === "string" ? title : undefined}
       className={`inline-flex items-center rounded-lg border px-2.5 py-1.5 text-xs transition-all ${style}`}
     >
       {children}
     </button>
   );
+  return title ? <InfoTip content={title}>{btn}</InfoTip> : btn;
 }
 
 function envToExports(env) {

--- a/src/components/recipes/ModelSidebar.jsx
+++ b/src/components/recipes/ModelSidebar.jsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { getProviderLogo, getProviderLogoClass, getProviderDisplayName } from "@/lib/providers";
 import { recipeHref } from "@/lib/recipe-utils";
 import { ChevronRight, Type, Eye, Sparkles, Hash, Cpu } from "lucide-react";
+import { TooltipProvider, InfoTip } from "@/components/ui/tooltip";
 
 const TASK_ICON = {
   text:       Type,
@@ -30,6 +31,7 @@ export function ModelSidebar({ recipesByOrg }) {
   const toggle = (org) => setExpanded(expanded === org ? null : org);
 
   return (
+    <TooltipProvider>
     <nav className="w-64 shrink-0 hidden lg:block">
       <div className="sticky top-16 pt-4 space-y-0.5 max-h-[calc(100vh-5rem)] overflow-y-auto scrollbar-thin">
         <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground px-3 pb-2">
@@ -88,19 +90,19 @@ export function ModelSidebar({ recipesByOrg }) {
                     const primaryTask = (m.meta.tasks || [])[0];
                     const Icon = TASK_ICON[primaryTask] || Cpu;
                     return (
-                      <Link
-                        key={m.hf_id}
-                        href={recipeHref(m)}
-                        className={`flex items-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-mono transition-colors ${
-                          isActive
-                            ? "bg-vllm-blue/10 text-vllm-blue font-semibold"
-                            : "text-muted-foreground hover:text-foreground hover:bg-muted/30"
-                        }`}
-                        title={primaryTask}
-                      >
-                        <Icon size={10} className="shrink-0 opacity-60" />
-                        <span className="truncate">{m.hf_repo || m.meta.title}</span>
-                      </Link>
+                      <InfoTip key={m.hf_id} content={primaryTask}>
+                        <Link
+                          href={recipeHref(m)}
+                          className={`flex items-center gap-1.5 px-2 py-1.5 rounded-md text-[11px] font-mono transition-colors ${
+                            isActive
+                              ? "bg-vllm-blue/10 text-vllm-blue font-semibold"
+                              : "text-muted-foreground hover:text-foreground hover:bg-muted/30"
+                          }`}
+                        >
+                          <Icon size={10} className="shrink-0 opacity-60" />
+                          <span className="truncate">{m.hf_repo || m.meta.title}</span>
+                        </Link>
+                      </InfoTip>
                     );
                   })}
                 </div>
@@ -110,5 +112,6 @@ export function ModelSidebar({ recipesByOrg }) {
         })}
       </div>
     </nav>
+    </TooltipProvider>
   );
 }

--- a/src/components/ui/tooltip.jsx
+++ b/src/components/ui/tooltip.jsx
@@ -1,0 +1,53 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({ delayDuration = 150, ...props }) {
+  return <TooltipPrimitive.Provider delayDuration={delayDuration} {...props} />;
+}
+
+function Tooltip(props) {
+  return <TooltipPrimitive.Root {...props} />;
+}
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef(function TooltipContent(
+  { className, sideOffset = 6, children, ...props },
+  ref,
+) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-w-xs rounded-md border border-border bg-popover px-2.5 py-1.5 text-xs leading-snug text-popover-foreground shadow-md ring-1 ring-black/5 dark:ring-white/5",
+          "whitespace-pre-line",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+});
+
+// Convenience wrapper: `<InfoTip content="...">{trigger}</InfoTip>`
+// Renders nothing extra when content is empty (falsy) — trigger passes through.
+function InfoTip({ content, children, side, align, sideOffset, asChild = true }) {
+  if (!content) return children;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild={asChild}>{children}</TooltipTrigger>
+      <TooltipContent side={side} align={align} sideOffset={sideOffset}>
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider, InfoTip };


### PR DESCRIPTION
Adds two mutually-exclusive multimodal-encoder features across all 26 multimodal recipes: encoder_parallel (--mm-encoder-tp-mode data, default on) and text_only (--language-model-only, opt-in). Replaces browser-native `title=` tooltips with a Radix-based Tooltip component so hover delay drops from ~700ms to 150ms and overflow/portal clipping goes away.