### PR TITLE
Add AMD MI300X/MI325X/MI355X support for Wan2.2 recipe

### DIFF
--- a/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers.yaml
+++ b/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "wan2.2"
   provider: "Wan AI"
   description: "Wan2.2 video generation models — T2V/I2V MoE (14B active) and unified TI2V (5B dense), served via vLLM-Omni"
-  date_updated: 2026-04-17
+  date_updated: 2026-04-27
   difficulty: intermediate
   tasks:
     - omni
@@ -49,7 +49,12 @@ variants:
 
 compatible_strategies: []
 
-hardware_overrides: {}
+hardware_overrides:
+  amd:
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      SAFETENSORS_FAST_GPU: "1"
+
 strategy_overrides: {}
 
 guide: |
@@ -75,6 +80,17 @@ guide: |
   uv pip install vllm==0.12.0
   uv pip install git+https://github.com/vllm-project/vllm-omni.git@ef01223c42be10ee260b9f6e5ec31894cd09d86e
   ```
+
+  ### AMD ROCm (MI300X/MI325X/MI355X)
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install vllm==0.12.0 --extra-index-url https://wheels.vllm.ai/rocm/
+  uv pip install git+https://github.com/vllm-project/vllm-omni.git@ef01223c42be10ee260b9f6e5ec31894cd09d86e
+  ```
+
+  > ⚠️ The vLLM ROCm wheel requires Python 3.12, ROCm 7.0, and glibc >= 2.35.
 
   ## Text-to-Video (T2V)
 
@@ -103,6 +119,20 @@ guide: |
     --output t2v_output.mp4
   ```
 
+  ### Running T2V on MI300X/MI325X/MI355X GPUs
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 \
+  SAFETENSORS_FAST_GPU=1 \
+  python examples/offline_inference/text_to_video/text_to_video.py \
+    --model Wan-AI/Wan2.2-T2V-A14B-Diffusers \
+    --prompt "A serene lakeside sunrise with mist over the water." \
+    --height 720 --width 1280 \
+    --num_frames 81 --num_inference_steps 40 \
+    --guidance_scale 4.0 --fps 24 \
+    --output t2v_output.mp4
+  ```
+
   ## Image-to-Video (I2V)
 
   ```python
@@ -122,9 +152,33 @@ guide: |
   )
   ```
 
+  ### Running I2V on MI300X/MI325X/MI355X GPUs
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 \
+  SAFETENSORS_FAST_GPU=1 \
+  python examples/offline_inference/image_to_video/image_to_video.py \
+    --model Wan-AI/Wan2.2-I2V-A14B-Diffusers \
+    --image input.jpg --prompt "A cat playing with yarn" \
+    --num_frames 81 --num_inference_steps 50 \
+    --guidance_scale 5.0 --fps 16 --output i2v_output.mp4
+  ```
+
   TI2V CLI:
 
   ```bash
+  python examples/offline_inference/image_to_video/image_to_video.py \
+    --model Wan-AI/Wan2.2-TI2V-5B-Diffusers \
+    --image input.jpg --prompt "A cat playing with yarn" \
+    --num_frames 81 --num_inference_steps 50 \
+    --guidance_scale 5.0 --fps 16 --output ti2v_output.mp4
+  ```
+
+  ### Running TI2V on MI300X/MI325X/MI355X GPUs
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 \
+  SAFETENSORS_FAST_GPU=1 \
   python examples/offline_inference/image_to_video/image_to_video.py \
     --model Wan-AI/Wan2.2-TI2V-5B-Diffusers \
     --image input.jpg --prompt "A cat playing with yarn" \


### PR DESCRIPTION
- Update Wan2.2 docs for AMD GPUs
- Add AMD ROCm install instructions for vLLM-Omni (Python 3.12, ROCm 7.0)
- Add VLLM_ROCM_USE_AITER=1 for enabling AITER backend
- Cover all three Wan2.2 tasks: Text-to-Video (T2V), Image-to-Video (I2V), and unified TI2V on MI300X/MI325X/MI355X GPUs