### PR TITLE
[TPU][Gemma4] Update TPU Docker image references for Gemma 4

### DIFF
--- a/Google/Gemma4.md
+++ b/Google/Gemma4.md
@@ -141,7 +141,8 @@ docker run -itd --name gemma4-tpu \
         --model google/gemma-4-31B-it \
         --tensor-parallel-size 2 \
         --max-model-len 16384 \
-        --max-num-batched-tokens 16384 \
+        --max-num-batched-tokens 4096 \
+        --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' \
         --block-size=256 \
         --disable_chunked_mm_input \
         --host 0.0.0.0 \

--- a/Google/Gemma4.md
+++ b/Google/Gemma4.md
@@ -128,6 +128,7 @@ docker run -itd --name gemma4 \
 
 ### Cloud TPU Deployment via Docker
 
+For 31B dense variant:
 ```shell
 docker run -itd --name gemma4-tpu \
     --privileged \
@@ -143,6 +144,27 @@ docker run -itd --name gemma4-tpu \
         --max-model-len 16384 \
         --max-num-batched-tokens 4096 \
         --additional_config='{"quantization": { "qwix": { "rules": [{ "module_path": ".*", "weight_qtype": "float8_e4m3fn", "act_qtype": "float8_e4m3fn"}]}}}' \
+        --block-size=256 \
+        --disable_chunked_mm_input \
+        --host 0.0.0.0 \
+        --port 8000
+```
+
+For 26B MoE variant:
+```shell
+docker run -itd --name gemma4-tpu \
+    --privileged \
+    --network host \
+    --shm-size 16G \
+    -v /dev/shm:/dev/shm \
+    -e HF_TOKEN=$HF_TOKEN \
+    -e USE_BATCHED_RPA_KERNEL=1 \
+    vllm/vllm-tpu:nightly \
+        python3 -m vllm.entrypoints.openai.api_server \
+        --model google/gemma-4-26B-A4B-it \
+        --tensor-parallel-size 4 \
+        --max-model-len 16384 \
+        --max-num-batched-tokens 4096 \
         --block-size=256 \
         --disable_chunked_mm_input \
         --host 0.0.0.0 \

--- a/Google/Gemma4.md
+++ b/Google/Gemma4.md
@@ -60,7 +60,7 @@ uv pip install vllm --pre \
 docker pull vllm/vllm-openai:latest       # For CUDA 12.9
 docker pull vllm/vllm-openai:latest-cu130 # For CUDA 13.0
 docker pull vllm/vllm-openai-rocm:latest  # For AMD GPUs
-docker pull vllm/vllm-tpu:gemma4          # For Cloud TPUs
+docker pull vllm/vllm-tpu:nightly         # For Cloud TPUs
 ```
 
 ## Running Gemma 4
@@ -135,10 +135,14 @@ docker run -itd --name gemma4-tpu \
     --shm-size 16G \
     -v /dev/shm:/dev/shm \
     -e HF_TOKEN=$HF_TOKEN \
-    vllm/vllm-tpu:gemma4 \
+    -e USE_BATCHED_RPA_KERNEL=1 \
+    vllm/vllm-tpu:nightly \
+        python3 -m vllm.entrypoints.openai.api_server \
         --model google/gemma-4-31B-it \
-        --tensor-parallel-size 8 \
+        --tensor-parallel-size 2 \
         --max-model-len 16384 \
+        --max-num-batched-tokens 16384 \
+        --block-size=256 \
         --disable_chunked_mm_input \
         --host 0.0.0.0 \
         --port 8000


### PR DESCRIPTION
TP=1 will OOM if using the **same args**, user might need to tune args themselves if they really want TP=1

Perf. on ironwood (v7x)
```
vllm bench serve \
    --model google/gemma-4-31B-it \
    --dataset-name random \
    --random-input-len 1024 \
    --random-output-len 1024 \
    --num-prompts 320 \
    --ignore-eos \
    --temperature=0

============ Serving Benchmark Result ============
Successful requests:                     320
Failed requests:                         0
Benchmark duration (s):                  189.72
Total input tokens:                      327680
Total generated tokens:                  327680
Request throughput (req/s):              1.69
Output token throughput (tok/s):         1727.14
Peak output token throughput (tok/s):    3432.00
Peak concurrent requests:                320.00
Total token throughput (tok/s):          3454.28
---------------Time to First Token----------------
Mean TTFT (ms):                          50174.86
Median TTFT (ms):                        53658.99
P99 TTFT (ms):                           106359.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          53.80
Median TPOT (ms):                        47.61
P99 TPOT (ms):                           83.25
---------------Inter-token Latency----------------
Mean ITL (ms):                           53.80
Median ITL (ms):                         42.96
P99 ITL (ms):                            183.69
==================================================
```