### PR TITLE
Site polish: cu130 baseline, per-recipe state, provider naming

### DIFF
--- a/models/Google/translategemma-27b-it.yaml
+++ b/models/Google/translategemma-27b-it.yaml
@@ -13,7 +13,6 @@ meta:
 model:
   model_id: "google/translategemma-27b-it"
   min_vllm_version: "0.14.1"
-  docker_image: "vllm/vllm-openai:v0.14.1-cu130"
   architecture: dense
   parameter_count: "27B"
   active_parameters: "27B"
@@ -74,7 +73,7 @@ guide: |
 
   ### Docker
   ```bash
-  docker pull vllm/vllm-openai:v0.14.1-cu130
+  docker pull vllm/vllm-openai:latest
   ```
 
   ## Deployment Configurations
@@ -87,7 +86,7 @@ guide: |
     --shm-size 16G \
     --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai:v0.14.1-cu130 \
+    vllm/vllm-openai:latest \
       Infomaniak-AI/vllm-translategemma-27b-it \
       --served-model-name translategemma-27b-it \
       --gpu-memory-utilization 0.8 \

--- a/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers.yaml
+++ b/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "Wan2.2"
   slug: "wan2.2"
-  provider: "Wan AI"
+  provider: "Wan (Alibaba)"
   description: "Wan2.2 video generation models — T2V/I2V MoE (14B active) and unified TI2V (5B dense), served via vLLM-Omni"
   date_updated: 2026-04-27
   difficulty: intermediate

--- a/models/XiaomiMiMo/MiMo-V2-Flash.yaml
+++ b/models/XiaomiMiMo/MiMo-V2-Flash.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "MiMo-V2-Flash"
   slug: "mimo-v2-flash"
-  provider: "Xiaomi MiMo"
+  provider: "MiMo (Xiaomi)"
   description: "Xiaomi's MoE reasoning model (309B total / 15B active) with hybrid attention and MTP for fast agentic workflows"
   date_updated: 2026-04-17
   difficulty: intermediate

--- a/models/XiaomiMiMo/MiMo-V2.5-Pro.yaml
+++ b/models/XiaomiMiMo/MiMo-V2.5-Pro.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "MiMo-V2.5-Pro"
   slug: "mimo-v2-5-pro"
-  provider: "Xiaomi MiMo"
+  provider: "MiMo (Xiaomi)"
   description: "Xiaomi's flagship MoE reasoning model (1.02T total / 42B active) with hybrid attention, native FP8 weights, and Multi-Token Prediction"
   date_updated: 2026-04-27
   difficulty: advanced

--- a/models/XiaomiMiMo/MiMo-V2.5.yaml
+++ b/models/XiaomiMiMo/MiMo-V2.5.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "MiMo-V2.5"
   slug: "mimo-v2-5"
-  provider: "Xiaomi MiMo"
+  provider: "MiMo (Xiaomi)"
   description: "MiMo-V2.5 is a native omnimodal model with strong agentic capabilities, supporting text, image, video, and audio understanding within a unified architecture"
   date_updated: 2026-04-27
   difficulty: advanced

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -29,7 +29,20 @@ model:
     - "--enable-expert-parallel"
   base_env: {}
 
-features: {}
+features:
+  tool_calling:
+    description: "Enable DeepSeek-R1 tool calling with the deepseek_v3 tool-call parser."
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "deepseek_v3"
+      - "--chat-template"
+      - "examples/tool_chat_template_deepseekr1.jinja"
+  reasoning:
+    description: "Enable reasoning/thinking mode with the DeepSeek R1 reasoning parser."
+    args:
+      - "--reasoning-parser"
+      - "deepseek_r1"
 
 opt_in_features: []
 

--- a/models/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.1.yaml
@@ -38,7 +38,9 @@ features:
       - "examples/tool_chat_template_deepseekv31.jinja"
   reasoning:
     description: "Dynamic thinking mode via chat_template_kwargs={'thinking': true|false}. No separate parser flag is required; the chat template emits <think>...</think> content."
-    args: []
+    args:
+      - "--reasoning-parser"
+      - "deepseek_v3"
 
 opt_in_features: []
 

--- a/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -31,9 +31,19 @@ dependencies:
     command: "uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation"
 
 features:
+  tool_calling:
+    description: "Enable tool calling with DeepSeek V3.2 chat template support."
+    args:
+      - "--tokenizer-mode"
+      - "deepseek_v32"
+      - "--tool-call-parser"
+      - "deepseek_v32"
+      - "--enable-auto-tool-choice"
   reasoning:
     description: "Dynamic thinking mode via chat_template_kwargs, same as DeepSeek-V3.1."
-    args: []
+    args:
+      - "--reasoning-parser"
+      - "deepseek_v3"
 
 opt_in_features: []
 

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -29,7 +29,20 @@ model:
     - "--enable-expert-parallel"
   base_env: {}
 
-features: {}
+features:
+  tool_calling:
+    description: "Enable DeepSeek-V3 tool calling with the deepseek_v3 tool-call parser."
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "deepseek_v3"
+      - "--chat-template"
+      - "examples/tool_chat_template_deepseekv3.jinja"
+  reasoning:
+    description: "Enable reasoning/thinking mode with the DeepSeek R1 reasoning parser."
+    args:
+      - "--reasoning-parser"
+      - "deepseek_v3"
 
 opt_in_features: []
 

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -7,7 +7,7 @@ meta:
   difficulty: hard
   tasks:
     - text
-  performance_headline: "1M efficient long-context attention"
+  performance_headline: "Compact 284B/13B V4 sibling — single-node 1M-context serving with FP4+FP8 weights and MTP"
   related_recipes: []
   hardware:
     h200: verified
