### PR TITLE
Document YaRN ultra-long context for Qwen3.5/3.6 family

### DIFF
--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -221,6 +221,23 @@ guide: |
     --enable-prefix-caching
   ```
 
+  ## Processing Ultra-Long Texts
+
+  Qwen3.5-397B-A17B natively supports `262,144` tokens. For longer inputs, apply
+  YaRN RoPE scaling via `--hf-overrides` and raise `--max-model-len`. Pick
+  `factor` to match your real workload — `2.0` covers ~524K, `4.0` covers
+  ~1M — since YaRN at higher factors degrades short-context quality.
+
+  ```bash
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
+    --tensor-parallel-size 8 \
+    --max-model-len 1010000 \
+    --reasoning-parser qwen3 \
+    --hf-overrides '{"text_config": {"rope_parameters": {"mrope_interleaved": true, "mrope_section": [11, 11, 10], "rope_type": "yarn", "rope_theta": 10000000, "partial_rotary_factor": 0.25, "factor": 4.0, "original_max_position_embeddings": 262144}}}'
+  ```
+
+  See the [model card](https://huggingface.co/Qwen/Qwen3.5-397B-A17B#processing-ultra-long-texts) for the full parameter reference.
+
   ## Client Usage
 
   ```python
@@ -277,8 +294,6 @@ guide: |
   - **Prefix Caching**: Prefix caching for Mamba cache "align" mode is currently experimental.
   - **Multi-token Prediction**: MTP-1 reduces per-token latency but degrades throughput under high concurrency because speculative tokens consume KV cache capacity. Adjust `num_speculative_tokens` (1-5) based on your use case.
   - **Encoder Data Parallelism**: `--mm-encoder-tp-mode data` deploys the vision encoder in a data-parallel fashion. This consumes additional memory and may require adjustment of `--gpu-memory-utilization`.
-  - **Ultra-Long Texts**: Qwen3.5 natively supports up to 262,144 tokens. For longer contexts, use RoPE scaling (YaRN). See the [HuggingFace model card](https://huggingface.co/Qwen/Qwen3.5-397B-A17B#processing-ultra-long-texts) for details.
-
   ## References
 
   - Model card: https://huggingface.co/Qwen/Qwen3.5-397B-A17B

--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -141,7 +141,7 @@ guide: |
   ~1M — since YaRN at higher factors degrades short-context quality.
 
   ```bash
-  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3.6-27B \
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3.6-27B-FP8 \
     --tensor-parallel-size 2 \
     --max-model-len 1010000 \
     --reasoning-parser qwen3 \

--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -133,6 +133,23 @@ guide: |
     --enable-prefix-caching
   ```
 
+  ## Processing Ultra-Long Texts
+
+  Qwen3.6-27B natively supports `262,144` tokens. For longer inputs, apply
+  YaRN RoPE scaling via `--hf-overrides` and raise `--max-model-len`. Pick
+  `factor` to match your real workload — `2.0` covers ~524K, `4.0` covers
+  ~1M — since YaRN at higher factors degrades short-context quality.
+
+  ```bash
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3.6-27B \
+    --tensor-parallel-size 2 \
+    --max-model-len 1010000 \
+    --reasoning-parser qwen3 \
+    --hf-overrides '{"text_config": {"rope_parameters": {"mrope_interleaved": true, "mrope_section": [11, 11, 10], "rope_type": "yarn", "rope_theta": 10000000, "partial_rotary_factor": 0.25, "factor": 4.0, "original_max_position_embeddings": 262144}}}'
+  ```
+
+  See the [model card](https://huggingface.co/Qwen/Qwen3.6-27B#processing-ultra-long-texts) for the full parameter reference.
+
   ## Client Usage
 
   ```python

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -148,6 +148,23 @@ guide: |
     --trust-remote-code
   ```
 
+  ## Processing Ultra-Long Texts
+
+  Qwen3.6-35B-A3B natively supports `262,144` tokens. For longer inputs, apply
+  YaRN RoPE scaling via `--hf-overrides` and raise `--max-model-len`. Pick
+  `factor` to match your real workload — `2.0` covers ~524K, `4.0` covers
+  ~1M — since YaRN at higher factors degrades short-context quality.
+
+  ```bash
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3.6-35B-A3B \
+    --tensor-parallel-size 2 \
+    --max-model-len 1010000 \
+    --reasoning-parser qwen3 \
+    --hf-overrides '{"text_config": {"rope_parameters": {"mrope_interleaved": true, "mrope_section": [11, 11, 10], "rope_type": "yarn", "rope_theta": 10000000, "partial_rotary_factor": 0.25, "factor": 4.0, "original_max_position_embeddings": 262144}}}'
+  ```
+
+  See the [model card](https://huggingface.co/Qwen/Qwen3.6-35B-A3B#processing-ultra-long-texts) for the full parameter reference.
+
   ## Client Usage
 
   ```python

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -156,7 +156,7 @@ guide: |
   ~1M — since YaRN at higher factors degrades short-context quality.
 
   ```bash
-  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3.6-35B-A3B \
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
     --tensor-parallel-size 2 \
     --max-model-len 1010000 \
     --reasoning-parser qwen3 \


### PR DESCRIPTION
## Summary

The Qwen3.5/3.6 family natively serves 262K context but supports extension up to ~1M tokens via YaRN RoPE scaling, as documented on each HF model card. Only `Qwen3.5-397B-A17B` mentioned this previously, and only as a one-liner pointing back at HF.

This PR adds a **Processing Ultra-Long Texts** section to the guide of each Qwen3.5/3.6 recipe, with:

- Guidance on choosing the YaRN `factor` (`2.0` ≈ 524K, `4.0` ≈ 1M) and the short-context quality tradeoff at higher factors.
- A complete `vllm serve` example using `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` and the exact `--hf-overrides` JSON from the model cards.
- A link back to the per-model HF docs for the full parameter reference.

## Recipes updated

- `Qwen/Qwen3.6-27B`
- `Qwen/Qwen3.6-35B-A3B`
- `Qwen/Qwen3.5-397B-A17B` (also drops the obsolete one-liner under Troubleshooting now that the dedicated section covers it)

## Test plan

- [x] `node scripts/build-recipes-api.mjs` → `✓ JSON API: 80 models, 8 strategies`
- [x] Visual check on the rendered guide pages