### PR TITLE
[SEO] Recipes discoverability infra (closes PROD-4)

### DIFF
--- a/src/app/[org]/[repo]/page.js
+++ b/src/app/[org]/[repo]/page.js
@@ -13,6 +13,13 @@ import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import { Badge } from "@/components/ui/badge";
 import { Cpu, Layers, Pencil, Bug, ExternalLink } from "lucide-react";
+import {
+  buildBreadcrumbLd,
+  buildSoftwareApplicationLd,
+  buildTechArticleLd,
+  hardwareLabel,
+  jsonLdScript,
+} from "@/lib/jsonld";
 
 export async function generateStaticParams() {
   return getAllRoutablePairs();
@@ -23,8 +30,10 @@ export async function generateMetadata({ params }) {
   const recipe = getRecipeByHfId(org, repo);
   if (!recipe) return {};
   const { meta, model } = recipe;
+  // Page <title> uses the canonical hf_id (e.g. "deepseek-ai/DeepSeek-V3.2")
+  // — that's what people search for. The layout template appends " | vLLM
+  // Recipes" so the final tab reads "deepseek-ai/DeepSeek-V3.2 | vLLM Recipes".
   const title = `${org}/${repo}`;
-  const description = meta.description || meta.title;
   const paramStr = model.parameter_count
     ? model.active_parameters && model.active_parameters !== model.parameter_count
       ? `${model.parameter_count} / ${model.active_parameters} active`
@@ -35,17 +44,24 @@ export async function generateMetadata({ params }) {
     .filter(Boolean)
     .join(" · ");
   const versionStr = model.min_vllm_version ? `vLLM ${model.min_vllm_version}+` : "";
-  // Provider subtitle is redundant with the "org/" prefix in the title, so
-  // the recipe OG uses: title + meta (spec strip) + version pill.
+  // og:title follows the umbrella spec (PROD-5):
+  //   "<Model Name> on vLLM — Serve command for <hardware list>"
+  // The og:site_name already provides "vLLM Recipes" branding, so the on-vLLM
+  // suffix here is purely a SERP-snippet signal. Falls back to the model meta
+  // line when no verified hardware is listed.
+  const hwList = hardwareLabel(recipe);
+  const ogTitle = hwList
+    ? `${repo} on vLLM — Serve command for ${hwList}`
+    : metaLine
+    ? `${title} — ${metaLine}`
+    : title;
+  // <meta name="description"> follows the umbrella spec template too. Prefer
+  // the recipe's own description, then fall back to the templated form.
+  const templateDescription = `Recommended \`vllm serve\` command, hardware matrix, and flag explanations for serving ${recipe.hf_id} with vLLM${hwList ? ` on ${hwList}` : ""}.`;
+  const description = meta.description || templateDescription;
   const ogUrl = `/og?title=${encodeURIComponent(title)}&meta=${encodeURIComponent(
     metaLine
   )}&version=${encodeURIComponent(versionStr)}&path=${encodeURIComponent(`/${org}/${repo}`)}`;
-  // og:title — aim for 50–60 chars for optimal preview width. Skip the
-  // " on vLLM" suffix since og:site_name already provides it.
-  const ogTitle = metaLine ? `${title} — ${metaLine}` : title;
-  // Page <title> uses the canonical hf_id (e.g. "deepseek-ai/DeepSeek-V3.2")
-  // — that's what people search for. The layout template appends " | vLLM
-  // Recipes" so the final tab reads "deepseek-ai/DeepSeek-V3.2 | vLLM Recipes".
   return {
     title,
     description,
@@ -86,40 +102,29 @@ export default async function RecipePage({ params }) {
     .map((s) => allRecipes.find((r) => r.hf_id === s || r.meta.slug === s))
     .filter(Boolean);
 
-  const recipeUrl = `${siteUrl}/${recipe.hf_org}/${recipe.hf_repo}`;
-  const jsonLd = [
-    {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      name: recipe.hf_id,
-      alternateName: recipe.meta.title,
-      description: recipe.meta.description || recipe.meta.title,
-      applicationCategory: "DeveloperApplication",
-      operatingSystem: "Linux",
-      url: recipeUrl,
-      softwareRequirements: recipe.model.min_vllm_version
-        ? `vLLM ${recipe.model.min_vllm_version}+`
-        : "vLLM",
-      creator: { "@type": "Organization", name: recipe.meta.provider, url: `https://huggingface.co/${recipe.hf_org}` },
-      sameAs: [`https://huggingface.co/${recipe.hf_id}`],
-    },
-    {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: [
-        { "@type": "ListItem", position: 1, name: "vLLM Recipes", item: siteUrl },
-        { "@type": "ListItem", position: 2, name: recipe.meta.provider, item: `${siteUrl}/${recipe.hf_org}` },
-        { "@type": "ListItem", position: 3, name: recipe.hf_repo, item: recipeUrl },
-      ],
-    },
-  ];
+  // JSON-LD @graph: TechArticle is the spec'd primary type (PROD-8), but
+  // SoftwareApplication carries useful schema (softwareRequirements, sameAs
+  // to HuggingFace) Google honours separately, so we keep both alongside the
+  // BreadcrumbList that mirrors the URL hierarchy.
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildTechArticleLd(recipe),
+      buildSoftwareApplicationLd(recipe),
+      buildBreadcrumbLd([
+        { name: "vLLM Recipes", url: "/" },
+        { name: recipe.meta.provider, url: `/${recipe.hf_org}` },
+        { name: recipe.hf_repo, url: `/${recipe.hf_org}/${recipe.hf_repo}` },
+      ]),
+    ],
+  };
 
   return (
     <main className="py-6 w-full min-w-0">
       <script
         type="application/ld+json"
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={jsonLdScript(jsonLd)}
       />
       {/* ── Model header ── */}
       <header className="mb-8">

--- a/src/app/[org]/page.js
+++ b/src/app/[org]/page.js
@@ -6,6 +6,7 @@ import { recipeHref } from "@/lib/recipe-utils";
 import { siteUrl } from "@/lib/site-url";
 import { Badge } from "@/components/ui/badge";
 import { ExternalLink, Type, Eye, Sparkles, Cpu, Hash } from "lucide-react";
+import { buildBreadcrumbLd, jsonLdScript } from "@/lib/jsonld";
 
 export async function generateStaticParams() {
   const recipes = getAllRecipes();
@@ -87,11 +88,10 @@ export default async function OrgPage({ params }) {
 
   const breadcrumbLd = {
     "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: "vLLM Recipes", item: siteUrl },
-      { "@type": "ListItem", position: 2, name: displayName, item: `${siteUrl}/${org}` },
-    ],
+    ...buildBreadcrumbLd([
+      { name: "vLLM Recipes", url: "/" },
+      { name: displayName, url: `/${org}` },
+    ]),
   };
 
   return (
@@ -99,7 +99,7 @@ export default async function OrgPage({ params }) {
       <script
         type="application/ld+json"
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+        dangerouslySetInnerHTML={jsonLdScript(breadcrumbLd)}
       />
       <header className="mb-8 flex items-center gap-4">
         {logo ? (

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -5,6 +5,11 @@ import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { SearchBox } from "@/components/recipes/SearchBox";
 import { getAllRecipes } from "@/lib/recipes";
 import { siteUrl } from "@/lib/site-url";
+import {
+  buildOrganizationLd,
+  buildWebSiteLd,
+  jsonLdScript,
+} from "@/lib/jsonld";
 import "./globals.css";
 
 const inter = Inter({
@@ -74,8 +79,23 @@ export default async function RootLayout({ children }) {
     },
   }));
 
+  // Sitewide JSON-LD graph. Per-page schemas reference these by @id so search
+  // engines and AI assistants can stitch the three vLLM properties (vllm.ai,
+  // docs.vllm.ai, recipes.vllm.ai) into one Organization-rooted graph.
+  const siteGraph = {
+    "@context": "https://schema.org",
+    "@graph": [buildOrganizationLd(), buildWebSiteLd()],
+  };
+
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+      <head>
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={jsonLdScript(siteGraph)}
+        />
+      </head>
       <body className="antialiased bg-background text-foreground min-h-screen flex flex-col">
         {/* Global header */}
         <header className="border-b border-border bg-background/95 backdrop-blur-sm sticky top-0 z-30">

--- a/src/app/llms-full.txt/route.js
+++ b/src/app/llms-full.txt/route.js
@@ -1,0 +1,128 @@
+// /llms-full.txt — full text of every recipe concatenated, with one
+// `# Title` + `Source: <url>` block per section. Designed for AI-assistant
+// retrieval-augmented use: a single fetch gives a model the entire recipes
+// corpus rather than crawling page-by-page.
+//
+// Section format follows the emerging convention used by Mintlify, Vercel,
+// and the docs.vllm.ai llms-full.txt. Each recipe section contains:
+//   - Title heading
+//   - Canonical URL (HTML)
+//   - Markdown shadow URL (machine-readable)
+//   - Publish/last-modified dates
+//   - Model metadata
+//   - Recommended `vllm serve` flags
+//   - The recipe's full guide (markdown body)
+
+import { getAllRecipes } from "@/lib/recipes";
+import { siteUrl } from "@/lib/site-url";
+import { hardwareLabel } from "@/lib/jsonld";
+
+export const dynamic = "force-static";
+
+function renderRecipeSection(recipe) {
+  const canonical = `${siteUrl}/${recipe.hf_org}/${recipe.hf_repo}`;
+  const markdown = `${canonical}.md`;
+  const hw = hardwareLabel(recipe);
+  const tasks = (recipe.meta?.tasks || []).join(", ");
+  const provider = recipe.meta?.provider || recipe.hf_org;
+
+  const header = [
+    `# ${recipe.hf_id} on vLLM`,
+    `Source: ${canonical}`,
+    `Markdown: ${markdown}`,
+    `Provider: ${provider}`,
+    recipe.hf_released ? `Released: ${recipe.hf_released}` : null,
+    recipe.meta?.date_updated ? `Updated: ${recipe.meta.date_updated}` : null,
+    recipe.model?.architecture ? `Architecture: ${recipe.model.architecture}` : null,
+    recipe.model?.parameter_count ? `Parameters: ${recipe.model.parameter_count}` : null,
+    recipe.model?.context_length
+      ? `Context length: ${recipe.model.context_length.toLocaleString()}`
+      : null,
+    recipe.model?.min_vllm_version ? `Min vLLM: ${recipe.model.min_vllm_version}` : null,
+    tasks ? `Tasks: ${tasks}` : null,
+    hw ? `Verified hardware: ${hw}` : null,
+    recipe.meta?.description ? `Summary: ${recipe.meta.description}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  // Variants and base args — the bits an AI assistant actually needs to
+  // answer "how do I serve this?". The interactive command builder also
+  // composes these at runtime, but exposing them in plain text means a
+  // retriever can answer without crawling the JS bundle.
+  const variantLines = [];
+  if (recipe.variants && Object.keys(recipe.variants).length > 0) {
+    variantLines.push("");
+    variantLines.push("## Variants");
+    for (const [name, v] of Object.entries(recipe.variants)) {
+      const precision = v.precision ? `precision=${v.precision}` : "";
+      const vram = v.vram_minimum_gb ? `vram_minimum_gb=${v.vram_minimum_gb}` : "";
+      const modelId = v.model_id ? `model_id=${v.model_id}` : "";
+      const bits = [precision, vram, modelId].filter(Boolean).join(", ");
+      variantLines.push(`- ${name}: ${bits || "(default)"}`);
+      if (v.description) variantLines.push(`  ${v.description}`);
+    }
+  }
+
+  const baseArgs = recipe.model?.base_args || [];
+  const baseEnv = recipe.model?.base_env || {};
+  const argsLines = [];
+  if (baseArgs.length > 0 || Object.keys(baseEnv).length > 0) {
+    argsLines.push("");
+    argsLines.push("## Recommended base flags");
+    if (baseArgs.length > 0) {
+      argsLines.push("```");
+      argsLines.push(`vllm serve ${recipe.model?.model_id || recipe.hf_id} \\`);
+      for (let i = 0; i < baseArgs.length; i++) {
+        const trailing = i < baseArgs.length - 1 ? " \\" : "";
+        argsLines.push(`  ${baseArgs[i]}${trailing}`);
+      }
+      argsLines.push("```");
+    }
+    if (Object.keys(baseEnv).length > 0) {
+      argsLines.push("");
+      argsLines.push("Environment:");
+      argsLines.push("```");
+      for (const [k, v] of Object.entries(baseEnv)) {
+        argsLines.push(`${k}=${v}`);
+      }
+      argsLines.push("```");
+    }
+  }
+
+  const guide = recipe.guide
+    ? ["", "## Guide", "", recipe.guide.trim()].join("\n")
+    : "";
+
+  return [header, variantLines.join("\n"), argsLines.join("\n"), guide]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export async function GET() {
+  const recipes = getAllRecipes();
+
+  const preamble = [
+    "# vLLM Recipes — full text",
+    "",
+    `Concatenated full text of every recipe on ${siteUrl}, formatted for`,
+    "AI-assistant retrieval. Each section is prefixed with its canonical URL,",
+    "markdown shadow URL, model metadata, recommended flags, and (where",
+    "present) the recipe's full guide body.",
+    "",
+    `Recipe count: ${recipes.length}`,
+    `Generated at build time from the canonical YAML sources under \`models/\`.`,
+    "",
+  ].join("\n");
+
+  const sections = recipes.map(renderRecipeSection);
+
+  const body = [preamble, ...sections].join("\n\n---\n\n");
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/src/app/llms.txt/route.js
+++ b/src/app/llms.txt/route.js
@@ -1,0 +1,85 @@
+// /llms.txt — curated hierarchical index of every recipe + supporting page,
+// formatted per the emerging spec at https://llmstxt.org. Absolute URLs end
+// in `.md`, pointing at the markdown shadow served alongside each recipe.
+//
+// This file is what AI assistants (Claude, ChatGPT, Perplexity, Gemini)
+// retrieve when they want to know "what does recipes.vllm.ai cover and
+// where do I find each topic?". Pair this with `/llms-full.txt` which
+// concatenates the full text of every recipe for retrieval-augmented use.
+
+import { getAllRecipes } from "@/lib/recipes";
+import { getProviderDisplayName } from "@/lib/providers";
+import { siteUrl } from "@/lib/site-url";
+
+export const dynamic = "force-static";
+
+function escapeMarkdownLinkText(text) {
+  return String(text).replace(/[\[\]\\]/g, "\\$&");
+}
+
+export async function GET() {
+  const recipes = getAllRecipes();
+
+  // Group recipes by provider, preserving date_updated-descending order from
+  // getAllRecipes(). Providers themselves are ordered by their newest recipe
+  // — same heuristic the homepage uses.
+  const groups = new Map();
+  for (const recipe of recipes) {
+    if (!groups.has(recipe.hf_org)) groups.set(recipe.hf_org, []);
+    groups.get(recipe.hf_org).push(recipe);
+  }
+
+  const corePages = [
+    ["Homepage", siteUrl, "Recipe catalogue: pick a model, get a working `vllm serve` command."],
+    [`Browse all recipes`, `${siteUrl}/browse`, "Flat alphabetical list of every recipe."],
+    [`JSON API`, `${siteUrl}/models.json`, "Machine-readable list of every recipe and its metadata."],
+  ];
+
+  const lines = [
+    "# vLLM Recipes",
+    "",
+    "> Per-model serving recipes for vLLM: hardware-tuned `vllm serve` commands, flag explanations, and known pitfalls. Each recipe page also serves clean markdown at the same URL with a `.md` suffix.",
+    "",
+    "## Core pages",
+    "",
+    ...corePages.map(([title, url, desc]) => `- [${title}](${url}): ${desc}`),
+    "",
+    "## Related properties",
+    "",
+    `- [vLLM](https://vllm.ai): project homepage and blog.`,
+    `- [vLLM documentation](https://docs.vllm.ai): full vLLM reference docs.`,
+    `- [vLLM on GitHub](https://github.com/vllm-project/vllm): source code and issues.`,
+    "",
+    "## Recipes",
+    "",
+  ];
+
+  for (const [org, recipesForOrg] of groups) {
+    const providerName = getProviderDisplayName(org);
+    lines.push(`### ${escapeMarkdownLinkText(providerName)}`);
+    lines.push("");
+    for (const r of recipesForOrg) {
+      const url = `${siteUrl}/${r.hf_org}/${r.hf_repo}.md`;
+      const summary = r.meta?.description
+        ? r.meta.description.replace(/\s+/g, " ").trim()
+        : `${r.hf_id} serving recipe.`;
+      lines.push(`- [${escapeMarkdownLinkText(r.hf_id)}](${url}): ${summary}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Feeds");
+  lines.push("");
+  lines.push(`- [Sitemap](${siteUrl}/sitemap.xml): canonical XML sitemap.`);
+  lines.push(
+    `- [llms-full.txt](${siteUrl}/llms-full.txt): full text of every recipe, concatenated for AI-assistant retrieval.`,
+  );
+  lines.push("");
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -14,9 +14,15 @@ export default async function HomePage() {
 
   return (
     <main className="max-w-[1480px] mx-auto px-4 sm:px-6 py-8">
-      {/* ── Hero (compact) ── */}
+      {/* ── Hero ── */}
       <header className="mb-6">
-        <h1 className="sr-only">vLLM Recipes — Deploy any model on any hardware with vLLM</h1>
+        {/* Visible H1: crawlers (Googlebot, GPTBot, ClaudeBot, PerplexityBot)
+            weight a single, semantically prominent headline. The previous
+            `sr-only` H1 satisfied screen readers but gave search engines no
+            visible page-topic signal. */}
+        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight mb-2">
+          vLLM Recipes
+        </h1>
         <p className="text-sm text-muted-foreground max-w-3xl">
           Pick a model, adjust for your GPUs, copy the <code className="font-mono text-[12px] bg-muted/50 px-1 py-0.5 rounded">vllm serve</code> line that runs.{" "}
           Community-maintained recipes for NVIDIA H100/H200/B200/B300, Grace-Blackwell, and AMD MI300X/MI325X/MI355X.{" "}

--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,13 +1,57 @@
 import { siteUrl } from "@/lib/site-url";
 
+// Internal-only paths we never want indexed. `/og` is the dynamic OG image
+// endpoint (never an SEO destination); `/api/` is the Next.js internal route
+// bucket; `/_next/` and `/static/` are framework build artefacts.
+const COMMON_DISALLOW = ["/og", "/api/", "/_next/", "/static/"];
+
+// Default policy is "allow everything to all crawlers" via `User-Agent: *`.
+// We still list the major AI crawlers explicitly so:
+//   1. Intent is visible to anyone auditing this file (it answers the
+//      common "is GPTBot allowed?" question without inference).
+//   2. Future changes to the `User-Agent: *` rule cannot accidentally drop
+//      AI-assistant traffic.
+// Note: there is no functional difference vs `User-Agent: *` today — these
+// stanzas are documentation that happens to be machine-readable.
+const AI_USER_AGENTS = [
+  // OpenAI
+  "GPTBot",
+  "ChatGPT-User",
+  "OAI-SearchBot",
+  // Anthropic
+  "ClaudeBot",
+  "Claude-Web",
+  "anthropic-ai",
+  // Perplexity
+  "PerplexityBot",
+  "Perplexity-User",
+  // Google's AI training opt-out token (distinct from Googlebot)
+  "Google-Extended",
+  // Other major engines / AI-search surfaces
+  "Bingbot",
+  "Applebot",
+  "Applebot-Extended",
+  "Amazonbot",
+  "Bytespider",
+  "CCBot",
+  "DuckAssistBot",
+  "YouBot",
+  "Mistral-AI-User",
+  "cohere-ai",
+  "Meta-ExternalAgent",
+  "Meta-ExternalFetcher",
+  "FacebookBot",
+];
+
 export default function robots() {
   return {
     rules: [
-      {
-        userAgent: "*",
+      { userAgent: "*", allow: "/", disallow: COMMON_DISALLOW },
+      ...AI_USER_AGENTS.map((userAgent) => ({
+        userAgent,
         allow: "/",
-        disallow: ["/og", "/api/"],
-      },
+        disallow: COMMON_DISALLOW,
+      })),
     ],
     sitemap: `${siteUrl}/sitemap.xml`,
     host: siteUrl,

--- a/src/lib/jsonld.js
+++ b/src/lib/jsonld.js
@@ -1,0 +1,156 @@
+// Centralised schema.org JSON-LD builders for recipes.vllm.ai.
+//
+// Every page emits a single `<script type="application/ld+json">` rooted in
+// an `@graph` so we can reference shared entities (the vLLM Organization, the
+// site WebSite) by `@id` instead of inlining them on each schema.
+//
+// Schemas wired here:
+//   - Organization        (sitewide, by @id)
+//   - WebSite             (sitewide, with SearchAction)
+//   - TechArticle         (per recipe — primary type per PROD-8 spec)
+//   - SoftwareApplication (per recipe — kept alongside TechArticle so the
+//                          existing SoftwareApplication signal isn't lost)
+//   - BreadcrumbList      (per page, mirroring URL hierarchy)
+//
+// JSON-LD is rendered inside a `<script>` tag, so a stray `</script>` inside
+// a stringified value would break the document. `jsonLdScript` defends with
+// the standard `<` → `<` substitution.
+
+import { siteUrl } from "@/lib/site-url";
+
+const ORG_NAME = "vLLM";
+const ORG_LEGAL_NAME = "vLLM Project";
+const ORG_DESCRIPTION =
+  "vLLM is a high-throughput, memory-efficient inference and serving engine for large language models.";
+// Use vllm.ai as the brand anchor so all three properties (vllm.ai,
+// docs.vllm.ai, recipes.vllm.ai) reference the same Organization @id.
+// This is the single most important architectural choice in the SEO
+// bundle — it stitches three subdomains into one authority cluster.
+const VLLM_BRAND_ID = "https://vllm.ai/#organization";
+
+export function buildOrganizationLd() {
+  return {
+    "@type": "Organization",
+    "@id": VLLM_BRAND_ID,
+    name: ORG_NAME,
+    legalName: ORG_LEGAL_NAME,
+    url: "https://vllm.ai",
+    description: ORG_DESCRIPTION,
+    logo: { "@type": "ImageObject", url: "https://vllm.ai/vLLM-Logo.png" },
+    sameAs: [
+      "https://github.com/vllm-project/vllm",
+      "https://x.com/vllm_project",
+      "https://huggingface.co/vllm-project",
+    ],
+  };
+}
+
+export function buildWebSiteLd() {
+  return {
+    "@type": "WebSite",
+    "@id": `${siteUrl}/#website`,
+    name: "vLLM Recipes",
+    url: siteUrl,
+    description:
+      "Per-model vLLM serving recipes: hardware-tuned vllm serve commands, flag explanations, and known pitfalls.",
+    publisher: { "@id": VLLM_BRAND_ID },
+    inLanguage: "en",
+  };
+}
+
+export function buildBreadcrumbLd(crumbs) {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: crumbs.map((crumb, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: crumb.name,
+      item: crumb.url.startsWith("http") ? crumb.url : `${siteUrl}${crumb.url}`,
+    })),
+  };
+}
+
+// Render the list of verified GPUs into a human-readable hardware string.
+// Used in both metadata templates and TechArticle.keywords.
+export function hardwareLabel(recipe) {
+  const hw = recipe?.meta?.hardware;
+  if (!hw || typeof hw !== "object") return "";
+  const verified = Object.entries(hw)
+    .filter(([, status]) => status === "verified")
+    .map(([gpu]) => gpu);
+  if (verified.length === 0) return "";
+  return verified.join(", ");
+}
+
+export function buildTechArticleLd(recipe) {
+  const url = `${siteUrl}/${recipe.hf_org}/${recipe.hf_repo}`;
+  const hwList = hardwareLabel(recipe);
+  const datePublished = recipe.hf_released || recipe.meta?.date_updated || undefined;
+  const dateModified = recipe.meta?.date_updated || datePublished;
+
+  const keywords = [
+    "vllm",
+    recipe.hf_repo,
+    recipe.meta?.provider,
+    ...(recipe.meta?.tasks || []),
+    recipe.model?.architecture,
+    hwList,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return {
+    "@type": "TechArticle",
+    "@id": `${url}#article`,
+    headline: `${recipe.hf_repo} on vLLM`,
+    name: `${recipe.hf_repo} on vLLM`,
+    description: recipe.meta?.description || `${recipe.hf_id} serving recipe for vLLM.`,
+    url,
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    inLanguage: "en",
+    isAccessibleForFree: true,
+    proficiencyLevel: "Expert",
+    keywords,
+    ...(datePublished && { datePublished }),
+    ...(dateModified && { dateModified }),
+    about: {
+      "@type": "Thing",
+      name: recipe.hf_id,
+      url: `https://huggingface.co/${recipe.hf_id}`,
+    },
+    author: {
+      "@type": "Organization",
+      name: recipe.meta?.provider || "vLLM",
+      ...(recipe.hf_org && { url: `https://huggingface.co/${recipe.hf_org}` }),
+    },
+    publisher: { "@id": VLLM_BRAND_ID },
+    isPartOf: { "@id": `${siteUrl}/#website` },
+  };
+}
+
+export function buildSoftwareApplicationLd(recipe) {
+  const url = `${siteUrl}/${recipe.hf_org}/${recipe.hf_repo}`;
+  return {
+    "@type": "SoftwareApplication",
+    name: recipe.hf_id,
+    alternateName: recipe.meta?.title,
+    description: recipe.meta?.description || recipe.meta?.title,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Linux",
+    url,
+    softwareRequirements: recipe.model?.min_vllm_version
+      ? `vLLM ${recipe.model.min_vllm_version}+`
+      : "vLLM",
+    creator: {
+      "@type": "Organization",
+      name: recipe.meta?.provider,
+      url: `https://huggingface.co/${recipe.hf_org}`,
+    },
+    sameAs: [`https://huggingface.co/${recipe.hf_id}`],
+  };
+}
+
+export function jsonLdScript(data) {
+  const json = JSON.stringify(data).replace(/</g, "\\u003c");
+  return { __html: json };
+}


### PR DESCRIPTION
## Summary

Brings recipes.vllm.ai to parity with the SEO bundle landing on vllm.ai and docs.vllm.ai. AI assistants (Claude, ChatGPT, Perplexity, Gemini) increasingly drive technical-content discovery and weight structured data + machine-readable indexes when deciding which sources to cite.

**Umbrella Linear issue:** [PROD-4](https://linear.app/inferact/issue/PROD-4/recipes-seo-infrastructure-umbrella-for-c1-c5)

Closes PROD-4
Closes PROD-5
Closes PROD-6
Closes PROD-7
Closes PROD-8
Closes PROD-9

## What changed

### Per-page metadata (PROD-5)
Recipe page `og:title` now follows the umbrella spec template: **"<repo> on vLLM — Serve command for <hardware list>"**, with the hardware list derived from each recipe's verified-hardware map. Description falls back to a templated form when the recipe lacks an explicit one. Page `<title>` is unchanged (canonical `hf_id`) because that's the string people search for.

### Visible H1 (PROD-6)
Homepage `<h1>` was `class="sr-only"`. Switched to a visible "vLLM Recipes" headline. The `[org]` and `[org]/[repo]` pages already had visible H1s.

### /llms.txt + /llms-full.txt (PROD-7)
Two new Next.js route handlers under `src/app/`. `/llms.txt` emits a curated hierarchical index per the [llmstxt.org](https://llmstxt.org) spec, with absolute `.md` URLs grouped by provider. `/llms-full.txt` concatenates every recipe's metadata + recommended flags + guide body into one fetchable corpus for retrieval-augmented use. Both statically generated.

> **Note**: the `.md` URLs in `/llms.txt` currently 404 — they're activated by the **PROD-10** (`.md` shadow URLs) PR, which copies recipe markdown sources into the build output. Filed in the same session.

### TechArticle + BreadcrumbList JSON-LD (PROD-8)
New `src/lib/jsonld.js` centralises schema.org builders. Recipe pages emit a single `@graph` containing `TechArticle` (spec'd primary type), `SoftwareApplication` (kept for the existing `softwareRequirements` + HuggingFace `sameAs` signal), and `BreadcrumbList`. The root layout adds sitewide `Organization` + `WebSite` blocks, both bound by `@id`, so recipes.vllm.ai inherits the same brand identity as vllm.ai and docs.vllm.ai.

### robots.txt (PROD-9)
`User-Agent: *` still allows everything. Added explicit allow stanzas for the major AI crawlers (GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, Claude-Web, PerplexityBot, Google-Extended, Bingbot, Applebot, Amazonbot, Bytespider, CCBot, …). This is documentation that happens to be machine-readable — no functional change vs the existing `User-Agent: * Allow: /`, but it answers "is GPTBot allowed?" without inference.

## Validation

- `pnpm next build` — all **226 routes** generate, including `/llms.txt`, `/llms-full.txt`, `/robots.txt`, `/sitemap.xml`.
- Sample recipe page (`/inclusionAI/Ring-2.6-1T`) emits `TechArticle` + `SoftwareApplication` + `BreadcrumbList` + `Organization` + `WebSite` + `ImageObject` + `Thing` + `WebPage` + `ListItem` schemas.
- `/robots.txt` contains the `User-Agent: *` default plus the AI-crawler stanzas and declares the sitemap URL.
- `/llms.txt` orders recipes by provider, descending by `date_updated`, with absolute `.md` URLs.

## Test plan

- [x] `node scripts/build-recipes-api.mjs` — validates all YAMLs parse.
- [x] `pnpm next build` — full Next build succeeds.
- [ ] Deploy preview; verify `curl -I https://<preview>/llms.txt` → 200.
- [ ] Deploy preview; verify `curl -I https://<preview>/llms-full.txt` → 200.
- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) on a sample recipe page detects `TechArticle` + `BreadcrumbList` with no errors.
- [ ] [Schema.org Validator](https://validator.schema.org) on the same page.

## Notes for reviewer

PR is opened from a personal fork (`zlxi02/recipes`) because the autonomous session's GitHub account only has read access on `vllm-project/recipes`. Marking as **draft** for human review of the umbrella scope before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code) during the PROD-2 autonomous SEO session.