### PR TITLE
Disable cudagraph profiler estimate on Hopper for DeepSeek-V4-Pro

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -103,6 +103,8 @@ hardware_overrides:
       - "--no-enable-flashinfer-autotune"
       - "--compilation-config"
       - '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
+    extra_env:
+      VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: "0"
   blackwell:
     extra_args:
       - "--attention_config.use_fp4_indexer_cache=True"


### PR DESCRIPTION
## Summary
- Sets `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0` in the `hopper` `hardware_overrides` block for DeepSeek-V4-Pro so H200 deployments skip the cudagraph memory estimate during profiling.

## Test plan
- [x] `node scripts/build-recipes-api.mjs` — JSON API regenerates cleanly (80 models, 8 strategies)
- [x] Verify on an H200 node that `vllm serve` picks up the env and starts without the profiler estimate