### PR TITLE
Use 1 speculative token on Hopper for DeepSeek-V4-{Pro,Flash}

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -61,10 +61,15 @@ features:
       - "--reasoning-parser"
       - "deepseek_v4"
   spec_decoding:
-    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens."
+    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens (1 on Hopper)."
     args:
       - "--speculative_config"
       - '{"method":"mtp","num_speculative_tokens":2}'
+    hardware_overrides:
+      hopper:
+        args:
+          - "--speculative_config"
+          - '{"method":"mtp","num_speculative_tokens":1}'
 
 opt_in_features:
   - spec_decoding

--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -61,10 +61,15 @@ features:
       - "--reasoning-parser"
       - "deepseek_v4"
   spec_decoding:
-    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens."
+    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens (1 on Hopper)."
     args:
       - "--speculative_config"
       - '{"method":"mtp","num_speculative_tokens":2}'
+    hardware_overrides:
+      hopper:
+        args:
+          - "--speculative_config"
+          - '{"method":"mtp","num_speculative_tokens":1}'
 
 opt_in_features:
   - spec_decoding

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -380,9 +380,17 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
     if (advancedArgs && advancedArgs.length) args.push(...advancedArgs);
 
     // 7. Features last — tool_calling, reasoning, mtp, etc.
+    //    A feature can declare per-generation overrides under
+    //    `hardware_overrides.<gen>.args`; when present they REPLACE the
+    //    feature's default args (not merged), so a recipe can ship different
+    //    spec-decoding configs for hopper vs blackwell without dedupe gymnastics.
     for (const f of enabledFeatures || []) {
       const feat = recipe.features?.[f];
-      if (feat?.args) args.push(...feat.args);
+      if (!feat) continue;
+      const featHo = feat.hardware_overrides?.[gen]
+        || (isNvidia ? feat.hardware_overrides?.nvidia : null);
+      const featArgs = featHo?.args ?? feat.args;
+      if (featArgs) args.push(...featArgs);
     }
 
     return args;


### PR DESCRIPTION
## Summary

- Add per-feature, per-generation arg overrides to the recipe schema: `features.<key>.hardware_overrides.<gen>.args` replaces the feature's default args on that GPU generation. Slots in alongside the existing top-level `hardware_overrides` and the brand-wide `nvidia:` fallback.
- Use it on `DeepSeek-V4-Pro` and `DeepSeek-V4-Flash` so enabling **Spec Decoding** on H100/H200 renders `--speculative_config '{"method":"mtp","num_speculative_tokens":1}'` while Blackwell (B200/GB200/B300/GB300) keeps `:2`.

## Test plan

- [x] `node scripts/build-recipes-api.mjs` parses both YAMLs cleanly.
- [x] Local dev server: on `/deepseek-ai/DeepSeek-V4-Pro` with **Spec Decoding** on, switching hardware between H200 and B200 flips `num_speculative_tokens` between 1 and 2.
- [x] Same check on `/deepseek-ai/DeepSeek-V4-Flash`.
- [x] Other features (`tool_calling`, `reasoning`) still render unchanged across hardware.