@@ -336,7 +336,7 @@ guide: |
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_NIXL_SIDE_CHANNEL_PORT=5557 \
     -e CUDA_VISIBLE_DEVICES=0,1,2,3 \
-    vllm/vllm-openai:deepseekv4-cu130 \
+    vllm/vllm-openai:latest \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
@@ -370,7 +370,7 @@ guide: |
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_NIXL_SIDE_CHANNEL_PORT=5558 \
     -e CUDA_VISIBLE_DEVICES=4,5,6,7 \
-    vllm/vllm-openai:deepseekv4-cu130 \
+    vllm/vllm-openai:latest \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \

--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -7,7 +7,7 @@ meta:
   difficulty: hard
   tasks:
     - text
-  performance_headline: "1M efficient long-context attention"
+  performance_headline: "Frontier 1.6T/49B reasoning MoE with native FP4+FP8 weights, MTP speculative decoding, and 1M-token context"
   related_recipes: []
   hardware:
     h200: verified

--- a/models/meituan-longcat/LongCat-Image-Edit.yaml
+++ b/models/meituan-longcat/LongCat-Image-Edit.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "LongCat-Image-Edit"
   slug: "longcat-image-edit"
-  provider: "Meituan"
+  provider: "LongCat (Meituan)"
   description: "Bilingual (Chinese-English) image editing model from Meituan LongCat, served via vLLM-Omni"
   date_updated: 2026-04-17
   difficulty: intermediate

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -171,7 +171,7 @@ guide: |
 
   **Docker (NVIDIA):**
   ```bash
-  docker pull vllm/vllm-openai:v0.17.0-cu130
+  docker pull vllm/vllm-openai:latest
   ```
 
   ## Client Usage

--- a/models/poolside/Laguna-XS.2.yaml
+++ b/models/poolside/Laguna-XS.2.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "Laguna XS.2"
   slug: "laguna-xs.2"
-  provider: "poolside"
+  provider: "Poolside"
   description: "Poolside's 33B total / 3B activated MoE coding model with mixed sliding-window + global attention, native interleaved reasoning, and 128K context — designed for agentic coding."
   date_updated: 2026-04-29
   difficulty: intermediate

--- a/models/tencent/Hunyuan-A13B-Instruct.yaml
+++ b/models/tencent/Hunyuan-A13B-Instruct.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "Hunyuan-A13B-Instruct"
   slug: "hunyuan-a13b-instruct"
-  provider: "Tencent Hunyuan"
+  provider: "Hunyuan (Tencent)"
   description: "Tencent Hunyuan A13B instruct-tuned MoE language model with AITER-accelerated AMD ROCm deployment"
   date_updated: 2026-04-17
   difficulty: beginner

--- a/models/tencent/HunyuanOCR.yaml
+++ b/models/tencent/HunyuanOCR.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "HunyuanOCR"
   slug: "hunyuan-ocr"
-  provider: "Tencent Hunyuan"
+  provider: "Hunyuan (Tencent)"
   description: "Tencent Hunyuan end-to-end OCR expert VLM (~1B) for online OCR serving with an OpenAI-compatible API"
   date_updated: 2026-04-17
   difficulty: beginner

--- a/models/tencent/Hy3-preview.yaml
+++ b/models/tencent/Hy3-preview.yaml
@@ -1,7 +1,7 @@
 meta:
   title: "Hy3-preview"
   slug: "hy3-preview"
-  provider: "Tencent Hunyuan"
+  provider: "Hunyuan (Tencent)"
   description: "Tencent Hunyuan Hy3-preview — scaled-up MoE language model (295B total / 21B active) with a 3.8B MTP layer for speculative decoding, 256K context, and hy_v3 tool/reasoning parsers"
   date_updated: 2026-04-23
   difficulty: intermediate

--- a/models/zai-org/GLM-5.1.yaml
+++ b/models/zai-org/GLM-5.1.yaml
@@ -96,7 +96,7 @@ guide: |
     -p 8000:8000 \
     --ipc=host \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai:glm51 zai-org/GLM-5.1-FP8 \
+    vllm/vllm-openai:latest zai-org/GLM-5.1-FP8 \
       --tensor-parallel-size 8 \
       --tool-call-parser glm47 \
       --reasoning-parser glm45 \
@@ -105,7 +105,7 @@ guide: |
       --served-model-name glm-5.1-fp8
   ```
 
-  Use `vllm/vllm-openai:glm51-cu130` for CUDA 13+.
+  Use `vllm/vllm-openai:latest-cu129` for CUDA 12.x.
 
   ### Install vLLM from Source
 

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -114,7 +114,7 @@ guide: |
     -p 8000:8000 \
     --ipc=host \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai:glm51 zai-org/GLM-5-FP8 \
+    vllm/vllm-openai:latest zai-org/GLM-5-FP8 \
       --tensor-parallel-size 8 \
       --tool-call-parser glm47 \
       --reasoning-parser glm45 \
@@ -122,7 +122,7 @@ guide: |
       --chat-template-content-format=string
   ```
 
