### PR TITLE
DeepSeek-V4-Pro: enable num_speculative_tokens=2 on Hopper

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -55,15 +55,10 @@ features:
       - "--reasoning-parser"
       - "deepseek_v4"
   spec_decoding:
-    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens (1 on Hopper)."
+    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens."
     args:
       - "--speculative_config"
       - '{"method":"mtp","num_speculative_tokens":2}'
-    hardware_overrides:
-      hopper:
-        args:
-          - "--speculative_config"
-          - '{"method":"mtp","num_speculative_tokens":1}'
 
 opt_in_features:
   - spec_decoding


### PR DESCRIPTION
## Summary
Drop the Hopper-specific `num_speculative_tokens=1` override for DeepSeek-V4-Pro MTP so Hopper (H200) uses the same `num_speculative_tokens=2` as Blackwell.

## Context
The recipe was originally added with a `hopper` hardware override under `spec_decoding` because H200 MTP kernels were limited to 1 draft token at the time. Recent vLLM H200 MTP testing shows the kernels accept 2 draft tokens, matching what Blackwell already does (cf. Blackwell MTP submission by @wzhao18). Removing the override aligns Hopper with the recipe default.

If H200 MTP throughput / acceptance rate at `num_speculative_tokens=2` ends up worse than at 1 in your testing, the override should be reinstated — but our internal sweep on H200 with this change is in flight, and current evidence is that 2 wins.

## Change
```yaml
   spec_decoding:
-    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens (1 on Hopper)."
+    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens."
     args:
       - "--speculative_config"
       - '{"method":"mtp","num_speculative_tokens":2}'
-    hardware_overrides:
-      hopper:
-        args:
-          - "--speculative_config"
-          - '{"method":"mtp","num_speculative_tokens":1}'
```

## Test plan
- [ ] On an H200 node, launch DeepSeek-V4-Pro with `spec_decoding` opted in and confirm the engine starts with `--speculative_config '{"method":"mtp","num_speculative_tokens":2}'`.
- [ ] Acceptance rate is in a sane range and end-to-end throughput at matched concurrency points is at least on par with `num_speculative_tokens=1`.
