### PR TITLE
Add mistralai/Mistral-Small-4-119B-2603 recipe

### DIFF
--- a/models/mistralai/Mistral-Small-4-119B-2603.yaml
+++ b/models/mistralai/Mistral-Small-4-119B-2603.yaml
@@ -13,8 +13,7 @@ meta:
 
 model:
   model_id: "mistralai/Mistral-Small-4-119B-2603"
-  min_vllm_version: "nightly"
-  nightly_required: true
+  min_vllm_version: "0.20.0"
   architecture: moe
   parameter_count: "119B"
   active_parameters: "6.5B"
@@ -27,10 +26,10 @@ model:
   base_env: {}
 
 dependencies:
-  - note: "Mistral tokenizer / chat-template runtime — Mistral Small 4 needs >= 1.11.0 (auto-installed with vLLM nightly, pin if you hit an older cached wheel)"
+  - note: "Mistral tokenizer / chat-template runtime — Mistral Small 4 needs >= 1.11.0 (vLLM 0.20.1+ bundles it, pin explicitly if you hit an older cached wheel)"
     command: 'uv pip install -U "mistral_common>=1.11.0"'
-  - note: "Mistral 4 architecture support requires transformers main (>= 5.3.0.dev0)"
-    command: 'uv pip install -U git+https://github.com/huggingface/transformers.git'
+  - note: "Transformers v5 silences YaRN warnings and is required for the latest Mistral 4 chat template"
+    command: "uv pip install -U transformers"
 
 features:
   tool_calling:
@@ -115,20 +114,19 @@ guide: |
 
   - Hardware: 2xB200 / 2xH200 / 2xMI300X (FP8 default) or 1xB200 with reduced
     context (NVFP4).
-  - vLLM **nightly** — Mistral 4 architecture support has not yet shipped in
-    a stable release.
+  - vLLM **>= 0.20.0** — earlier releases load the model but trip on the
+    Mistral tool-call / reasoning parsers fixed in PR #39217 (in 0.19.1+)
+    and the grammar factory landed in 0.20.0.
 
   ### Install vLLM
 
   ```bash
   uv venv && source .venv/bin/activate
-  uv pip install -U vllm --torch-backend=auto \
-      --extra-index-url https://wheels.vllm.ai/nightly
-  uv pip install -U git+https://github.com/huggingface/transformers.git
+  uv pip install -U vllm --torch-backend=auto
+  uv pip install -U "mistral_common>=1.11.0" transformers
   ```
 
-  This pulls in `mistral_common >= 1.11.0` automatically. Verify with
-  `python -c "import mistral_common; print(mistral_common.__version__)"`.
+  Verify with `python -c "import mistral_common; print(mistral_common.__version__)"`.
 
   ## Launch command
 
