### PR TITLE
Verify Ling-2.6-flash and Ling-2.6-1T on MI300X

### DIFF
--- a/models/inclusionAI/Ling-2.6-1T.yaml
+++ b/models/inclusionAI/Ling-2.6-1T.yaml
@@ -2,8 +2,8 @@ meta:
   title: "Ling-2.6-1T"
   slug: "ling-2.6-1t"
   provider: "inclusionAI"
-  description: "Ling-2.6-1T (BailingMoeV2_5) FP8 instruct model with 1T total / 50B active params, hybrid linear + MLA attention, 128K context"
-  date_updated: 2026-04-29
+  description: "Ling-2.6-1T (BailingMoeV2_5) FP8 instruct model with 1T total / 50B active params, hybrid linear + MLA attention, 262K context"
+  date_updated: 2026-05-13
   difficulty: advanced
   tasks:
     - text
@@ -12,17 +12,21 @@ meta:
     - inclusionAI/Ring-1T-FP8
   hardware:
     b300: verified
+    mi300x: verified
 
 model:
   model_id: "inclusionAI/Ling-2.6-1T"
-  min_vllm_version: "nightly"
-  nightly_required: true
+  min_vllm_version: "0.20.2"
+  docker_image:
+    amd: "vllm/vllm-openai-rocm:v0.20.2"
   architecture: moe
   parameter_count: "1T"
   active_parameters: "50B"
-  context_length: 131072
+  context_length: 262144
   base_args:
     - "--trust-remote-code"
+    - "--tensor-parallel-size"
+    - "8"
   base_env: {}
 
 features: {}
@@ -33,13 +37,67 @@ variants:
   default:
     precision: fp8
     vram_minimum_gb: 1200
-    description: "FP8 weights on 8x H200 with TP=8"
+    description: "FP8 weights with TP=8 on B300 or 8x MI300X/MI355X-class nodes"
 
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  amd:
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
 
 strategy_overrides:
   single_node_tp:
     tp: 8
