### PR TITLE
Fix Gemma-4-31B VRAM and DeepSeek-R1 NVFP4 model_id

### DIFF
--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -70,7 +70,7 @@ opt_in_features:
 variants:
   default:
     precision: bf16
-    vram_minimum_gb: 210
+    vram_minimum_gb: 75
     description: "Full BF16 — single 80 GB NVIDIA GPU or 1x MI300X/MI325X/MI350X/MI355X"
   nvfp4:
     model_id: "nvidia/gemma-4-31B-it-NVFP4"

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -57,7 +57,7 @@ variants:
     vram_minimum_gb: 805
     description: "May 2025 DeepSeek-R1 refresh (DeepSeek-R1-0528)"
   nvfp4:
-    model_id: "nvidia/DeepSeek-R1-NVFP4"
+    model_id: "nvidia/DeepSeek-R1-0528-NVFP4-v2"
     precision: nvfp4
     vram_minimum_gb: 403
     description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"


### PR DESCRIPTION
## Summary

- `models/Google/gemma-4-31B-it.yaml`: default-variant `vram_minimum_gb` from **210 → 75**. Per the repo formula (`params × bytes × 1.2`), 31B BF16 → `31 × 2 × 1.2 = 74.4` → **75 GB**. The previous 210 GB was the rough number for an 87B-class model and contradicted the variant description ("single 80 GB NVIDIA GPU or 1× MI300X/MI325X/MI350X/MI355X").
- `models/deepseek-ai/DeepSeek-R1.yaml`: nvfp4 variant `model_id` from `nvidia/DeepSeek-R1-NVFP4` → `nvidia/DeepSeek-R1-0528-NVFP4-v2`. The default variant already targets the May 2025 DeepSeek-R1-0528 refresh; the NVFP4 sibling should follow. Both HF refs return 200, so this is a correctness alignment, not a broken-link fix.

## Test plan

- [x] `node scripts/build-recipes-api.mjs` → `✓ JSON API: 92 models, 8 strategies`
- [x] Both HF model_ids verified with `curl` against `huggingface.co/api/models/<id>` (200 OK)