@@ -160,8 +158,8 @@ guide: |
 
   Mistral publishes a custom Docker image
   [`mistralllm/vllm-ms4:latest`](https://hub.docker.com/r/mistralllm/vllm-ms4)
-  with patched tool-call / reasoning parsing — use it if the upstream nightly
-  trips on either feature.
+  with patched tool-call / reasoning parsing — use it if you're pinned to a
+  vLLM version below 0.20.0 and hit either of those issues.
 
   ## EAGLE speculative decoding
 
@@ -235,7 +233,7 @@ guide: |
     or 65536, or move to NVFP4.
   - **`reasoning_effort` rejected**: the chat template only accepts `"none"`
     and `"high"`.
-  - **NVFP4 weight-loader errors** on stale nightly wheels: try Mistral's
+  - **NVFP4 weight-loader errors** on older wheels: try Mistral's
     `mistralllm/vllm-ms4:latest` Docker image, which carries the parser /
     weight-loader fixes Mistral ships ahead of the upstream merge.
 
@@ -244,4 +242,3 @@ guide: |
   - [Model card](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603)
   - [NVFP4 variant](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4)
   - [EAGLE draft head](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-eagle)
-  - [vLLM recipe request #459](https://github.com/vllm-project/recipes/issues/459)

--- a/models/mistralai/Mistral-Small-4-119B-2603.yaml
+++ b/models/mistralai/Mistral-Small-4-119B-2603.yaml
@@ -1,0 +1,247 @@
+meta:
+  title: "Mistral-Small-4-119B"
+  slug: "mistral-small-4-119b"
+  provider: "Mistral AI"
+  description: "Mistral Small 4 (119B MoE, 6.5B active) — multimodal hybrid instruct + reasoning model with native FP8 weights and 256K context"
+  date_updated: 2026-05-13
+  difficulty: intermediate
+  tasks:
+    - multimodal
+  related_recipes:
+    - mistralai/Mistral-Medium-3.5-128B
+    - mistralai/Mistral-Large-3-675B-Instruct-2512
+
+model:
+  model_id: "mistralai/Mistral-Small-4-119B-2603"
+  min_vllm_version: "nightly"
+  nightly_required: true
+  architecture: moe
+  parameter_count: "119B"
+  active_parameters: "6.5B"
+  context_length: 262144
+  base_args:
+    - "--max-model-len"
+    - "262144"
+    - "--attention-backend"
+    - "FLASH_ATTN_MLA"
+  base_env: {}
+
+dependencies:
+  - note: "Mistral tokenizer / chat-template runtime — Mistral Small 4 needs >= 1.11.0 (auto-installed with vLLM nightly, pin if you hit an older cached wheel)"
+    command: 'uv pip install -U "mistral_common>=1.11.0"'
+  - note: "Mistral 4 architecture support requires transformers main (>= 5.3.0.dev0)"
+    command: 'uv pip install -U git+https://github.com/huggingface/transformers.git'
+
+features:
+  tool_calling:
+    description: "Mistral tool-call parser with automatic tool choice — emits [TOOL_CALLS] / [ARGS] from the chat template"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "mistral"
+  reasoning:
+    description: "Mistral reasoning parser extracts [THINK]...[/THINK] into message.reasoning_content (emitted when reasoning_effort='high')"
+    args:
+      - "--reasoning-parser"
+      - "mistral"
+  spec_decoding:
+    description: "EAGLE speculative decoding via the mistralai/Mistral-Small-4-119B-2603-eagle 2-layer draft head"
+    args:
+      - "--speculative-config"
+      - '{"model":"mistralai/Mistral-Small-4-119B-2603-eagle","num_speculative_tokens":3,"method":"eagle","max_model_len":"65536"}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: fp8
+    vram_minimum_gb: 143
+    description: "Native FP8 E4M3 weights (vision tower / projector / lm_head kept in BF16); recommended on 2xB200/H200 or MI300X with FLASH_ATTN_MLA"
+  nvfp4:
+    model_id: "mistralai/Mistral-Small-4-119B-2603-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 72
+    description: "NVFP4 4-bit weights for B200-class GPUs (Marlin fallback on Hopper); overrides the attention backend to TRITON_MLA"
+    extra_args:
+      - "--attention-backend"
+      - "TRITON_MLA"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+
+hardware_overrides:
+  amd:
+    extra_args:
+      - "--no-enable-prefix-caching"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      SAFETENSORS_FAST_GPU: "1"
+
+strategy_overrides:
+  single_node_tp:
+    # Mistral recommends TP=2 for both FP8 and NVFP4; TEP/DEP not yet
+    # documented by the model authors. Override the default full-node TP.
+    tp: 2
+
+guide: |
+  ## Overview
+
+  Mistral Small 4 119B is a hybrid Mixture-of-Experts model from Mistral AI:
+  **128 experts, 4 active per token** (plus 1 shared expert), 119B total
+  parameters with **6.5B activated per token**. It unifies the capabilities of
+  three earlier Mistral families — **Instruct**, **Reasoning** (formerly
+  Magistral), and **Devstral** — into a single checkpoint, with per-request
+  toggling between fast instant-reply and step-by-step reasoning via
+  `reasoning_effort`.
+
+  The weights ship pre-quantized to FP8 E4M3 (the vision tower, multimodal
+  projector, and `lm_head` are kept in BF16). Multimodal input accepts text
+  and image (Pixtral-style encoder, 1540x1540, patch size 14). Context length
+  is **256K** via YaRN scaling (factor 128x over the 8K base) — the config
+  advertises 1M positions but Mistral recommends serving at 256K.
+
+  Mistral Small 4 also ships two companion checkpoints:
+
+  - **NVFP4** ([`mistralai/Mistral-Small-4-119B-2603-NVFP4`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4)) —
+    4-bit `compressed-tensors` weights (~72 GB raw); served with the
+    `TRITON_MLA` backend.
+  - **EAGLE draft head** ([`mistralai/Mistral-Small-4-119B-2603-eagle`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-eagle)) —
+    a 2-layer Mistral-style draft trained on the 119B target; enable via the
+    `spec_decoding` feature.
+
+  ## Prerequisites
+
+  - Hardware: 2xB200 / 2xH200 / 2xMI300X (FP8 default) or 1xB200 with reduced
+    context (NVFP4).
+  - vLLM **nightly** — Mistral 4 architecture support has not yet shipped in
+    a stable release.
+
+  ### Install vLLM
+
+  ```bash
+  uv venv && source .venv/bin/activate
+  uv pip install -U vllm --torch-backend=auto \
+      --extra-index-url https://wheels.vllm.ai/nightly
+  uv pip install -U git+https://github.com/huggingface/transformers.git
+  ```
+
+  This pulls in `mistral_common >= 1.11.0` automatically. Verify with
+  `python -c "import mistral_common; print(mistral_common.__version__)"`.
+
+  ## Launch command
+
+  FP8 default (2xB200 / 2xH200):
+
+  ```bash
+  vllm serve mistralai/Mistral-Small-4-119B-2603 \
+    --max-model-len 262144 \
+    --tensor-parallel-size 2 \
+    --attention-backend FLASH_ATTN_MLA \
+    --tool-call-parser mistral --enable-auto-tool-choice \
+    --reasoning-parser mistral \
+    --max_num_batched_tokens 16384 --max_num_seqs 128 \
+    --gpu_memory_utilization 0.8
+  ```
+
+  NVFP4 variant (single B200, or 2xB200 for full 256K context):
+
+  ```bash
+  vllm serve mistralai/Mistral-Small-4-119B-2603-NVFP4 \
+    --max-model-len 262144 \
+    --tensor-parallel-size 2 \
+    --attention-backend TRITON_MLA \
+    --tool-call-parser mistral --enable-auto-tool-choice \
+    --reasoning-parser mistral \
+    --max_num_batched_tokens 16384 --max_num_seqs 128 \
+    --gpu_memory_utilization 0.8
+  ```
+
+  Mistral publishes a custom Docker image
+  [`mistralllm/vllm-ms4:latest`](https://hub.docker.com/r/mistralllm/vllm-ms4)
+  with patched tool-call / reasoning parsing — use it if the upstream nightly
+  trips on either feature.
+
+  ## EAGLE speculative decoding
+
+  The EAGLE draft head is **not** included in the default config — toggle the
+  `spec_decoding` feature (or pass `--speculative_config` directly):
+
+  ```bash
+  vllm serve mistralai/Mistral-Small-4-119B-2603 \
+    --max-model-len 262144 \
+    --tensor-parallel-size 2 \
+    --attention-backend FLASH_ATTN_MLA \
+    --tool-call-parser mistral --enable-auto-tool-choice \
+    --reasoning-parser mistral \
+    --max_num_batched_tokens 16384 --max_num_seqs 128 \
+    --gpu_memory_utilization 0.8 \
+    --speculative_config '{
+      "model": "mistralai/Mistral-Small-4-119B-2603-eagle",
+      "num_speculative_tokens": 3,
+      "method": "eagle",
+      "max_model_len": "65536"
+    }'
+  ```
+
+  ## Client usage
+
+  Reasoning is opt-in per request via `reasoning_effort`. Only `"none"` and
+  `"high"` are accepted — anything else raises an exception in the chat
+  template. Recommended sampling:
+
+  - `reasoning_effort="none"`: `temperature` 0.0–0.7 depending on task.
+  - `reasoning_effort="high"`: `temperature=0.7`.
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")
+  resp = client.chat.completions.create(
+      model="mistralai/Mistral-Small-4-119B-2603",
+      messages=[{"role": "user", "content": "Plan a 3-day Paris trip."}],
+      extra_body={"reasoning_effort": "high"},
+      temperature=0.7, max_tokens=4096,
+  )
+  msg = resp.choices[0].message
+  print("reasoning:", getattr(msg, "reasoning_content", None))
+  print("answer:", msg.content)
+  ```
+
+  Image input (vision):
+
+  ```python
+  resp = client.chat.completions.create(
+      model="mistralai/Mistral-Small-4-119B-2603",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://..."}},
+              {"type": "text", "text": "Describe this image."},
+          ],
+      }],
+      max_tokens=512,
+  )
+  ```
+
+  Tool calling follows the standard OpenAI schema — the chat template emits
+  `[AVAILABLE_TOOLS]` / `[TOOL_CALLS]` tokens which the `mistral` tool-call
+  parser surfaces as `message.tool_calls`.
+
+  ## Troubleshooting
+
+  - **OOM at full 256K context** on 2xH200: drop `--max-model-len` to 131072
+    or 65536, or move to NVFP4.
+  - **`reasoning_effort` rejected**: the chat template only accepts `"none"`
+    and `"high"`.
+  - **NVFP4 weight-loader errors** on stale nightly wheels: try Mistral's
+    `mistralllm/vllm-ms4:latest` Docker image, which carries the parser /
+    weight-loader fixes Mistral ships ahead of the upstream merge.
+
+  ## References
+
+  - [Model card](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603)
+  - [NVFP4 variant](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4)
+  - [EAGLE draft head](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-eagle)
+  - [vLLM recipe request #459](https://github.com/vllm-project/recipes/issues/459)


### PR DESCRIPTION
## Summary

Adds a recipe for [`mistralai/Mistral-Small-4-119B-2603`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603) — Mistral AI's hybrid instruct + reasoning MoE (128 experts, 4 active; 119B total / 6.5B active per token; native FP8; 256K context; multimodal text+image).

- **Default variant** (FP8, ~143 GB VRAM): 2×B200 / 2×H200 / 2×MI300X with `FLASH_ATTN_MLA`.
- **NVFP4 variant** ([`mistralai/Mistral-Small-4-119B-2603-NVFP4`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4), ~72 GB): single B200, overrides attention backend to `TRITON_MLA`.
- **EAGLE spec-decoding** ([`mistralai/Mistral-Small-4-119B-2603-eagle`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-eagle)): wired as the opt-in `spec_decoding` feature.
- **Tool calling + reasoning**: Mistral parsers (`--tool-call-parser mistral`, `--reasoning-parser mistral`).
- Pins `mistral_common>=1.11.0` and transformers `main` (>= 5.3.0.dev0); nightly vLLM required.
- Per Mistral's docs, defaults to TP=2 (`strategy_overrides.single_node_tp.tp: 2`). AMD path adds `VLLM_ROCM_USE_AITER=1` / `SAFETENSORS_FAST_GPU=1` and disables prefix caching.

Closes #459.

## Test plan
- [x] `node scripts/build-recipes-api.mjs` passes
- [x] FP8 default renders with `--attention-backend FLASH_ATTN_MLA --max-model-len 262144 --tensor-parallel-size 2` and the Mistral tool-call / reasoning parsers
- [x] NVFP4 variant overrides attention backend to `TRITON_MLA`
- [x] EAGLE `--speculative-config` JSON matches the model card
- [x] DCO sign-off included

🤖 Generated with [Claude Code](https://claude.com/claude-code)