### PR TITLE
Update Kimi K2.5 Eagle3 MLA and add Kimi K2.6 NVFP4 variant

### DIFF
--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "kimi-k2.5"
   provider: "Moonshot AI"
   description: "Open-source native multimodal agentic MoE model with vision-language understanding, tool calling, and thinking modes"
-  date_updated: 2026-04-16
+  date_updated: 2026-05-14
   difficulty: intermediate
   tasks:
     - multimodal
@@ -44,7 +44,7 @@ features:
     description: "Eagle3 speculative decoding for accelerated inference (requires vLLM >= 0.18.0)"
     args:
       - "--speculative-config"
-      - '{"model":"lightseekorg/kimi-k2.5-eagle3","method":"eagle3","num_speculative_tokens":3}'
+      - '{"model":"lightseekorg/kimi-k2.5-eagle3-mla","method":"eagle3","num_speculative_tokens":3}'
   text_only:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
@@ -233,7 +233,7 @@ guide: |
 
   - [Kimi-K2.5 on Hugging Face](https://huggingface.co/moonshotai/Kimi-K2.5)
   - [NVIDIA Kimi-K2.5-NVFP4 on Hugging Face](https://huggingface.co/nvidia/Kimi-K2.5-NVFP4)
-  - [Eagle3 speculative decoding model](https://huggingface.co/lightseekorg/kimi-k2.5-eagle3)
+  - [Eagle3 MLA speculative decoding model](https://huggingface.co/lightseekorg/kimi-k2.5-eagle3-mla)
   - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html)
   - [vLLM Expert Parallelism docs](https://docs.vllm.ai/en/latest/serving/expert_parallel_deployment.html)
   - [vLLM NixlConnector usage guide](https://docs.vllm.ai/en/latest/features/nixl_connector_usage.html)

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "kimi-k2.6"
   provider: "Moonshot AI"
   description: "Open-source native multimodal agentic MoE model with vision-language understanding, tool calling, and thinking modes"
-  date_updated: 2026-04-20
+  date_updated: 2026-05-14
   difficulty: intermediate
   tasks:
     - multimodal
@@ -66,6 +66,16 @@ variants:
     precision: int4
     vram_minimum_gb: 714
     description: "Packed INT4 via compressed-tensors (~595 GB on disk); fits 8×H200"
+  nvfp4:
+    model_id: "nvidia/Kimi-K2.6-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 600
+    description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs (e.g. GB200)"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -198,6 +208,7 @@ guide: |
   ## References
 
   - [Kimi-K2.6 on Hugging Face](https://huggingface.co/moonshotai/Kimi-K2.6)
+  - [NVIDIA Kimi-K2.6-NVFP4 on Hugging Face](https://huggingface.co/nvidia/Kimi-K2.6-NVFP4)
   - [vLLM multimodal inputs guide](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html)
   - [vLLM Expert Parallelism docs](https://docs.vllm.ai/en/latest/serving/expert_parallel_deployment.html)
   - [vLLM NixlConnector usage guide](https://docs.vllm.ai/en/latest/features/nixl_connector_usage.html)

--- a/moonshotai/Kimi-K2.5.md
+++ b/moonshotai/Kimi-K2.5.md
@@ -261,7 +261,7 @@ vllm serve moonshotai/Kimi-K2.5 -tp 8 \
 
 
 ### Accelerating Kimi 2.5 with Eagle3 MTP
-We recommend using [lightseekorg/kimi-k2.5-eagle3](https://huggingface.co/lightseekorg/kimi-k2.5-eagle3) and [nvidia/Kimi-K2.5-Thinking-Eagle3](https://huggingface.co/nvidia/Kimi-K2.5-Thinking-Eagle3) to accelerate inference of Kimi 2.5. This feature is supported in vLLM nightly and `vLLM>=0.18.0`.
+We recommend using [lightseekorg/kimi-k2.5-eagle3-mla](https://huggingface.co/lightseekorg/kimi-k2.5-eagle3-mla) and [nvidia/Kimi-K2.5-Thinking-Eagle3](https://huggingface.co/nvidia/Kimi-K2.5-Thinking-Eagle3) to accelerate inference of Kimi 2.5. This feature is supported in vLLM nightly and `vLLM>=0.18.0`.
 
 ```bash
 vllm serve moonshotai/Kimi-K2.5 \


### PR DESCRIPTION
## Summary

- Update the Kimi K2.5 speculative decoding / Eagle3 draft model to `lightseekorg/kimi-k2.5-eagle3-mla`.
- Add the `nvfp4` variant for Kimi K2.6 using `nvidia/Kimi-K2.6-NVFP4`.

## References

- Kimi K2.6 NVFP4 model: https://huggingface.co/nvidia/Kimi-K2.6-NVFP4
- Kimi K2.5 Eagle3 MLA draft model: https://huggingface.co/lightseekorg/kimi-k2.5-eagle3-mla