### PR TITLE
fix(deepseek): set TP=8 for V4-Flash single_node_tp on 8-GPU nodes

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -97,6 +97,7 @@ strategy_overrides:
     # Latency-oriented TP-only deployment: no expert parallelism (single_node_tp
     # strategy doesn't add --enable-expert-parallel) and no MoE mega-kernel
     # backend on Blackwell. Autotune is disabled to minimize startup time.
+    tp: 8
     extra_args:
       - "--no-enable-flashinfer-autotune"
     hardware_overrides:


### PR DESCRIPTION
The auto-fit logic sets TP=1 when the model fits on a single GPU (170 GB <= 180 GB per B200). Override tp: 8 for single_node_tp so that 8xB200 and 8xH200 deployments shard across all GPUs as intended for the latency-oriented tensor-parallel-only path.