### PR TITLE
Update GPT-OSS Eagle3 speculative decoding to v3

### DIFF
--- a/OpenAI/GPT-OSS.md
+++ b/OpenAI/GPT-OSS.md
@@ -251,7 +251,7 @@ no-enable-prefix-caching: true
 max-cudagraph-capture-size: 2048
 max-num-batched-tokens: 8192
 stream-interval: 20
-speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v2","num_speculative_tokens":3,"method":"eagle3","draft_tensor_parallel_size":1}'
+speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v3","num_speculative_tokens":7,"method":"eagle3","draft_tensor_parallel_size":1}'
 ```
 
 `GPT-OSS_EAGLE3_Hopper.yaml`
@@ -260,7 +260,7 @@ no-enable-prefix-caching: true
 max-cudagraph-capture-size: 2048
 max-num-batched-tokens: 8192
 stream-interval: 20
-speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v2","num_speculative_tokens":3,"method":"eagle3","draft_tensor_parallel_size":1}'
+speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v3","num_speculative_tokens":7,"method":"eagle3","draft_tensor_parallel_size":1}'
 ```
 
 ### Launch the vLLM Server

--- a/OpenAI/GPT-OSS_EAGLE3_Blackwell.yaml
+++ b/OpenAI/GPT-OSS_EAGLE3_Blackwell.yaml
@@ -3,4 +3,4 @@ no-enable-prefix-caching: true
 max-cudagraph-capture-size: 2048
 max-num-batched-tokens: 8192
 stream-interval: 20
-speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v2","num_speculative_tokens":3,"method":"eagle3","draft_tensor_parallel_size":1}'
+speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v3","num_speculative_tokens":7,"method":"eagle3","draft_tensor_parallel_size":1}'

--- a/OpenAI/GPT-OSS_EAGLE3_Hopper.yaml
+++ b/OpenAI/GPT-OSS_EAGLE3_Hopper.yaml
@@ -2,4 +2,4 @@ no-enable-prefix-caching: true
 max-cudagraph-capture-size: 2048
 max-num-batched-tokens: 8192
 stream-interval: 20
-speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v2","num_speculative_tokens":3,"method":"eagle3","draft_tensor_parallel_size":1}'
+speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v3","num_speculative_tokens":7,"method":"eagle3","draft_tensor_parallel_size":1}'

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "gpt-oss"
   provider: "OpenAI"
   description: "OpenAI's gpt-oss family (20B / 120B) with MXFP4 MoE, attention-sinks, built-in tools via Responses API"
-  date_updated: 2026-04-17
+  date_updated: 2026-05-10
   difficulty: intermediate
   tasks:
     - text
@@ -37,7 +37,7 @@ features:
     description: "EAGLE3 speculative decoding for accelerated inference"
     args:
       - "--speculative-config"
-      - '{"model":"nvidia/gpt-oss-120b-Eagle3-v2","num_speculative_tokens":3,"method":"eagle3","draft_tensor_parallel_size":1}'
+      - '{"model":"nvidia/gpt-oss-120b-Eagle3-v3","num_speculative_tokens":7,"method":"eagle3","draft_tensor_parallel_size":1}'
 
 opt_in_features:
   - spec_decoding
@@ -248,4 +248,4 @@ guide: |
   - [gpt-oss-120b](https://huggingface.co/openai/gpt-oss-120b)
   - [gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b)
   - [amd/gpt-oss-120b-w-mxfp4-a-fp8](https://huggingface.co/amd/gpt-oss-120b-w-mxfp4-a-fp8)
-  - [Eagle3 draft model](https://huggingface.co/nvidia/gpt-oss-120b-Eagle3-v2)
+  - [Eagle3 draft model](https://huggingface.co/nvidia/gpt-oss-120b-Eagle3-v3)


### PR DESCRIPTION
## Summary

- Update GPT-OSS EAGLE3 speculative decoding from `nvidia/gpt-oss-120b-Eagle3-v2` to `nvidia/gpt-oss-120b-Eagle3-v3`
- Increase `num_speculative_tokens` from `3` to `7`
- Update the GPT-OSS recipe reference link and `date_updated`

## Reference

- https://huggingface.co/nvidia/gpt-oss-120b-Eagle3-v3

## Accuracy test

Tested on GB300 using:

```bash
CUDA_VISIBLE_DEVICES=0 vllm serve openai/gpt-oss-120b \
  --kv-cache-dtype fp8 \
  --tool-call-parser openai \
  --enable-auto-tool-choice \
  --speculative-config '{"method": "eagle3", "model": "nvidia/gpt-oss-120b-Eagle3-v3", "num_speculative_tokens": 7}' \
  --trust-remote-code
```

Ran one GPQA low-reasoning accuracy test:

```bash
python -m gpt_oss.evals --model openai/gpt-oss-120b --eval gpqa --n-threads 2048 --reasoning-effort low --base-url http://127.0.0.1:8000/v1
```

Result:

```text
[{'eval_name': 'gpqa', 'model_name': 'openai__gpt-oss-120b-low_temp1.0_20260510_114028', 'metric': 0.6527777777777778}]
```
