### PR TITLE
Update DeepSeek-V4-Pro TEP compilation-config

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -109,11 +109,11 @@ strategy_overrides:
   single_node_tep:
     extra_args:
       - "--compilation-config"
-      - '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
   multi_node_tep:
     extra_args:
       - "--compilation-config"
-      - '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
   single_node_dep:
     extra_args:
       - "--compilation-config"


### PR DESCRIPTION
## Summary
- Switch `single_node_tep` and `multi_node_tep` strategy overrides for `deepseek-ai/DeepSeek-V4-Pro` to `{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}` (was `{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}`).

verified that full_and_piecewise works on TP+EP  as suggested by @wzhao18 to do full_and_piecewise for TP+EP too and not just DPEP https://github.com/SemiAnalysisAI/InferenceX/pull/1204#discussion_r3156238518 

+viz @esmeetu


## TP+EP with decode only cudagraphs (unofifical experiment point)
<img width="2122" height="1310" alt="image" src="https://github.com/user-attachments/assets/c909541c-0114-4ceb-aa09-628318acc49d" />


## local dev screenshot of change
<img width="1014" height="572" alt="image" src="https://github.com/user-attachments/assets/b4aaac4b-e2f9-4161-b4ae-6cf09eb70dec" />

## Test plan
- [ ] Verify rendered command on `/deepseek-ai/DeepSeek-V4-Pro` for `single_node_tep` and `multi_node_tep` shows the new `--compilation-config` value.
- [ ] `vllm serve` smoke test on the TEP strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)