+
+guide: |
+  ## Overview
+
+  [Ling-2.6-1T](https://huggingface.co/inclusionAI/Ling-2.6-1T) is inclusionAI's
+  BailingMoeV2_5 FP8 flagship model with 1T total / 50B active parameters, hybrid
+  linear + MLA attention, and a 262K context window.
+
+  ## Deployment Configurations
+
+  ### Docker (AMD MI300X / MI325X / MI355X, TP=8)
+
+  TP=8 has been verified on an MI300X-class node at the model-derived 262K
+  context. MI325X and MI355X have larger per-GPU HBM.
+
+  ```bash
+  docker run --rm -it \
+    --cap-add=SYS_PTRACE \
+    --ipc=host \
+    --privileged=true \
+    --shm-size=128GB \
+    --network=host \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --group-add video \
+    -e VLLM_ROCM_USE_AITER=1 \
+    vllm/vllm-openai-rocm:v0.20.2 \
+      inclusionAI/Ling-2.6-1T \
+      --tensor-parallel-size 8 \
+      --trust-remote-code
+  ```
+
+  ## Client Usage
+
+  ### Text Generation
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="inclusionAI/Ling-2.6-1T",
+      messages=[{"role": "user", "content": "Write a poem about the ocean."}],
+      max_tokens=512, temperature=0.7,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## References
+
+  - [Ling-2.6-1T on Hugging Face](https://huggingface.co/inclusionAI/Ling-2.6-1T)
+  - [vLLM ROCm GPU install docs](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/?device=rocm)
+  - [ROCm vLLM optimization guide](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference-optimization/vllm-optimization.html)

--- a/models/inclusionAI/Ling-2.6-flash.yaml
+++ b/models/inclusionAI/Ling-2.6-flash.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "ling-2.6-flash"
   provider: "inclusionAI"
   description: "Ling-2.6-flash (BailingMoeV2_5) instruct model with 104B total / 7.4B active params, hybrid linear + MLA attention, 128K context, optimized for agent workloads"
-  date_updated: 2026-04-28
+  date_updated: 2026-05-13
   difficulty: intermediate
   tasks:
     - text
@@ -11,11 +11,13 @@ meta:
     - inclusionAI/Ring-1T-FP8
   hardware:
     h200: verified
+    mi300x: verified
 
 model:
   model_id: "inclusionAI/Ling-2.6-flash"
-  min_vllm_version: "nightly"
-  nightly_required: true
+  min_vllm_version: "0.20.2"
+  docker_image:
+    amd: "vllm/vllm-openai-rocm:v0.20.2"
   architecture: moe
   parameter_count: "104B"
   active_parameters: "7.4B"
@@ -34,13 +36,67 @@ variants:
   default:
     precision: bf16
     vram_minimum_gb: 250
-    description: "BF16 weights on 4x H200 with TP=4"
+    description: "BF16 weights with base TP=4; the guide shows a tested 2-GPU AMD command"
 
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  amd:
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
 
 strategy_overrides:
   single_node_tp:
     tp: 4
+
+guide: |
+  ## Overview
+
+  [Ling-2.6-flash](https://huggingface.co/inclusionAI/Ling-2.6-flash) is a
+  BailingMoeV2_5 MoE instruct model with 104B total / 7.4B active parameters,
+  hybrid linear + MLA attention, and a 131K context window.
+
+  ## Deployment Configurations
+
+  ### Docker (AMD MI300X / MI325X / MI355X, TP=2)
+
+  MI300X / MI325X / MI355X GPUs have larger per-GPU HBM, so TP=2 fits the full
+  131K context.
+
+  ```bash
+  docker run --rm -it \
+    --cap-add=SYS_PTRACE \
+    --ipc=host \
+    --privileged=true \
+    --shm-size=128GB \
+    --network=host \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --group-add video \
+    -e VLLM_ROCM_USE_AITER=1 \
+    vllm/vllm-openai-rocm:v0.20.2 \
+      inclusionAI/Ling-2.6-flash \
+      --tensor-parallel-size 2 \
+      --trust-remote-code
+  ```
+
+  ## Client Usage
+
+  ### Text Generation
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="inclusionAI/Ling-2.6-flash",
+      messages=[{"role": "user", "content": "Write a poem about the ocean."}],
+      max_tokens=512, temperature=0.7,
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## References
+
+  - [Ling-2.6-flash on Hugging Face](https://huggingface.co/inclusionAI/Ling-2.6-flash)
+  - [vLLM ROCm GPU install docs](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/?device=rocm)
+  - [ROCm vLLM optimization guide](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference-optimization/vllm-optimization.html)


### PR DESCRIPTION
## Summary

Adds ROCm guidance for the inclusionAI Ling-2.6 recipes.

- Updates `inclusionAI/Ling-2.6-flash` to use `vllm/vllm-openai-rocm:v0.20.2` for AMD.
- Adds `mi300x: verified` for `Ling-2.6-flash` after ROCm testing.
- Documents an AMD TP=2 launch path for `Ling-2.6-flash`; MI300X / MI325X / MI355X have enough per-GPU HBM for the full 131K context at TP=2.
- Updates `inclusionAI/Ling-2.6-1T` to use `vllm/vllm-openai-rocm:v0.20.2` for AMD.
- Adds `mi300x: verified` for `Ling-2.6-1T` after full-context ROCm TP=8 validation.
- Adds concise AMD Docker guide sections with `VLLM_ROCM_USE_AITER=1`.

## Evidence

Tested on an MI300X-class ROCm host (`gfx942`) with `vllm/vllm-openai-rocm:v0.20.2`.

`Ling-2.6-flash`:
- TP=4 and TP=2
- `/v1/models` reported `max_model_len: 131072`
- OpenAI-compatible chat completion smoke test returned a valid response.

`Ling-2.6-1T`:
- TP=8
- vLLM selected the model-derived context: `Using max model len 262144`
- `/v1/models` reported `max_model_len: 262144`
- vLLM reported GPU KV cache capacity for `4,578,702` tokens.