### PR TITLE
Revert #350

### DIFF
--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -91,9 +91,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  blackwell:
-    extra_args:
-      - "--attention-config.use_trtllm_ragged_deepseek_prefill=True"
   amd:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
     extra_args:

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -78,9 +78,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  blackwell:
-    extra_args:
-      - "--attention-config.use_trtllm_ragged_deepseek_prefill=True"
   amd:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
     extra_args:


### PR DESCRIPTION
Now that 0.20 has been released with FA4 MLA prefill issues resolved, revert workaround.