### PR TITLE
Add PaddlePaddle/PaddleOCR-VL-1.5 recipe

### DIFF
--- a/.claude/skills/add-recipe/SKILL.md
+++ b/.claude/skills/add-recipe/SKILL.md
@@ -22,10 +22,20 @@ Recipes are YAML files at `models/<hf_org>/<hf_repo>.yaml`. The path mirrors Hug
    - **Companion / draft repos** — EAGLE / MTP / Eagle3 heads, NVFP4 quants, instruct vs base. Wire as `spec_decoding` feature (draft pointer in `--speculative-config`) or a sibling variant with `model_id:` override. Copy the recommended `--speculative-config` JSON verbatim from the README.
    - **Recommended serve flags** — `--tensor-parallel-size`, `--gpu_memory_utilization`, `--max_num_batched_tokens`, `--max_num_seqs` go into the guide's launch command and into variant `extra_args` when they're variant-specific.
    - **Hardware guidance / sampling defaults** — "recommended on 8xH200" lines inform variant `description` + `vram_minimum_gb`; recommended `temperature` / `top_p` / `reasoning_effort` go in the guide's Client Usage block.
-4. **Create the YAML.** Write `models/<hf_org>/<hf_repo>.yaml` following the schema below. Only include sections the model needs; leave `features: {}`, `opt_in_features: []`, `hardware_overrides: {}`, `strategy_overrides: {}` empty if not applicable.
-5. **Register the provider (if new).** If `<hf_org>` isn't already in `src/lib/providers.js`, add an entry with `display_name` and the logo path `/providers/<hf_org>.png` (or `.jpeg`). Logos get downloaded by `scripts/fetch-provider-logos.mjs` on the next build.
-6. **Validate.** Run `node scripts/build-recipes-api.mjs`. It must print `✓ JSON API: N models, 7 strategies` with no errors.
-7. **Commit.** Follow the user's earlier feedback (no kill-and-rebuild of dev server; syntax-check only).
+4. **Cross-check upstream vLLM support.** The README can be aspirational or stale — verify what's actually shipped, and capture known caveats. Run the searches in parallel:
+   - `gh search issues --repo vllm-project/vllm "<model-name>" --state all --limit 20` (or `WebSearch` for `"<model-name>" site:github.com/vllm-project/vllm`)
+   - `gh search prs --repo vllm-project/vllm "<model-name>" --state merged --limit 10` — the merge commit tells you the minimum vLLM release containing support
+   - For newer architectures, also search the model author's repo (e.g. `PaddlePaddle/PaddleOCR`, `deepseek-ai/DeepSeek-VL2`) for "vllm" discussions — authors often post the canonical launch command and known issues there
+
+   What to extract:
+   - **`min_vllm_version`** — if the support PR landed in v0.12.0, set `min_vllm_version: "0.12.0"`. If it's only on `main` / nightly, set `min_vllm_version: "nightly"` + `nightly_required: true`. If support is still an open issue (no PR merged), flag this to the user before authoring — the recipe may not yet be runnable. For derivative releases (e.g. PaddleOCR-VL-1.5 vs 1.0) with identical `architectures` / `model_type` / `auto_map`, the existing handler usually loads them via `--trust-remote-code` even before a dedicated PR — note this assumption in your reply.
+   - **Troubleshooting** — recurring errors and fixes from issue comments (e.g. "needs `--enforce-eager` on 0.11.x", "transformers>=5 required", "`--mm-processor-cache-gb 0` to avoid OOM"). Surface these in the guide's Troubleshooting section, or as inline tips next to the launch command if they're load-bearing.
+   - **Links to put in `guide`'s References** — the model card, the vLLM support issue/PR, and any author-side deployment doc. These give users a path forward if their setup breaks.
+
+5. **Create the YAML.** Write `models/<hf_org>/<hf_repo>.yaml` following the schema below. Only include sections the model needs; leave `features: {}`, `opt_in_features: []`, `hardware_overrides: {}`, `strategy_overrides: {}` empty if not applicable.
+6. **Register the provider (if new).** If `<hf_org>` isn't already in `src/lib/providers.js`, add an entry with `display_name` and the logo path `/providers/<hf_org>.png` (or `.jpeg`). Logos get downloaded by `scripts/fetch-provider-logos.mjs` on the next build.
+7. **Validate.** Run `node scripts/build-recipes-api.mjs`. It must print `✓ JSON API: N models, 7 strategies` with no errors.
+8. **Commit.** Follow the user's earlier feedback (no kill-and-rebuild of dev server; syntax-check only).
 
 ## YAML schema (top-level fields, in order)
 

