### PR TITLE
Add compilation-config for TEP strategies in DeepSeek-V4-Pro

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -103,6 +103,14 @@ hardware_overrides:
       - "--attention_config.use_fp4_indexer_cache=True"
 
 strategy_overrides:
+  single_node_tep:
+    extra_args:
+      - "--compilation-config"
+      - '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
+  multi_node_tep:
+    extra_args:
+      - "--compilation-config"
+      - '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
   single_node_dep:
     extra_args:
       - "--compilation-config"


### PR DESCRIPTION
## Summary

- Add `strategy_overrides` for `single_node_tep` and `multi_node_tep` with `--compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'`
- This adds the recommended compilation config for TEP strategies as requested

## Context

Slack thread: https://inferact.slack.com/archives/C0A6DT1479A/p1777065098762819?thread_ts=1777061888.315929&cid=C0A6DT1479A

https://claude.ai/code/session_01JMUNThJharTtNjvAE4Utn9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMUNThJharTtNjvAE4Utn9)_