### PR TITLE
Add NVIDIA DGX Spark (2× GB10) recipe for Gemma 4 31B

### DIFF
--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -225,7 +225,7 @@ guide: |
   # Donor: NGC ships HPC-X + MLNX OFED for ARM64 RoCE
   FROM nvcr.io/nvidia/vllm:26.03-py3 AS donor
 
-  FROM vllm/vllm-openai:v0.19.0-aarch64-cu130-ubuntu2404
+  FROM vllm/vllm-openai:v0.19.1-aarch64-cu130-ubuntu2404
   COPY --from=donor /opt/hpcx /opt/hpcx
   COPY --from=donor /usr/lib/aarch64-linux-gnu/libmlx5.so* /usr/lib/aarch64-linux-gnu/
   COPY --from=donor /usr/lib/aarch64-linux-gnu/libibverbs* /usr/lib/aarch64-linux-gnu/
@@ -239,6 +239,7 @@ guide: |
   export NCCL_NET_GDR_LEVEL=5
   export NCCL_SOCKET_IFNAME=enp1s0f0np0          # pin to the 200 Gbps RoCE interface
   ```
+  The mixed-case names above (lowercase `rocep1s0f0` / `enp1s0f0np0` alongside `roceP2p1s0f0` / `enP7s7` with capital `P`) are not a typo — the kernel's predictable-naming scheme uses a capital `P` segment for devices on a non-zero PCI domain, and DGX Spark's two ConnectX-7 ports land on different domains. Discover the actual names on your box with `ibv_devices` and `ip link` and use them as listed.
 
   Head node (`192.168.100.10`):
   ```bash
@@ -273,7 +274,7 @@ guide: |
   - **`--enforce-eager`** and **`--disable-custom-all-reduce`**: CUDA graphs and the custom all-reduce kernel are unstable on multi-node aarch64 in this configuration; both are required for stable operation.
   - **`--async-scheduling`**: validated functional on this hardware including the thinking-mode streaming path.
   - **`--gpu-memory-utilization 0.85`** is the value validated end-to-end on this hardware. Higher values may be possible but are untested here; the unified-memory model on Spark makes 0.85 a conservative default.
-  - **Do not enable `--kv-cache-dtype fp8` on this configuration.** Gemma 4's heterogeneous attention head dimensions (256 / 512) cause `get_kv_cache_configs` to assert that "KV cache specs for the same layer are different across workers" under TP > 1 in vLLM 0.19.1 — engine init fails. The model-level FP8 KV cache recommendation in the section above does not apply to multi-node TP > 1.
+  - **Do not enable `--kv-cache-dtype fp8` on this configuration.** Gemma 4's heterogeneous attention head dimensions (256 / 512) cause `get_kv_cache_configs` to assert that "KV cache specs for the same layer are different across workers" under TP > 1 in vLLM 0.19.1 — engine init fails. The FP8 KV cache recommendation in the **Configuration Tips** section below does not apply to multi-node TP > 1.
   - The recipe omits `--chat-template`: vLLM 0.19.1 (declared in `min_vllm_version`) carries the upstream tool-call/reasoning parser fix that previously required a custom template.
   - Verify NCCL is using the RoCE plugin: the head log should contain `NET/IB : Using [0]rocep1s0f0:1/RoCE`.
   - `enP7s7` (2.5 Gbps onboard Ethernet) must not be selected by NCCL — pin via `NCCL_SOCKET_IFNAME`.

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "gemma-4-31b-it"
   provider: "Google"
   description: "Google's unified multimodal Gemma 4 dense model (31B) with native text, image, and audio, plus thinking mode and tool-use protocol."
-  date_updated: 2026-04-17
+  date_updated: 2026-04-25
   difficulty: intermediate
   tasks:
     - multimodal
@@ -12,6 +12,7 @@ meta:
   related_recipes: []
   hardware:
     h100: verified
+    gb10: verified
     mi300x: verified
     mi325x: verified
     mi355x: verified
