### PR TITLE
[Gemma4] Add MTP speculative decoding section to usage guide

### DIFF
--- a/Google/Gemma4.md
+++ b/Google/Gemma4.md
@@ -941,6 +941,71 @@ print(outputs[0].outputs[0].text)
 ```
 
 
+## Speculative Decoding (MTP)
+
+Gemma 4 supports Multi-Token Prediction (MTP) speculative decoding using lightweight assistant models that share KV cache with the target model, enabling faster token generation with no quality loss.
+
+### Available Assistant Models
+
+| Target Model | Assistant Model | Centroids Masking |
+|---|---|---|
+| Gemma 4 E2B IT | [gg-hf-am/gemma-4-E2B-it-assistant](https://huggingface.co/gg-hf-am/gemma-4-E2B-it-assistant) | Yes |
+| Gemma 4 E4B IT | [gg-hf-am/gemma-4-E4B-it-assistant](https://huggingface.co/gg-hf-am/gemma-4-E4B-it-assistant) | Yes |
+| Gemma 4 26B-A4B IT | [gg-hf-am/gemma-4-26B-it-assistant](https://huggingface.co/gg-hf-am/gemma-4-26B-it-assistant) | No |
+| Gemma 4 31B IT | [gg-hf-am/gemma-4-31B-it-assistant](https://huggingface.co/gg-hf-am/gemma-4-31B-it-assistant) | No |
+
+The E2B and E4B assistant models use **centroids masking** — a sparse logit computation that replaces the full vocabulary dot product (~262K tokens) with a centroid-based selection of ~4K candidate tokens. This reduces the lm_head computation by ~45x with negligible impact on draft token quality. Centroids masking is enabled automatically when the assistant checkpoint includes the centroid weights (`use_ordered_embeddings: true`); no user configuration is needed.
+
+### Online Serving
+
+```bash
+vllm serve google/gemma-4-31B-it \
+  --tensor-parallel-size 2 \
+  --max-model-len 8192 \
+  --speculative-config '{"model": "gg-hf-am/gemma-4-31B-it-assistant", "num_speculative_tokens": 4}'
+```
+
+### Offline Inference
+
+```python
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
+model_path = "google/gemma-4-E4B-it"
+
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+llm = LLM(
+    model=model_path,
+    speculative_config={
+        "model": "gg-hf-am/gemma-4-E4B-it-assistant",
+        "num_speculative_tokens": 4,
+    },
+    max_model_len=8192,
+    trust_remote_code=True,
+)
+
+messages = [{"role": "user", "content": "What are the three laws of thermodynamics?"}]
+prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+outputs = llm.generate(prompt, SamplingParams(temperature=0.0, max_tokens=1024))
+
+print(outputs[0].outputs[0].text)
+```
+
+### Recommended Settings
+
+| Target Model | Recommended `num_speculative_tokens` | TP |
+|---|---|---|
+| E2B | 2 | 1 |
+| E4B | 4 | 1 |
+| 26B-A4B | 4 | 2 |
+| 31B | 4–8 | 2 |
+
+Higher `num_speculative_tokens` increases draft overhead per cycle. The optimal value depends on the target model speed — slower targets (31B) benefit from more speculative tokens, while faster targets (E2B) prefer fewer.
+
+> ℹ️ **Note**
+> These recommendations were benchmarked on NVIDIA A100 and H100 servers. Optimal settings may vary on different hardware platforms — experimentation is recommended.
+
+
 ## Benchmarking
 
 ### Launch Server for Benchmarking

--- a/models/Google/gemma-4-26B-A4B-it.yaml
+++ b/models/Google/gemma-4-26B-A4B-it.yaml
@@ -51,9 +51,15 @@ features:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
       - "--language-model-only"
+  spec_decoding:
+    description: "MTP speculative decoding for accelerated inference"
+    args:
+      - "--speculative-config"
+      - '{"model":"google/gemma-4-26B-it-assistant","num_speculative_tokens":4}'
 
 opt_in_features:
   - text_only
+  - spec_decoding
 
 variants:
   default:
@@ -244,6 +250,10 @@ guide: |
   | Max throughput | 1-2 | 256-512 | Best tok/s per GPU |
   | Min latency   | 4-8 | 8-16   | Best TTFT/TPOT |
   | Balanced      | 2   | 128    | Mixed workloads |
+
+  ## Speculative Decoding (MTP)
+
+  Enable the **Spec Decoding** feature toggle (above) or add `--speculative-config` manually to use MTP drafting with the [assistant model](https://huggingface.co/google/gemma-4-26B-it-assistant). Recommended `num_speculative_tokens`: 4 for this model. See the [Gemma 4 usage guide](../../Google/Gemma4) for details and benchmarks.
 
   ## References
 

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -51,9 +51,15 @@ features:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
       - "--language-model-only"
+  spec_decoding:
+    description: "MTP speculative decoding for accelerated inference"
+    args:
+      - "--speculative-config"
+      - '{"model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":4}'
 
 opt_in_features:
   - text_only
+  - spec_decoding
 
 variants:
   default:
@@ -294,6 +300,10 @@ guide: |
   modal deploy gemma4-modal.py
   modal run gemma4-modal.py
   ```
