### PR TITLE
Add NVIDIA RTX 5090 profile and update picker order

### DIFF
--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -287,7 +287,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   // All hardware profiles grouped by brand, sorted by architectural generation
   // within brand (oldest → newest; matches the semianalysis GPU timeline).
   const hwByBrand = useMemo(() => {
-    const NVIDIA_ORDER = ["h100", "h200", "b200", "gb200", "b300", "gb300", "rtx5090"];
+    const NVIDIA_ORDER = ["rtx5090", "h100", "h200", "b200", "gb200", "b300", "gb300"];
     const AMD_ORDER = ["mi300x", "mi325x", "mi355x"];
     const rankIn = (list, id) => {
       const i = list.indexOf(id);

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -287,7 +287,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   // All hardware profiles grouped by brand, sorted by architectural generation
   // within brand (oldest → newest; matches the semianalysis GPU timeline).
   const hwByBrand = useMemo(() => {
-    const NVIDIA_ORDER = ["h100", "h200", "b200", "gb200", "b300", "gb300"];
+    const NVIDIA_ORDER = ["h100", "h200", "b200", "gb200", "b300", "gb300", "rtx5090"];
     const AMD_ORDER = ["mi300x", "mi325x", "mi355x"];
     const rankIn = (list, id) => {
       const i = list.indexOf(id);

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -41,6 +41,22 @@ hardware_profiles:
     vram_gb: 768
     multi_node: false
 
+  # ── NVIDIA Blackwell (consumer) ──
+  # Consumer/workstation Blackwell parts. `restricted: true` keeps them out of
+  # the default hardware picker — they only appear for recipes that explicitly
+  # opt in via `meta.hardware` (e.g. `rtx5090: verified`), since the vast
+  # majority of recipes target multi-GPU server nodes that won't fit on a
+  # single 32 GB consumer card.
+  rtx5090:
+    brand: NVIDIA
+    generation: blackwell
+    display_name: "RTX 5090"
+    description: "NVIDIA GeForce RTX 5090 · 32 GB GDDR7 · single-GPU workstation (consumer Blackwell, GB202, PCIe)"
+    gpu_count: 1
+    vram_gb: 32
+    multi_node: false
+    restricted: true
+
   # ── NVIDIA Blackwell Ultra ──
   b300:
     brand: NVIDIA


### PR DESCRIPTION
This pull request adds support for the NVIDIA RTX 5090 (a consumer Blackwell GPU) to the hardware taxonomy and ensures it is correctly ordered in the hardware picker. The RTX 5090 is marked as restricted so it only appears for recipes that explicitly opt in, reflecting its consumer/workstation orientation and limited suitability for most multi-GPU server workloads.

Hardware taxonomy updates:

* Added a new entry for `rtx5090` (NVIDIA GeForce RTX 5090, 32 GB GDDR7, consumer Blackwell) to `taxonomy.yaml`, with `restricted: true` to prevent it from appearing in the default hardware picker.

Hardware picker ordering:

* Updated the `NVIDIA_ORDER` array in `CommandBuilder.jsx` to include `rtx5090` at the beginning, ensuring it is sorted correctly among NVIDIA hardware profiles.