### PR TITLE
chore: env var cleanup — remove stale VLLM_USE_V1 and VLLM_COMMIT flags

### DIFF
--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -81,18 +81,7 @@ guide: |
   - **NVIDIA:** compute capability >= 7.0; ~220 GB for weights + 240 GB per 1M context tokens
   - **AMD:** MI300X / MI325X / MI350X / MI355X with ROCm 7.0+
 
-  ### Install vLLM (NVIDIA, verified commit)
-
-  ```bash
-  uv venv
-  source .venv/bin/activate
-  export VLLM_COMMIT=0f3ce4c74b1875791d6604e006b6e905fde9f698
-  uv pip install vllm \
-      --torch-backend=auto \
-      --extra-index-url https://wheels.vllm.ai/${VLLM_COMMIT}
-  ```
-
-  ### Install vLLM (NVIDIA, nightly)
+  ### Install vLLM (NVIDIA)
 
   ```bash
   uv pip install -U vllm --extra-index-url https://wheels.vllm.ai/nightly

--- a/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -99,11 +99,8 @@ guide: |
 
   ```bash
   HIP_VISIBLE_DEVICES="4,5,6,7" \
-  VLLM_USE_V1=1 \
   VLLM_ROCM_USE_AITER=1 \
   VLLM_ROCM_USE_AITER_MHA=0 \
-  VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 \
-  VLLM_USE_TRITON_FLASH_ATTN=0 \
   SAFETENSORS_FAST_GPU=1 \
   vllm serve Qwen/Qwen3-235B-A22B \
     --trust-remote-code \
@@ -121,11 +118,8 @@ guide: |
 
   ```bash
   HIP_VISIBLE_DEVICES="4,5,6,7" \
-  VLLM_USE_V1=1 \
   VLLM_ROCM_USE_AITER=1 \
   VLLM_ROCM_USE_AITER_MHA=0 \
-  VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 \
-  VLLM_USE_TRITON_FLASH_ATTN=0 \
   SAFETENSORS_FAST_GPU=1 \
   vllm serve Qwen/Qwen3-235B-A22B-FP8 \
     --trust-remote-code \


### PR DESCRIPTION
Part of the env var audit tracked in #366. Removes two flags confirmed safe to drop: `VLLM_USE_V1` (V1 is now the default engine in vLLM and the flag is a no-op) and `VLLM_COMMIT` (a one-off wheel pin in the MiniMax-M2.7 guide that was never a runtime env var pattern — replaced with the standard nightly install). Also drops the co-located `VLLM_V1_USE_PREFILL_DECODE_ATTENTION` and `VLLM_USE_TRITON_FLASH_ATTN=0` lines from the same Qwen3-235B block, which are V1-era workarounds that no longer apply.