@@ -215,6 +216,67 @@ guide: |
       --disable_chunked_mm_input \
       --host 0.0.0.0 --port 8000
   ```
+
+  ### NVIDIA DGX Spark (2× GB10, BF16, RoCE)
+  Two-node TP=2 deployment over ConnectX-7 200 Gbps RoCE. Each node has one GB10 GPU and ~110 GB unified memory; the model spans both nodes.
+
+  The upstream `vllm/vllm-openai:gemma4-cu130` image does not bundle HPC-X for RoCE NCCL on aarch64. Build a two-stage image that pulls HPC-X + MLNX OFED libraries from the NGC vLLM image:
+  ```dockerfile
+  # Donor: NGC ships HPC-X + MLNX OFED for ARM64 RoCE
+  FROM nvcr.io/nvidia/vllm:26.03-py3 AS donor
+
+  FROM vllm/vllm-openai:v0.19.0-aarch64-cu130-ubuntu2404
+  COPY --from=donor /opt/hpcx /opt/hpcx
+  COPY --from=donor /usr/lib/aarch64-linux-gnu/libmlx5.so* /usr/lib/aarch64-linux-gnu/
+  COPY --from=donor /usr/lib/aarch64-linux-gnu/libibverbs* /usr/lib/aarch64-linux-gnu/
+  RUN pip install --no-deps "ray==2.54.0" "transformers>=5.5.0"
+  ```
+
+  Required NCCL environment on both nodes:
+  ```bash
+  export NCCL_IB_DISABLE=0
+  export NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0     # discover with `ibv_devices`
+  export NCCL_NET_GDR_LEVEL=5
+  export NCCL_SOCKET_IFNAME=enp1s0f0np0          # pin to the 200 Gbps RoCE interface
+  ```
+
+  Head node (`192.168.100.10`):
+  ```bash
+  vllm serve google/gemma-4-31B-it \
+    --tensor-parallel-size 2 \
+    --distributed-executor-backend mp \
+    --nnodes 2 --node-rank 0 \
+    --master-addr 192.168.100.10 --master-port 29501 \
+    --gpu-memory-utilization 0.85 \
+    --max-model-len 32768 \
+    --enforce-eager \
+    --disable-custom-all-reduce \
+    --async-scheduling \
+    --enable-auto-tool-choice \
+    --reasoning-parser gemma4 \
+    --tool-call-parser gemma4 \
+    --host 0.0.0.0 --port 8000
+  ```
+
+  Worker node (`192.168.100.11`):
+  ```bash
+  vllm serve google/gemma-4-31B-it \
+    --tensor-parallel-size 2 \
+    --distributed-executor-backend mp \
+    --nnodes 2 --node-rank 1 \
+    --master-addr 192.168.100.10 --master-port 29501 \
+    --headless
+  ```
+
+  Notes:
+  - **`--distributed-executor-backend mp`**: the Ray Compiled Graph executor is unstable on TP=2 multi-node here; the native MP backend is stable. See [vllm#30016](https://github.com/vllm-project/vllm/issues/30016).
+  - **`--enforce-eager`** and **`--disable-custom-all-reduce`**: CUDA graphs and the custom all-reduce kernel are unstable on multi-node aarch64 in this configuration; both are required for stable operation.
+  - **`--async-scheduling`**: validated functional on this hardware including the thinking-mode streaming path.
+  - **`--gpu-memory-utilization 0.85`** is the value validated end-to-end on this hardware. Higher values may be possible but are untested here; the unified-memory model on Spark makes 0.85 a conservative default.
+  - **Do not enable `--kv-cache-dtype fp8` on this configuration.** Gemma 4's heterogeneous attention head dimensions (256 / 512) cause `get_kv_cache_configs` to assert that "KV cache specs for the same layer are different across workers" under TP > 1 in vLLM 0.19.1 — engine init fails. The model-level FP8 KV cache recommendation in the section above does not apply to multi-node TP > 1.
+  - The recipe omits `--chat-template`: vLLM 0.19.1 (declared in `min_vllm_version`) carries the upstream tool-call/reasoning parser fix that previously required a custom template.
+  - Verify NCCL is using the RoCE plugin: the head log should contain `NET/IB : Using [0]rocep1s0f0:1/RoCE`.
+  - `enP7s7` (2.5 Gbps onboard Ethernet) must not be selected by NCCL — pin via `NCCL_SOCKET_IFNAME`.
 
   ## Client Usage
 

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -60,6 +60,15 @@ hardware_profiles:
     vram_gb: 1152
     multi_node: false
 
+  gb10:
+    brand: NVIDIA
+    generation: blackwell
+    display_name: "DGX Spark (GB10)"
+    description: "NVIDIA DGX Spark · Grace-Blackwell GB10 superchip · 1 GPU · ~110 GB unified memory per node (ARM64) · multi-node over RoCE"
+    gpu_count: 1
+    vram_gb: 110
+    multi_node: true
+
   # ── AMD Instinct ──
   mi300x:
     brand: AMD


### PR DESCRIPTION
## Summary

Adds support for **NVIDIA DGX Spark** (2× GB10, ARM64, ConnectX-7 200 Gbps RoCE) as a verified hardware target for the Gemma 4 31B recipe.

Three changes, in this PR:

1. **`taxonomy.yaml`** — new `gb10` hardware profile (NVIDIA Blackwell, 1 GPU/node, ~110 GB unified memory, multi-node).
2. **`models/Google/gemma-4-31B-it.yaml`** — `meta.hardware.gb10: verified` so DGX Spark appears in the NVIDIA hardware picker for this recipe.
3. **`models/Google/gemma-4-31B-it.yaml` `guide` block** — new `### NVIDIA DGX Spark (2× GB10, BF16, RoCE)` subsection with the Dockerfile, NCCL/RoCE env, and head/worker `vllm serve` commands for two-node TP=2.