--- a/models/PaddlePaddle/PaddleOCR-VL-1.5.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL-1.5.yaml
@@ -1,0 +1,180 @@
+meta:
+  title: "PaddleOCR-VL-1.5"
+  slug: "paddleocr-vl-1.5"
+  provider: "PaddlePaddle"
+  description: "PaddleOCR-VL-1.5 (0.9B) — next-gen compact VLM for document parsing; adds text spotting, seal recognition, and Tibetan/Bengali"
+  date_updated: 2026-05-11
+  difficulty: beginner
+  tasks:
+    - multimodal
+  related_recipes:
+    - "PaddlePaddle/PaddleOCR-VL"
+
+model:
+  model_id: "PaddlePaddle/PaddleOCR-VL-1.5"
+  min_vllm_version: "0.11.1"
+  architecture: dense
+  parameter_count: "0.9B"
+  active_parameters: "0.9B"
+  context_length: 131072
+  base_args:
+    - "--trust-remote-code"
+    - "--max-num-batched-tokens"
+    - "16384"
+    - "--no-enable-prefix-caching"
+    - "--mm-processor-cache-gb"
+    - "0"
+  base_env: {}
+
+dependencies:
+  - note: "PaddlePaddle runtime (install in a separate venv from vllm to avoid conflicts)"
+    command: "uv pip install paddlepaddle-gpu==3.2.1 --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/"
+  - note: "PaddleOCR document-parsing helpers (1.5 ships under the same paddleocr[doc-parser] extra)"
+    command: 'uv pip install -U "paddleocr[doc-parser]"'
+  - note: "Safetensors loader used by the doc-parser path"
+    command: "uv pip install safetensors"
+
+features:
+  text_only:
+    description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
+    args:
+      - "--language-model-only"
+  encoder_parallel:
+    description: "Run the vision encoder in data-parallel mode — avoids TP comm overhead on the small encoder. Mutually exclusive with text_only."
+    args:
+      - "--mm-encoder-tp-mode"
+      - "data"
+
+opt_in_features:
+  - text_only
+  - encoder_parallel
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 2
+    description: "BF16 weights — small footprint, runs on most GPUs"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+
+hardware_overrides:
+  amd:
+    extra_args: []
+    extra_env:
+      SAFETENSORS_FAST_GPU: "1"
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  [PaddleOCR-VL-1.5](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5) is the next
+  generation of PaddleOCR-VL — same 0.9B architecture (NaViT-style dynamic-resolution
+  vision encoder + ERNIE-4.5-0.3B LM), with substantial accuracy gains and new tasks:
+
+  - **94.5% on OmniDocBench v1.5** (SOTA)
+  - **Text spotting** — line-level localization + recognition in one pass
+  - **Seal recognition** — new task with SOTA results
+  - **Irregular-shape localization** — polygonal detection under skew/warping
+  - **Multilingual** — adds Tibetan and Bengali
+  - Cross-page table merging and paragraph-heading recognition
+
+  Architecture is identical to PaddleOCR-VL, so the vLLM launch command and feature
+  flags are the same.
+
+  ## Prerequisites
+
+  - Hardware: 1x GPU (small VRAM footprint)
+  - vLLM >= 0.11.1 (nightly if not released yet)
+
+  ### Install vLLM
+
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --pre \
+    --extra-index-url https://wheels.vllm.ai/nightly \
+    --extra-index-url https://download.pytorch.org/whl/cu129 \
+    --index-strategy unsafe-best-match
+  ```
+
+  ## Launch command
+
+  ```bash
+  vllm serve PaddlePaddle/PaddleOCR-VL-1.5 \
+    --trust-remote-code \
+    --max-num-batched-tokens 16384 \
+    --no-enable-prefix-caching \
+    --mm-processor-cache-gb 0
+  ```
+
+  Tip: OCR workloads don't benefit much from prefix caching or image reuse, so disable
+  those to avoid hashing/caching overhead.
+
+  ## Client Usage
+
+  Task-specific prompts (note the two new tasks `spotting` and `seal`):
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1", timeout=3600)
+
+  TASKS = {
+      "ocr": "OCR:",
+      "table": "Table Recognition:",
+      "formula": "Formula Recognition:",
+      "chart": "Chart Recognition:",
+      "spotting": "Spotting:",
+      "seal": "Seal Recognition:",
+  }
+
+  response = client.chat.completions.create(
+      model="PaddlePaddle/PaddleOCR-VL-1.5",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://.../receipt.png"}},
+              {"type": "text", "text": TASKS["spotting"]},
+          ],
+      }],
+      temperature=0.0,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Offline Inference with PP-DocLayoutV2
+
+  Use separate venvs for `vllm` and `paddlepaddle` to avoid conflicts. If you see
+  "The model PaddleOCR-VL-1.5-0.9B does not exist.", add
+  `--served-model-name PaddleOCR-VL-1.5-0.9B`.
+
+  ```bash
+  uv pip install paddlepaddle-gpu==3.2.1 --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/
+  uv pip install -U "paddleocr[doc-parser]"
+  uv pip install safetensors
+  ```
+
+  ```python
+  from paddleocr import PaddleOCRVL
+
+  pipeline = PaddleOCRVL(
+      vl_rec_model_name="PaddleOCR-VL-1.5-0.9B",
+      vl_rec_backend="vllm-server",
+      vl_rec_server_url="http://localhost:8000/v1",
+      layout_detection_model_name="PP-DocLayoutV2",
+      layout_detection_model_dir="/path/to/your/PP-DocLayoutV2/",
+  )
+
+  output = pipeline.predict("https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/paddleocr_vl_demo.png")
+  for i, res in enumerate(output):
+      res.save_to_json(save_path=f"output_{i}.json")
+      res.save_to_markdown(save_path=f"output_{i}.md")
+  ```
+
+  ## References
+
+  - [PaddleOCR-VL-1.5 on Hugging Face](https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5)
+  - [PaddleOCR GitHub](https://github.com/PaddlePaddle/PaddleOCR)
+  - [vLLM support tracking issue](https://github.com/vllm-project/vllm/issues/33554)


### PR DESCRIPTION
## Summary

- Add `models/PaddlePaddle/PaddleOCR-VL-1.5.yaml` — the next-gen 0.9B document-parsing VLM from PaddlePaddle.
- Architecture is identical to the existing PaddleOCR-VL recipe (`PaddleOCRVLForConditionalGeneration` / `paddleocr_vl` model_type, same ERNIE-4.5-0.3B base), so the launch command, dependencies, and feature flags (`text_only`, `encoder_parallel`) mirror the 1.0 recipe.
- Guide-only changes vs 1.0: new `Spotting:` and `Seal Recognition:` task prompts, mention of added Tibetan/Bengali support, and the `PaddleOCR-VL-1.5-0.9B` served-model-name needed by the offline PP-DocLayoutV2 pipeline.
- Kept as an independent recipe rather than a variant of `PaddleOCR-VL` so the site URL `/PaddlePaddle/PaddleOCR-VL-1.5` mirrors the HF repo, per repo convention.

Note: native 1.5 support in vLLM is still tracked at [vllm-project/vllm#33554](https://github.com/vllm-project/vllm/issues/33554); since the arch is unchanged, `--trust-remote-code` on the existing PaddleOCR-VL handler loads it on 0.11.1.

Also extends `.claude/skills/add-recipe/SKILL.md` with an "upstream support" step (search vLLM and the model author's repo for issues/PRs) to inform `min_vllm_version`, surface troubleshooting, and collect reference links.

## Test plan

- [x] `node scripts/build-recipes-api.mjs` → `✓ JSON API: 93 models, 8 strategies`
- [ ] Smoke-test `vllm serve PaddlePaddle/PaddleOCR-VL-1.5 --trust-remote-code --max-num-batched-tokens 16384 --no-enable-prefix-caching --mm-processor-cache-gb 0` on a single H200
- [ ] Verify Spotting/Seal prompts return non-empty results via the OpenAI-compatible endpoint