### PR TITLE
Add AMD MI300X/MI325X/MI355X support for Stable Audio Open recipe

### DIFF
--- a/StabilityAI/Stable-Audio-Open.md
+++ b/StabilityAI/Stable-Audio-Open.md
@@ -23,6 +23,23 @@ uv pip install soundfile  # Recommended
 uv pip install scipy
 ```
 
+### AMD ROCm: MI300X, MI325X, MI355X
+
+> **Note:** The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35.
+> If your environment does not meet these requirements, please use the Docker-based setup.
+
+```bash
+uv venv --python 3.12
+source .venv/bin/activate
+VLLM_OMNI_TARGET_DEVICE=rocm uv pip install \
+  git+https://github.com/vllm-project/vllm-omni.git \
+  vllm==0.14.1+rocm700 \
+  --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700
+
+# Audio saving
+uv pip install soundfile
+```
+
 The CLI examples below are from the vLLM-Omni repo. If you want to run them directly, clone that repo and run the scripts from its `examples/offline_inference` directory.
 
 ## Text-to-Audio Generation

--- a/models/stabilityai/stable-audio-open-1.0.yaml
+++ b/models/stabilityai/stable-audio-open-1.0.yaml
@@ -9,6 +9,10 @@ meta:
     - omni
   related_recipes:
     - stabilityai/stable-diffusion-3.5-medium
+  hardware:
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "stabilityai/stable-audio-open-1.0"
@@ -27,6 +31,9 @@ dependencies:
     command: "uv pip install git+https://github.com/vllm-project/vllm-omni.git"
   - note: "soundfile (recommended) or scipy for WAV output"
     command: "uv pip install soundfile"
+  - note: "AMD ROCm: install vLLM for ROCm and vLLM-Omni"
+    command: "VLLM_OMNI_TARGET_DEVICE=rocm uv pip install git+https://github.com/vllm-project/vllm-omni.git vllm==0.14.1+rocm700 --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700"
+    optional: true
 
 features: {}
 
@@ -40,7 +47,10 @@ variants:
 
 compatible_strategies: []
 
-hardware_overrides: {}
+hardware_overrides:
+  amd:
+    extra_env:
+      VLLM_OMNI_TARGET_DEVICE: "rocm"
 strategy_overrides: {}
 
 guide: |
@@ -67,6 +77,23 @@ guide: |
   source .venv/bin/activate
   uv pip install vllm==0.14.1
   uv pip install git+https://github.com/vllm-project/vllm-omni.git
+
+  # Audio saving
+  uv pip install soundfile
+  ```
+
+  ### AMD ROCm (MI300X, MI325X, MI355X)
+
+  > **Note:** The vLLM wheel for ROCm requires Python 3.12, ROCm 7.0, and glibc >= 2.35.
+  > If your environment does not meet these requirements, please use the Docker-based setup.
+
+  ```bash
+  uv venv --python 3.12
+  source .venv/bin/activate
+  VLLM_OMNI_TARGET_DEVICE=rocm uv pip install \
+    git+https://github.com/vllm-project/vllm-omni.git \
+    vllm==0.14.1+rocm700 \
+    --extra-index-url https://wheels.vllm.ai/rocm/0.14.1/rocm700
 
   # Audio saving
   uv pip install soundfile


### PR DESCRIPTION
## Summary

Add comprehensive AMD MI300X/MI325X/MI355X GPU support for Stable Audio Open text-to-audio generation model, served via vLLM-Omni.

## Changes

- **YAML recipe** (`models/stabilityai/stable-audio-open-1.0.yaml`):
  - Add `meta.hardware` entries for `mi300x`, `mi325x`, `mi355x` (all `verified`)
  - Add AMD ROCm dependency with `optional: true` (`vllm==0.14.1+rocm700` + vLLM-Omni from source)
  - Add `hardware_overrides` for AMD with `VLLM_OMNI_TARGET_DEVICE` env var
  - Add `### AMD ROCm` subsection under Installation guide

- **Legacy markdown** (`StabilityAI/Stable-Audio-Open.md`):
  - Add `### AMD ROCm: MI300X, MI325X, MI355X` install subsection

## Notes

- vLLM-Omni model (task: `omni`) — uses offline Python scripts, no `vllm serve` commands
- AMD ROCm install uses vllm stable ROCm wheel (0.14.1+rocm700)
- Uses `VLLM_OMNI_TARGET_DEVICE=rocm` env var at install time
- Compatible strategies remain `[]` (omni models)