## Flag Dictionary

The flag set in the recipe is the one validated under sustained production traffic on this hardware. Each load-bearing flag is non-obvious from the existing single-node NVIDIA recipe:

- **`--distributed-executor-backend mp`** — the Ray Compiled Graph executor is unstable on TP>1 multi-node on this hardware; the native multiprocessing backend is stable under the same workload. Matches guidance in vllm-project/vllm#30016.
- **`--enforce-eager`** + **`--disable-custom-all-reduce`** — CUDA graphs and the custom all-reduce kernel are unstable on multi-node aarch64 in this configuration; both are required for stable operation.
- **`--async-scheduling`** — tested compatible (including the thinking-mode streaming path).
- **`--gpu-memory-utilization 0.85`** — the value soak-validated on this hardware. The recipe explicitly notes higher values may be possible but are untested here, so users on Spark know what's been verified vs. what's recommended generically.
- **No `--chat-template` flag** — vLLM 0.19.1 (declared in `min_vllm_version`) carries the upstream tool-call/reasoning parser fix that previously required a custom template. The recipe notes this so people don't carry forward stale guidance.
- **`--kv-cache-dtype fp8` is explicitly called out as a do-not-enable** for this configuration. Gemma 4's heterogeneous attention head dimensions (256 / 512) cause `get_kv_cache_configs` to assert "KV cache specs for the same layer are different across workers" under TP > 1 in vLLM 0.19.1 — engine init fails. This is a concrete trap because the recipe's existing "Configuration Tips" section recommends FP8 KV cache generically; the new note makes clear that recommendation does not apply to multi-node TP > 1.

**Build/runtime infrastructure:**

- **HPC-X / MLNX OFED libraries** — the upstream `vllm/vllm-openai:gemma4-cu130` aarch64 image does not bundle them, so the included two-stage Dockerfile pulls them from the NGC vLLM image as a donor layer. Without this, NCCL falls back off RoCE.
- The NCCL env block pins `NCCL_SOCKET_IFNAME` to the 200 Gbps ConnectX-7 interface — DGX Spark also exposes a 2.5 Gbps onboard NIC that NCCL will otherwise sometimes select.

## Validation

- `node scripts/build-recipes-api.mjs` → `JSON API: 82 models, 8 strategies` (no errors).
- Local `next dev` preview confirms the new `DGX Spark (GB10)` hardware tile appears under NVIDIA on the recipe page and the guide subsection renders correctly.
- Configuration exercised end-to-end on real hardware:
  - 36+ hours under sustained agent traffic on the multiprocessing executor — no crashes, no NCCL errors.
  - Thinking-mode multi-turn session: 805 reasoning SSE events over a single streaming probe, zero special-token leak literals, clean `finish_reason: stop`.
- Each individual flag in the recipe was tested:
  - `--async-scheduling`: validated functional including the thinking-mode streaming path.
  - `--kv-cache-dtype fp8`: tested and confirmed **incompatible** in this configuration (engine init fails at `kv_cache_utils.py:1552` with "KV cache specs for the same layer are different across workers"). Documented as a do-not-enable in the guide notes so other Spark users don't follow the upstream Configuration Tips section into the same crash.