### PR TITLE
Add TEP strategies for DeepSeek-V4-Pro

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -76,7 +76,9 @@ variants:
     description: "Native FP4+FP8 mixed checkpoint (MoE experts FP4, remaining params FP8)"
 
 compatible_strategies:
+  - single_node_tep
   - single_node_dep
+  - multi_node_tep
   - multi_node_dep
   - pd_cluster
 


### PR DESCRIPTION
## Summary

- Adds `single_node_tep` and `multi_node_tep` to the DeepSeek-V4-Pro compatible strategies
- Enables Tensor + Expert Parallel deployment for this MoE model alongside existing DEP and PD cluster strategies

Requested in Slack: https://inferact.slack.com/archives/C0A6DT1479A/p1777062412879429?thread_ts=1777061888.315929&cid=C0A6DT1479A

## Test plan

- [x] `node scripts/build-recipes-api.mjs` passes (80 models, 8 strategies)
- [ ] Verify TEP commands render correctly on the recipe page

https://claude.ai/code/session_01Q15o1i9EA9zixJWJPj78xQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q15o1i9EA9zixJWJPj78xQ)_