### PR TITLE
feat(MiniMax-M2.5): add VLLM_FLOAT32_MATMUL_PRECISION=high for Blackwell (B200/B300 FP8+FP4)

### DIFF
--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -69,10 +69,7 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides:
-  blackwell:
-    extra_env:
-      VLLM_FLOAT32_MATMUL_PRECISION: "high"
+hardware_overrides: {}
 
 strategy_overrides: {}
 
@@ -145,7 +142,7 @@ guide: |
   ### Blackwell (B200 / B300) — FP8
 
   ```bash
-  VLLM_FLOAT32_MATMUL_PRECISION=high vllm serve MiniMaxAI/MiniMax-M2.5 \
+  vllm serve MiniMaxAI/MiniMax-M2.5 \
     --tensor-parallel-size 4 \
     --enable-expert-parallel \
     --tool-call-parser minimax_m2 \
@@ -155,14 +152,19 @@ guide: |
     --trust-remote-code
   ```
 
+  > **Note**: For improved performance on Blackwell GPUs (B200 / B300), you may set
+  > `VLLM_FLOAT32_MATMUL_PRECISION=high` to enable TF32 TensorCore acceleration for
+  > float32 matmuls. This deviates from the original implementation, which uses full FP32
+  > precision for MoE gating, but evaluations show no observable differences on GSM8K,
+  > MMLU-Pro, and tool-calling benchmarks. The same flag applies to the NVFP4 variant.
+
   ### Blackwell (B200 / B300) — NVFP4
 
   Use the `nvidia/MiniMax-M2.5-NVFP4` checkpoint. Required environment variables are
   applied automatically by the command builder.
 
   ```bash
-  VLLM_USE_FLASHINFER_MOE_FP4=1 VLLM_FLOAT32_MATMUL_PRECISION=high \
-  vllm serve nvidia/MiniMax-M2.5-NVFP4 \
+  VLLM_USE_FLASHINFER_MOE_FP4=1 vllm serve nvidia/MiniMax-M2.5-NVFP4 \
     --tensor-parallel-size 4 \
     --enable-expert-parallel \
     --kv-cache-dtype fp8 \

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -157,7 +157,7 @@ guide: |
 
   ### Blackwell (B200 / B300) — NVFP4
 
-  Use the `nvidia/MiniMax-M2.5-NVFP4` checkpoint. `VLLM_FLOAT32_MATMUL_PRECISION=high` is
+  Use the `nvidia/MiniMax-M2.5-NVFP4` checkpoint. Required environment variables are
   applied automatically by the command builder.
 
   ```bash

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "minimax-m2.5"
   provider: "MiniMax"
   description: "MiniMax M2.5 MoE language model (230B total / 10B active) for coding, agent toolchains, and long-context reasoning — native FP8 checkpoint"
-  date_updated: 2026-04-17
+  date_updated: 2026-04-21
   difficulty: intermediate
   tasks:
     - text
@@ -69,7 +69,10 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides: {}
+hardware_overrides:
+  blackwell:
+    extra_env:
+      VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
 strategy_overrides: {}
 
@@ -137,6 +140,37 @@ guide: |
     --reasoning-parser minimax_m2 \
     --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice
+  ```
+
+  ### Blackwell (B200 / B300) — FP8
+
+  ```bash
+  VLLM_FLOAT32_MATMUL_PRECISION=high vllm serve MiniMaxAI/MiniMax-M2.5 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  ### Blackwell (B200 / B300) — NVFP4
+
+  Use the `nvidia/MiniMax-M2.5-NVFP4` checkpoint. `VLLM_FLOAT32_MATMUL_PRECISION=high` is
+  applied automatically by the command builder.
+
+  ```bash
+  VLLM_USE_FLASHINFER_MOE_FP4=1 VLLM_FLOAT32_MATMUL_PRECISION=high \
+  vllm serve nvidia/MiniMax-M2.5-NVFP4 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --kv-cache-dtype fp8 \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice \
+    --trust-remote-code
   ```
 
   ### AMD ROCm

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -57,8 +57,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -164,7 +162,7 @@ guide: |
   applied automatically by the command builder.
 
   ```bash
-  VLLM_USE_FLASHINFER_MOE_FP4=1 vllm serve nvidia/MiniMax-M2.5-NVFP4 \
+  vllm serve nvidia/MiniMax-M2.5-NVFP4 \
     --tensor-parallel-size 4 \
     --enable-expert-parallel \
     --kv-cache-dtype fp8 \

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "minimax-m2.7"
   provider: "MiniMax"
   description: "MiniMax M2.7 MoE language model (230B total / 10B active) — latest M2 release for coding, agent toolchains, and long-context reasoning with native FP8"
-  date_updated: 2026-04-17
+  date_updated: 2026-04-21
   difficulty: intermediate
   tasks:
     - text
@@ -171,6 +171,25 @@ guide: |
     --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice
   ```
+
+  ### Blackwell (B200 / B300)
+
+  ```bash
+  vllm serve MiniMaxAI/MiniMax-M2.7 \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --enable-auto-tool-choice \
+    --trust-remote-code
+  ```
+
+  > **Note**: For improved performance on Blackwell GPUs (B200 / B300), you may set
+  > `VLLM_FLOAT32_MATMUL_PRECISION=high` to enable TF32 TensorCore acceleration for
+  > float32 matmuls. This deviates from the original implementation, which uses full FP32
+  > precision for MoE gating, but evaluations show no observable differences on GSM8K,
+  > MMLU-Pro, and tool-calling benchmarks.
 
   ### AMD ROCm — TP2 or TP4
 


### PR DESCRIPTION
Add Blackwell (B200 / B300) serving sections to the MiniMax-M2.5 guide, covering both the FP8 and NVFP4 variants. Includes an optional performance note recommending `VLLM_FLOAT32_MATMUL_PRECISION=high` on Blackwell GPUs, which enables TF32 TensorCore acceleration for float32 matmuls at the cost of slightly lower precision for MoE gating — consistent with the approach taken in vllm-project/recipes#334 for M2.7. Sources: SemiAnalysisAI/InferenceX#1069 (B200 FP4), SemiAnalysisAI/InferenceX#1107 (B300 FP4), SemiAnalysisAI/InferenceX#1106 (B300 FP8).