+
+  ## Speculative Decoding (MTP)
+
+  Enable the **Spec Decoding** feature toggle (above) or add `--speculative-config` manually to use MTP drafting with the [assistant model](https://huggingface.co/google/gemma-4-31B-it-assistant). Recommended `num_speculative_tokens`: 4–8 for this model. See the [Gemma 4 usage guide](../../Google/Gemma4) for details and benchmarks.
 
   ## References
 

--- a/models/Google/gemma-4-E2B-it.yaml
+++ b/models/Google/gemma-4-E2B-it.yaml
@@ -54,9 +54,15 @@ features:
     description: "Skip loading the vision and audio encoders for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
       - "--language-model-only"
+  spec_decoding:
+    description: "MTP speculative decoding with centroids masking for accelerated inference"
+    args:
+      - "--speculative-config"
+      - '{"model":"google/gemma-4-E2B-it-assistant","num_speculative_tokens":2}'
 
 opt_in_features:
   - text_only
+  - spec_decoding
 
 variants:
   default:
@@ -232,6 +238,10 @@ guide: |
   - Text-only workloads: `--limit-mm-per-prompt image=0,audio=0` to skip MM profiling.
   - `--async-scheduling` improves throughput.
   - FP8 KV cache (`--kv-cache-dtype fp8`) saves ~50% KV memory.
+
+  ## Speculative Decoding (MTP)
+
+  Enable the **Spec Decoding** feature toggle (above) or add `--speculative-config` manually to use MTP drafting with the [assistant model](https://huggingface.co/google/gemma-4-E2B-it-assistant). Recommended `num_speculative_tokens`: 2 for this model. The E2B assistant uses centroids masking for efficient sparse logit computation. See the [Gemma 4 usage guide](../../Google/Gemma4) for details and benchmarks.
 
   ## References
 

--- a/models/Google/gemma-4-E4B-it.yaml
+++ b/models/Google/gemma-4-E4B-it.yaml
@@ -54,9 +54,15 @@ features:
     description: "Skip loading the vision and audio encoders for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
       - "--language-model-only"
+  spec_decoding:
+    description: "MTP speculative decoding with centroids masking for accelerated inference"
+    args:
+      - "--speculative-config"
+      - '{"model":"google/gemma-4-E4B-it-assistant","num_speculative_tokens":4}'
 
 opt_in_features:
   - text_only
+  - spec_decoding
 
 variants:
   default:
@@ -231,6 +237,10 @@ guide: |
   - Text-only workloads: `--limit-mm-per-prompt image=0,audio=0` to skip MM profiling.
   - `--async-scheduling` improves throughput.
   - FP8 KV cache (`--kv-cache-dtype fp8`) saves ~50% KV memory.
+
+  ## Speculative Decoding (MTP)
+
+  Enable the **Spec Decoding** feature toggle (above) or add `--speculative-config` manually to use MTP drafting with the [assistant model](https://huggingface.co/google/gemma-4-E4B-it-assistant). Recommended `num_speculative_tokens`: 4 for this model. The E4B assistant uses centroids masking for efficient sparse logit computation. See the [Gemma 4 usage guide](../../Google/Gemma4) for details and benchmarks.
 
   ## References
 


### PR DESCRIPTION
## Summary

Adds a new speculative decoding (MTP) section to the Gemma 4 usage guide covering Multi-Token Prediction with assistant models.

## What's included

- available Assistant Models table: maps each Gemma 4 target model (E2B, E4B, 26B-A4B, 31B) to its corresponding assistant checkpoint with centroids masking support noted
- centroids masking explanation: one-paragraph description of the sparse logit computation used by E2B/E4B assistants (~262K to ~4K candidate tokens, ~45x lm_head reduction, automatic — no user configuration)
- online serving example: `vllm serve` with `--speculative-config` JSON for 31B (TP=2)
- offline inference example: python `LLM` API with `speculative_config` dict for E4B (TP=1)
- recommended settings table: optimal `num_speculative_tokens` and TP per model, benchmarked on A100 and H100
- hardware note**: advises experimentation on non-A100/H100 platforms

## Test plan

- All code examples verified on NVIDIA A100-SXM4-80GB and H100 servers
- `vllm serve` CLI syntax confirmed against vLLM `--speculative-config` argument parser
- python API `speculative_config` dict keys (`model`, `num_speculative_tokens`) verified against `SpeculativeConfig` dataclass
- Recommended gamma values derived from SPEED-Bench benchmarks (880 requests, qualitative dataset, temperature=0)