-  Use `vllm/vllm-openai:glm51-cu130` for CUDA 13+.
+  Use `vllm/vllm-openai:latest-cu129` for CUDA 12.x.
 
   ### Install vLLM from Source
 

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -76,9 +76,8 @@ function resolveDockerImage(recipe, baseCuda) {
 
 // Synthesize the canonical NVIDIA install commands (pip + docker) for a recipe
 // so JSON consumers see the same one-liners the site shows. Mirrors the logic
-// in InstallBlock; defaults to NVIDIA + the model's base CUDA tag (cu130 for
-// vLLM ≥0.20.0, cu129 for older). Per-recipe overrides at `model.install`
-// follow the same semantics as the UI:
+// in InstallBlock; defaults to NVIDIA + cu130 (today's upstream baseline).
+// Per-recipe overrides at `model.install` follow the same semantics as the UI:
 //   pip: false              → omit the `pip` key
 //   pip: { command?, note?} → use overrides; missing fields fall back to defaults
 //   (same for docker)
@@ -89,10 +88,8 @@ function synthesizeInstall(recipe) {
   const dockerCfg = installCfg.docker;
 
   const v = recipe.model?.min_vllm_version || "";
-  const [maj, min] = v.split(".").map((n) => parseInt(n, 10) || 0);
-  const is020Plus = maj > 0 || min >= 20;
   const nightlyRequired = recipe.model?.nightly_required === true;
-  const baseCuda = nightlyRequired || is020Plus ? "cu130" : "cu129";
+  const baseCuda = "cu130";
 
   const out = {};
 

--- a/src/app/[org]/[repo]/page.js
+++ b/src/app/[org]/[repo]/page.js
@@ -134,6 +134,9 @@ export default async function RecipePage({ params }) {
               {recipe.hf_repo}
             </h1>
             <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{recipe.meta.description}</p>
+            {recipe.meta.performance_headline && (
+              <p className="text-xs text-muted-foreground/70 italic mt-1 leading-snug">{recipe.meta.performance_headline}</p>
+            )}
             <a
               href={`https://huggingface.co/${recipe.hf_id}`}
               target="_blank"

--- a/src/components/recipes/BrowseList.jsx
+++ b/src/components/recipes/BrowseList.jsx
@@ -697,7 +697,7 @@ function Row({ recipe }) {
 
         {/* Notes */}
         <div className="hidden md:block text-xs text-muted-foreground line-clamp-2 leading-snug">
-          {r.meta.performance_headline || r.meta.description}
+          {r.meta.description || r.meta.performance_headline}
         </div>
 
         {/* Mobile: spec strip */}

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -314,14 +314,14 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
 
   const [hwId, setHwId] = useState(searchParams.get("hardware") || defaultHw);
 
-  // After mount: restore user preferences from localStorage. URL params always
-  // win (explicit > stored). Each preference is applied only when compatible
-  // with the current recipe — otherwise the recipe-specific default stands.
+  // After mount: restore the user's hardware preference from localStorage.
+  // URL params always win (explicit > stored). Hardware is the only piece of
+  // state we share across recipes — it tracks the user's physical setup, not
+  // anything model-specific. Nodes / strategy / features are intentionally
+  // per-recipe: switching to multi-node on a 670B model shouldn't push a
+  // 7B recipe into multi-node too.
   //   hardware → NVIDIA only (AMD is opt-in per session, H200 stays canonical
   //              on first load)
-  //   nodes    → only if the recipe actually supports multi-node
-  //   strategy → only if present in the recipe's compatible_strategies
-  //   features → map of {key: on/off} applied when the feature exists
   useEffect(() => {
     const prefs = loadPreferences();
     if (!searchParams.get("hardware") && prefs.hardware) {
@@ -330,25 +330,6 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       if (prefProfile?.brand === "NVIDIA" && isPrecisionCompatible(prefProfile, v) && isHardwareSupported(recipe, prefs.hardware)) {
         setHwId(prefs.hardware);
       }
-    }
-    if (!searchParams.get("nodes") && prefs.nodes && supportsMultiNode) {
-      const n = parseInt(prefs.nodes, 10);
-      if ([1, 2].includes(n)) setNodeCount(n);
-    }
-    if (!searchParams.get("strategy") && prefs.strategy) {
-      if ((recipe.compatible_strategies || []).includes(prefs.strategy)) {
-        setStrategyOverride(prefs.strategy);
-      }
-    }
-    if (!searchParams.get("features") && prefs.features && typeof prefs.features === "object") {
-      const recipeFeatures = Object.keys(recipe.features || {});
-      const base = new Set(defaultFeaturesFor(hwId));
-      for (const [key, on] of Object.entries(prefs.features)) {
-        if (!recipeFeatures.includes(key)) continue;
-        if (on) base.add(key);
-        else base.delete(key);
-      }
-      setFeatures([...base]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -501,11 +482,10 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   }, [recipe]);
   const [installMode, setInstallMode] = useState(initialInstallMode);
 
-  // CUDA variant selector for the NVIDIA docker image tag. The available
-  // suffix depends on the recipe's vLLM version (the tag's base CUDA flips
-  // at 0.20.0 — see `altCudaSuffix` below). State holds the raw suffix
-  // (`"cu129"` | `"cu130"`) or `"default"` for the base tag.
-  // Only surfaced for NVIDIA — AMD / TPU don't ship paired CUDA variants.
+  // CUDA variant selector for the NVIDIA docker image tag. State holds the
+  // raw suffix (`"cu129"` | `"cu130"`) or `"default"` for the upstream base
+  // tag (currently CUDA 13). Only surfaced for NVIDIA — AMD / TPU don't ship
+  // paired CUDA variants.
   const [dockerCudaVariant, setDockerCudaVariant] = useState("default");
 
   // ── Derived ──
@@ -684,27 +664,22 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       features: featuresToUrl(next, id),
     });
     savePreference("hardware", id);
-    if (shouldBumpNodes) savePreference("nodes", "2");
-    if (shouldUnbumpNodes) savePreference("nodes", undefined);
   };
 
   const selectStrategy = (s) => {
     setStrategyOverride(s);
     syncUrl({ strategy: s });
-    // Persist as global pref so subsequent recipes default to the same
-    // strategy when compatible. Empty string clears the preference.
-    savePreference("strategy", s || undefined);
-    // Spec-decoding auto-enable for latency strategies is handled by an effect
-    // below so it also fires on initial mount when TP is the default recommendation.
+    // Strategy is intentionally not persisted across recipes — `pd_cluster`
+    // on one model says nothing about what's right on another. Spec-decoding
+    // auto-enable for latency strategies is handled by an effect below so it
+    // also fires on initial mount when TP is the default recommendation.
   };
 
   const selectNodes = (n) => {
     setNodeCount(n);
     setStrategyOverride("");
     syncUrl({ nodes: n === 1 ? "" : String(n), strategy: "" });
-    savePreference("nodes", String(n));
-    // Switching nodes resets strategy, so clear the stored strategy too.
-    savePreference("strategy", undefined);
+    // Nodes / strategy stay per-recipe — see the mount-time effect.
   };
 
   const setPdNodes = (role, n) => {
@@ -747,21 +722,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       : features.filter((x) => x !== f);
     setFeatures(next);
     syncUrl({ features: featuresToUrl(next, hwId) });
-    // Persist as {key: on/off} map. A value that matches the recipe's default
-    // (on for base features, off for opt-ins) gets removed from the map so
-    // prefs don't grow unbounded across recipes.
-    const prefs = loadPreferences();
-    const fprefs = { ...(prefs.features || {}) };
-    const isOn = next.includes(f);
-    const hwOptIn = (recipe.hardware_opt_in_features?.[hwId] || []).includes(f);
-    const isOptIn = (recipe.opt_in_features || []).includes(f) || hwOptIn;
-    const matchesDefault = isOptIn ? !isOn : isOn;
-    if (matchesDefault) delete fprefs[f];
-    else fprefs[f] = isOn;
-    // If this toggle disabled a mutex partner, clear its stored pref too so
-    // reload doesn't resurrect the conflict.
-    if (on && mutex[f]) delete fprefs[mutex[f]];
-    savePreference("features", Object.keys(fprefs).length ? fprefs : undefined);
+    // Features stay per-recipe — see the mount-time effect.
   };
 
   const toggleAdvanced = (id) => {
@@ -920,35 +881,23 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     );
   }
 
-  // The CUDA baseline for NVIDIA images flipped at vLLM 0.20.0: pre-0.20.0
-  // the base tag is CUDA 12.9 and the alternative suffix is `-cu130`;
-  // 0.20.0+ the base tag is CUDA 13 and the alternative suffix is `-cu129`.
-  // Nightly recipes track the post-flip baseline regardless of the (possibly
-  // non-numeric, e.g. "nightly") `min_vllm_version` string they declare.
-  // Offering the wrong suffix would give the user a tag that doesn't exist.
-  const altCudaSuffix = useMemo(() => {
-    if (recipe.model?.nightly_required === true) return "cu129";
-    const v = recipe.model?.min_vllm_version || "";
-    const [maj, min] = v.split(".").map((n) => parseInt(n, 10) || 0);
-    const is020Plus = maj > 0 || min >= 20;
-    return is020Plus ? "cu129" : "cu130";
-  }, [recipe]);
+  // Upstream `vllm/vllm-openai:latest` (and recent pinned tags) ship CUDA 13
+  // as the base; CUDA 12.9 is the legacy alternate published as a `-cu129`
+  // suffix. The recipe's `min_vllm_version` doesn't change which tag the user
+  // pulls — `:latest` is always today's base regardless — so the alt suffix
+  // is a constant.
+  const altCudaSuffix = "cu129";
 
   const dockerMeta = useMemo(() => {
     const meta = computeDockerMeta(recipe, currentVariant, hwProfile);
     if (meta.brandKey !== "nvidia") return meta;
 
     // Explicit CUDA map (e.g. `{cu129: ..., cu130: ...}`) — pick the matching
-    // tag and skip auto-suffix. "default" resolves to the base CUDA for this
-    // vLLM version (< 0.20.0 → cu129 base; 0.20.0+ → cu130 base), except on
-    // Blackwell where cu130 is preferred when the map offers it. If the
-    // chosen variant is missing, fall through to whichever key is present.
+    // tag and skip auto-suffix. "default" resolves to cu130 (the upstream
+    // baseline today). If the chosen variant is missing, fall through to
+    // whichever key is present.
     if (meta.cudaMap) {
-      const versionBase = altCudaSuffix === "cu130" ? "cu129" : "cu130";
-      const baseCuda =
-        hwProfile?.generation === "blackwell" && "cu130" in meta.cudaMap
-          ? "cu130"
-          : versionBase;
+      const baseCuda = "cu130";
       const wanted = dockerCudaVariant === "default" ? baseCuda : dockerCudaVariant;
       const picked = meta.cudaMap[wanted] || meta.cudaMap[baseCuda] || meta.cudaMap.cu129 || meta.cudaMap.cu130;
       return { ...meta, image: picked || meta.image };
@@ -1186,7 +1135,9 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                 ? { label: "Latency oriented", classes: "bg-green-500/20 text-green-600 dark:text-green-400" }
                 : o === "balanced"
                   ? { label: "Balanced", classes: "bg-blue-500/20 text-blue-600 dark:text-blue-400" }
-                  : { label: "Throughput oriented", classes: "bg-amber-500/20 text-amber-700 dark:text-amber-400" };
+                  : o === "production"
+                    ? { label: "Production deployment", classes: "bg-purple-500/20 text-purple-700 dark:text-purple-400" }
+                    : { label: "Throughput oriented", classes: "bg-amber-500/20 text-amber-700 dark:text-amber-400" };
               return (
                 <span className={`inline-block text-[10px] font-medium mt-1.5 px-1.5 py-0.5 rounded ${classes}`}>
                   {label}
@@ -1492,7 +1443,7 @@ function InstallBlock({ recipe, dockerMeta, installMode, setInstallMode, dockerC
   const pipHidden = pipCfg === false;
   const dockerHidden = dockerCfg === false;
   const [open, setOpen] = useState(false);
-  const { isAmd, isTpu, image: dockerImage, brandKey } = dockerMeta;
+  const { isAmd, isTpu, image: dockerImage, brandKey, cudaMap } = dockerMeta;
   const minV = recipe.model?.min_vllm_version;
 
   // When a recipe's min_vllm_version hasn't shipped yet (cutting-edge models
@@ -1502,10 +1453,9 @@ function InstallBlock({ recipe, dockerMeta, installMode, setInstallMode, dockerC
   // win — this flag only affects the default.
   const nightlyRequired = recipe.model?.nightly_required === true;
   // Resolve the CUDA tag for pip's nightly wheel index from the same toggle
-  // that drives the Docker tag suffix. "default" → the version-base CUDA
-  // (cu130 for ≥0.20.0, cu129 for older); explicit picks pass through.
-  const baseCuda = altCudaSuffix === "cu129" ? "cu130" : "cu129";
-  const pipCudaTag = dockerCudaVariant === "default" ? baseCuda : dockerCudaVariant;
+  // that drives the Docker tag suffix. "default" → cu130 (today's upstream
+  // baseline); explicit picks pass through.
+  const pipCudaTag = dockerCudaVariant === "default" ? "cu130" : dockerCudaVariant;
   const defaultPipCmd = isAmd
     ? `uv venv --python 3.12
 source .venv/bin/activate
@@ -1524,9 +1474,7 @@ uv pip install -U vllm --torch-backend auto`;
   const pipNote =
     pipCfg?.note ||
     (nightlyRequired && !isAmd
-      ? altCudaSuffix === "cu129"
-        ? `vLLM ${minV} isn't released yet — nightly required. For CUDA 12.9, switch the toggle to cu129.`
-        : `vLLM ${minV} isn't released yet — nightly required. For CUDA 13, switch the toggle to cu130.`
+      ? `vLLM ${minV} isn't released yet — nightly required. For CUDA 12.9, switch the toggle to cu129.`
       : undefined);
 
   // Docker install step is just the image pull; the `docker run` that actually
@@ -1540,9 +1488,9 @@ uv pip install -U vllm --torch-backend auto`;
     ? "TPU builds are published by vllm-project/tpu-inference. See the Trillium and Ironwood tpu-recipes for pinned image tags and exact deployment flags."
     : isAmd
       ? undefined
-      : altCudaSuffix === "cu129"
-        ? "vLLM 0.20.0+ default tag ships CUDA 13. Switch to cu129 for the -cu129 variant if your host is on CUDA 12.9."
-        : "Default tag ships CUDA 12.9. Switch to cu130 for the -cu130 variant on CUDA 13 hosts.";
+      : cudaMap
+        ? "This recipe ships paired CUDA-tagged images. Pick `cu129` for CUDA 12.9 hosts or `cu130` for CUDA 13."
+        : "Default tag ships CUDA 13. Switch to cu129 for the -cu129 variant if your host is on CUDA 12.9.";
   const dockerNote = dockerCfg?.note || defaultDockerNote;
   // Show the CUDA selector when we're on NVIDIA and the user isn't supplying
   // a full override command (which already bakes in a specific tag). Visible
@@ -1631,9 +1579,9 @@ uv pip install -U vllm --torch-backend auto`;
                           ? "Legacy CUDA 12.9 build"
                           : v.id === "cu130"
                             ? "CUDA 13 build"
-                            : altCudaSuffix === "cu129"
-                              ? "Base tag — CUDA 13 (vLLM 0.20.0+)"
-                              : "Base tag — CUDA 12.9"
+                            : cudaMap
+                              ? "Recipe-recommended tag for this hardware"
+                              : "Base tag — CUDA 13"
                       }
                       className={`px-2 py-0.5 text-[11px] font-mono rounded transition-colors ${
                         dockerCudaVariant === v.id

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -329,6 +329,13 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       const prefProfile = taxonomy.hardware_profiles?.[prefs.hardware];
       if (prefProfile?.brand === "NVIDIA" && isPrecisionCompatible(prefProfile, v) && isHardwareSupported(recipe, prefs.hardware)) {
         setHwId(prefs.hardware);
+        // Auto-bump nodes when the restored hardware can't fit single-node
+        // — mirrors the bump in `setHw` so a model switch (via sticky hw)
+        // doesn't silently leave nodeCount=1 on a recipe that clearly needs
+        // multi-node. URL `?nodes=N` still wins so shareable links round-trip.
+        if (!searchParams.get("nodes") && supportsMultiNode && !fitsSingleNode(prefProfile, v)) {
+          setNodeCount(2);
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -340,9 +347,18 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     (s) => s.startsWith("multi_node_") || s === "pd_cluster"
   );
   const [nodeCount, setNodeCount] = useState(() => {
-    const n = parseInt(searchParams.get("nodes") || "1", 10);
     if (!supportsMultiNode) return 1;
-    return [1, 2].includes(n) ? n : 1;
+    const urlN = searchParams.get("nodes");
+    if (urlN) {
+      const n = parseInt(urlN, 10);
+      return [1, 2].includes(n) ? n : 1;
+    }
+    // No URL pin: start on multi-node when the initial hardware can't fit
+    // single-node. Same fit check the hardware-change handler runs.
+    const initialHwId = searchParams.get("hardware") || defaultHw;
+    const initialHw = taxonomy.hardware_profiles?.[initialHwId];
+    const v = recipe.variants?.[variant] || recipe.variants?.default || {};
+    return initialHw && !fitsSingleNode(initialHw, v) ? 2 : 1;
   });
   // PD-specific per-role node counts. Only surfaced when the active strategy
   // is `pd_cluster`; ignored otherwise. Defaults come from the recipe's

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package, Info, Zap, Globe } from "lucide-react";
+import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package, Info, Zap, Globe, Wrench, Brain } from "lucide-react";
 import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, fitsSingleNode, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun } from "@/lib/command-synthesis";
 import { TooltipProvider, InfoTip } from "@/components/ui/tooltip";
 import { detectPlaceholdersAll, substitute, substituteEnv, loadEndpoints, saveEndpoint, clearEndpoints } from "@/lib/cluster-endpoints";
@@ -62,7 +62,7 @@ const ADVANCED_OPTIONS = [
     gatedBy: (_recipe, activeStrategy) => /(?:^|_)(?:tep|dep)$/.test(activeStrategy || ""),
   },
 ];
-import { loadPreferences, savePreference } from "@/lib/preferences";
+import { loadPreferences, savePreference, loadRecipeState, saveRecipeState } from "@/lib/preferences";
 
 function CopyButton({ text, className = "" }) {
   const [copied, setCopied] = useState(false);
@@ -314,28 +314,45 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
 
   const [hwId, setHwId] = useState(searchParams.get("hardware") || defaultHw);
 
-  // After mount: restore the user's hardware preference from localStorage.
-  // URL params always win (explicit > stored). Hardware is the only piece of
-  // state we share across recipes — it tracks the user's physical setup, not
-  // anything model-specific. Nodes / strategy / features are intentionally
-  // per-recipe: switching to multi-node on a 670B model shouldn't push a
-  // 7B recipe into multi-node too.
-  //   hardware → NVIDIA only (AMD is opt-in per session, H200 stays canonical
-  //              on first load)
+  // After mount: restore preferences from localStorage in two scopes.
+  // URL params always win (explicit > stored).
+  //   1. Global (hardware): tracks the user's physical setup, shared across
+  //      every recipe. NVIDIA-only — AMD is opt-in per session and H200
+  //      stays canonical on first load.
+  //   2. Per-recipe (strategy / nodes / features): keyed by hf_id, so each
+  //      recipe remembers its own choices independently. Picking TP on
+  //      V4-Flash doesn't make V4-Pro default to TP — Pro keeps whatever
+  //      was last picked there (or its YAML default if untouched).
   useEffect(() => {
     const prefs = loadPreferences();
+    let restoredFitsHw = null;
     if (!searchParams.get("hardware") && prefs.hardware) {
       const v = recipe.variants?.[variant] || recipe.variants?.default || {};
       const prefProfile = taxonomy.hardware_profiles?.[prefs.hardware];
       if (prefProfile?.brand === "NVIDIA" && isPrecisionCompatible(prefProfile, v) && isHardwareSupported(recipe, prefs.hardware)) {
         setHwId(prefs.hardware);
-        // Auto-bump nodes when the restored hardware can't fit single-node
-        // — mirrors the bump in `setHw` so a model switch (via sticky hw)
-        // doesn't silently leave nodeCount=1 on a recipe that clearly needs
-        // multi-node. URL `?nodes=N` still wins so shareable links round-trip.
-        if (!searchParams.get("nodes") && supportsMultiNode && !fitsSingleNode(prefProfile, v)) {
-          setNodeCount(2);
-        }
+        restoredFitsHw = prefProfile;
+      }
+    }
+
+    const rs = loadRecipeState(recipe.hf_id);
+    if (!searchParams.get("strategy") && rs.strategy &&
+        (recipe.compatible_strategies || []).includes(rs.strategy)) {
+      setStrategyOverride(rs.strategy);
+    }
+    if (!searchParams.get("features") && Array.isArray(rs.features)) {
+      const recipeFeatures = Object.keys(recipe.features || {});
+      setFeatures(rs.features.filter((f) => recipeFeatures.includes(f)));
+    }
+    // Nodes: prefer the saved value; otherwise auto-bump if the resolved
+    // hardware can't fit single-node (mirrors `setHw`'s bump).
+    if (!searchParams.get("nodes") && supportsMultiNode) {
+      const saved = parseInt(rs.nodes, 10);
+      if ([1, 2].includes(saved)) {
+        setNodeCount(saved);
+      } else if (restoredFitsHw) {
+        const v = recipe.variants?.[variant] || recipe.variants?.default || {};
+        if (!fitsSingleNode(restoredFitsHw, v)) setNodeCount(2);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -680,22 +697,30 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       features: featuresToUrl(next, id),
     });
     savePreference("hardware", id);
+    // Mirror the new state to per-recipe storage so a hardware switch
+    // doesn't leave stale strategy/nodes/features cached for this recipe.
+    saveRecipeState(recipe.hf_id, {
+      strategy: undefined,
+      nodes: shouldBumpNodes ? 2 : shouldUnbumpNodes ? 1 : nodeCount,
+      features: next,
+    });
   };
 
   const selectStrategy = (s) => {
     setStrategyOverride(s);
     syncUrl({ strategy: s });
-    // Strategy is intentionally not persisted across recipes — `pd_cluster`
-    // on one model says nothing about what's right on another. Spec-decoding
-    // auto-enable for latency strategies is handled by an effect below so it
-    // also fires on initial mount when TP is the default recommendation.
+    // Persisted per-recipe (keyed by hf_id), so picking TP here doesn't
+    // affect any other recipe's default. Spec-decoding auto-enable for
+    // latency strategies is handled by an effect below so it also fires
+    // on initial mount when TP is the default recommendation.
+    saveRecipeState(recipe.hf_id, { strategy: s || undefined });
   };
 
   const selectNodes = (n) => {
     setNodeCount(n);
     setStrategyOverride("");
     syncUrl({ nodes: n === 1 ? "" : String(n), strategy: "" });
-    // Nodes / strategy stay per-recipe — see the mount-time effect.
+    saveRecipeState(recipe.hf_id, { nodes: n, strategy: undefined });
   };
 
   const setPdNodes = (role, n) => {
@@ -738,7 +763,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       : features.filter((x) => x !== f);
     setFeatures(next);
     syncUrl({ features: featuresToUrl(next, hwId) });
-    // Features stay per-recipe — see the mount-time effect.
+    saveRecipeState(recipe.hf_id, { features: next });
   };
 
   const toggleAdvanced = (id) => {
@@ -1245,6 +1270,12 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                     {key === "spec_decoding" && (
                       <Zap size={11} className="inline-block mr-1 -mt-0.5 text-vllm-yellow" fill="currentColor" />
                     )}
+                    {key === "tool_calling" && (
+                      <Wrench size={11} className="inline-block mr-1 -mt-0.5 text-muted-foreground" />
+                    )}
+                    {key === "reasoning" && (
+                      <Brain size={11} className="inline-block mr-1 -mt-0.5 text-muted-foreground" />
+                    )}
                     {key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
                     {key === "spec_decoding" && (
                       <span className="ml-1.5 text-[11px] text-vllm-yellow font-normal">
@@ -1372,7 +1403,7 @@ function PillGroup({ children }) {
 
 function HwStatusDot({ status }) {
   // Only `verified` is a meaningful signal. Everything else (including
-  // undeclared GPUs) renders no dot — the pill looks clean.
+  // undeclared GPUs) renders nothing — the pill looks clean.
   if (status !== "verified") return null;
   return <span className="inline-block w-1.5 h-1.5 rounded-full mr-1.5 shrink-0 bg-green-500" aria-hidden />;
 }

--- a/src/components/recipes/RecipeCardGrid.jsx
+++ b/src/components/recipes/RecipeCardGrid.jsx
@@ -145,7 +145,7 @@ function RecipeCard({ recipe }) {
 
       {/* Footer: hint or description */}
       <div className="mt-auto text-[11px] text-muted-foreground line-clamp-2 leading-snug">
-        {recipe.meta?.performance_headline || recipe.meta?.description || ""}
+        {recipe.meta?.description || recipe.meta?.performance_headline || ""}
       </div>
       {isOmni && (
         <div className="text-[10px] text-vllm-yellow/80 font-medium">via vLLM-Omni</div>

--- a/src/components/recipes/SearchBox.jsx
+++ b/src/components/recipes/SearchBox.jsx
@@ -122,6 +122,18 @@ export function SearchBox({ recipes }) {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, []);
 
+  // Selecting a result needs to close the dropdown synchronously: otherwise
+  // `setQuery("")` flips `list` from the matched results to the "Latest 5"
+  // default while the route is still loading and the onBlur timeout (200ms)
+  // hasn't run yet, causing a visible flash from results → Latest → close.
+  const selectResult = (href) => {
+    setFocused(false);
+    setQuery("");
+    setSelectedIndex(0);
+    inputRef.current?.blur();
+    router.push(href);
+  };
+
   const handleKeyDown = (e) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -130,11 +142,12 @@ export function SearchBox({ recipes }) {
       e.preventDefault();
       setSelectedIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter" && list[selectedIndex]) {
-      router.push(list[selectedIndex].href);
-      setQuery("");
-      inputRef.current?.blur();
+      e.preventDefault();
+      selectResult(list[selectedIndex].href);
     } else if (e.key === "Escape") {
+      setFocused(false);
       setQuery("");
+      setSelectedIndex(0);
       inputRef.current?.blur();
     }
   };
@@ -167,7 +180,7 @@ export function SearchBox({ recipes }) {
           )}
           {list.map((r, i) => {
             const active = i === selectedIndex;
-            const onClick = () => { router.push(r.href); setQuery(""); inputRef.current?.blur(); };
+            const onClick = () => selectResult(r.href);
             if (r.type === "provider") {
               return <ProviderResult key={`p-${r.org}`} entry={r} active={active} onClick={onClick} />;
             }

--- a/src/lib/preferences.js
+++ b/src/lib/preferences.js
@@ -1,9 +1,17 @@
 /**
  * User preferences persisted across sessions via localStorage.
- * Used by CommandBuilder to remember the user's preferred hardware.
+ *
+ * Two scopes:
+ *   1. Global (`vllm-recipes-prefs`): user's physical setup that's the same
+ *      across every recipe — currently just `hardware`.
+ *   2. Per-recipe (`vllm-recipes-recipe-state`, keyed by `hf_id`): selection
+ *      state that's specific to a model — strategy, nodes, features. So
+ *      picking TP on V4-Flash sticks for V4-Flash, while V4-Pro keeps its
+ *      own choice independently.
  */
 
 const KEY = "vllm-recipes-prefs";
+const RECIPE_STATE_KEY = "vllm-recipes-recipe-state";
 
 export function loadPreferences() {
   if (typeof window === "undefined") return {};
@@ -25,5 +33,40 @@ export function savePreference(key, value) {
       prefs[key] = value;
     }
     localStorage.setItem(KEY, JSON.stringify(prefs));
+  } catch {}
+}
+
+export function loadRecipeState(hfId) {
+  if (typeof window === "undefined" || !hfId) return {};
+  try {
+    const raw = localStorage.getItem(RECIPE_STATE_KEY);
+    const all = raw ? JSON.parse(raw) : {};
+    return all[hfId] || {};
+  } catch {
+    return {};
+  }
+}
+
+// Merge `partial` into the recipe's state. Keys with empty/undefined values
+// are removed; if the recipe ends up with no state, drop its entry entirely
+// so storage stays tight as users browse.
+export function saveRecipeState(hfId, partial) {
+  if (typeof window === "undefined" || !hfId) return;
+  try {
+    const raw = localStorage.getItem(RECIPE_STATE_KEY);
+    const all = raw ? JSON.parse(raw) : {};
+    const merged = { ...(all[hfId] || {}), ...partial };
+    for (const k of Object.keys(merged)) {
+      const v = merged[k];
+      const empty = v === undefined || v === null || v === "" ||
+        (Array.isArray(v) && v.length === 0);
+      if (empty) delete merged[k];
+    }
+    if (Object.keys(merged).length === 0) {
+      delete all[hfId];
+    } else {
+      all[hfId] = merged;
+    }
+    localStorage.setItem(RECIPE_STATE_KEY, JSON.stringify(all));
   } catch {}
 }

--- a/src/lib/providers.js
+++ b/src/lib/providers.js
@@ -29,13 +29,13 @@ export const PROVIDERS = {
   "jinaai":          { display_name: "Jina AI",                 logo: "/providers/jinaai.png" },
   "PaddlePaddle":    { display_name: "PaddlePaddle",            logo: "/providers/PaddlePaddle.png" },
   "ByteDance-Seed":  { display_name: "Seed (ByteDance)",        logo: "/providers/ByteDance-Seed.png" },
-  "tencent":         { display_name: "Tencent Hunyuan",         logo: "/providers/tencent.png" },
-  "XiaomiMiMo":      { display_name: "Xiaomi MiMo",             logo: "/providers/XiaomiMiMo.jpeg" },
-  "Wan-AI":          { display_name: "Wan AI",                  logo: "/providers/Wan-AI.png" },
-  "meituan-longcat": { display_name: "Meituan LongCat",         logo: "/providers/meituan-longcat.png" },
-  "stabilityai":     { display_name: "Stability AI",            logo: "/providers/stabilityai.png" },
-  "stepfun-ai":      { display_name: "StepFun",                 logo: "/providers/stepfun-ai.png" },
-  "poolside":        { display_name: "Poolside",                logo: "/providers/poolside.png" },
+  "tencent":         { display_name: "Hunyuan (Tencent)",       logo: "/providers/tencent.png" },
+  "XiaomiMiMo":      { display_name: "MiMo (Xiaomi)",            logo: "/providers/XiaomiMiMo.jpeg" },
+  "Wan-AI":          { display_name: "Wan (Alibaba)",            logo: "/providers/Wan-AI.png" },
+  "meituan-longcat": { display_name: "LongCat (Meituan)",        logo: "/providers/meituan-longcat.png" },
+  "stabilityai":     { display_name: "Stability AI",             logo: "/providers/stabilityai.png" },
+  "stepfun-ai":      { display_name: "StepFun",                  logo: "/providers/stepfun-ai.png" },
+  "poolside":        { display_name: "Poolside",                 logo: "/providers/poolside.png" },
 };
 
 export function getProviderLogo(hfOrg) {

--- a/strategies/pd_cluster.yaml
+++ b/strategies/pd_cluster.yaml
@@ -1,6 +1,7 @@
 name: pd_cluster
 deploy_type: pd_cluster
 display_name: "Prefill/Decode Disaggregation"
+orientation: production
 description: >
   Disaggregated prefill/decode cluster. Splits inference into separate
   prefill and decode workers communicating via NIXL KV cache transfer.


### PR DESCRIPTION
## Summary

A grab-bag of recipe-site polish, plus aligning the docker-tag logic with the post-flip reality that `vllm/vllm-openai:latest` ships CUDA 13 today.

**Command builder / install block**
- Drop the vLLM 0.20.0 version flip in CUDA tag selection — `:latest` is `cu130` regardless of what `min_vllm_version` a recipe declares, so `altCudaSuffix` is now constant `cu129`. Mirror the change in `scripts/build-recipes-api.mjs` so the JSON API matches the UI.
- New install-block note for recipes with an explicit `{cu129, cu130}` map (e.g. `MiMo-V2.5-Pro`): describes the paired tags directly instead of the suffix-append wording.
- Per-recipe Strategy / Nodes / Features — selecting `multi_node_*` or `pd_cluster` on a 670B model no longer leaks into a 7B model. Only `hardware` persists across recipes (it's about the user's setup, not the model).
- Search box: selecting a result closes the dropdown synchronously, so the list no longer flashes from search results → Latest while the route loads.
- Card / list summary now prefers `meta.description` (the model facts) and `performance_headline` becomes a quiet italic kicker on the detail page.

**Strategy**
- `pd_cluster` gets `orientation: production` and renders a purple "Production deployment" badge below the strategy row.

**Provider naming**
- Standardized to `Family (Company)` form for sub-brands: `Hunyuan (Tencent)`, `MiMo (Xiaomi)`, `LongCat (Meituan)`, `Wan (Alibaba)`. YAML `provider:` strings aligned with the registry; `Poolside` casing fixed.

**Recipes**
- DeepSeek-V4-Pro / V4-Flash: replace generic `performance_headline` with model-specific copy.
- Replace pinned `cu130` / `cu129` docker tags with `:latest` in guide blocks (`translategemma-27b-it`, `Kimi-K2.5`, `GLM-5`, `GLM-5.1`, `DeepSeek-V4-Flash`).

## Test plan

- [ ] `node scripts/build-recipes-api.mjs` reports `90 models, 8 strategies` (no parse errors)
- [ ] Homepage cards / browse list show `meta.description` (not the headline)
- [ ] Detail page renders `performance_headline` as the small italic line below description (V4-Pro/Flash visible difference)
- [ ] Provider grid + cards + sidebar all show identical names per provider
- [ ] CUDA selector on `MiMo-V2.5-Pro` shows the paired-tag note; on a recipe with `:latest` (e.g. `Qwen3.5-4B`, `min_vllm_version 0.17.0`) it shows the `default` + `cu129` toggle (no obsolete `cu130` alt)
- [ ] Pick `pd_cluster` strategy on a recipe that supports it — purple `Production deployment` badge appears
- [ ] Toggle `multi-node` on a 670B recipe, navigate to a small recipe — small recipe stays single-node
- [ ] Type a search query, press Enter / click result — dropdown closes immediately, no flash to Latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)