### PR TITLE
[SEO] .md shadow URLs for recipes (closes PROD-10)

### DIFF
--- a/src/app/api/recipe-md/[org]/[repo]/route.js
+++ b/src/app/api/recipe-md/[org]/[repo]/route.js
@@ -1,0 +1,204 @@
+// /api/recipe-md/<org>/<repo> — internal markdown shadow for a recipe.
+// Reached via middleware-driven rewrite when someone requests
+// `/<org>/<repo>.md`; never linked publicly.
+//
+// PROD-10 — why .md shadow URLs matter: AI assistants (Claude, ChatGPT,
+// Perplexity) often fetch URLs the user pastes. The recipes site is
+// command-builder heavy; the rendered HTML page works fine in a browser
+// but is awkward to retrieve cleanly because the command itself is
+// client-composed from variant + hardware + strategy state. Serving a
+// canonical markdown view fixes that:
+//
+//   - One representative `vllm serve` command (default variant, default
+//     hardware) that an assistant can quote verbatim.
+//   - The recipe metadata, variant list, verified hardware, and the
+//     full guide body — every piece an assistant needs to answer
+//     "how do I run X with vLLM?".
+//   - YAML-like frontmatter at the top so retrievers can extract
+//     structured fields without parsing markdown.
+//
+// We do NOT use User-Agent sniffing (cloaking risk) or Accept-header
+// negotiation (operationally fragile through CDNs). The `.md` suffix
+// is the explicit signal.
+
+import { getAllRoutablePairs, getRecipeByHfId } from "@/lib/recipes";
+import { siteUrl } from "@/lib/site-url";
+
+// Render the recipe's verified hardware map into a comma-separated string.
+// Inlined here so this PR has no cross-branch dependency on jsonld.js.
+function hardwareLabel(recipe) {
+  const hw = recipe?.meta?.hardware;
+  if (!hw || typeof hw !== "object") return "";
+  const verified = Object.entries(hw)
+    .filter(([, status]) => status === "verified")
+    .map(([gpu]) => gpu);
+  return verified.join(", ");
+}
+
+export const dynamic = "force-static";
+
+export async function generateStaticParams() {
+  return getAllRoutablePairs();
+}
+
+function renderRecipeMarkdown(recipe) {
+  const canonical = `${siteUrl}/${recipe.hf_org}/${recipe.hf_repo}`;
+  const hw = hardwareLabel(recipe);
+  const provider = recipe.meta?.provider || recipe.hf_org;
+  const tasks = (recipe.meta?.tasks || []).join(", ");
+
+  const frontmatter = [
+    "---",
+    `title: ${JSON.stringify(`${recipe.hf_id} on vLLM`)}`,
+    `hf_id: ${recipe.hf_id}`,
+    `provider: ${JSON.stringify(provider)}`,
+    recipe.hf_released ? `released: ${recipe.hf_released}` : null,
+    recipe.meta?.date_updated ? `last_updated: ${recipe.meta.date_updated}` : null,
+    recipe.model?.architecture ? `architecture: ${recipe.model.architecture}` : null,
+    recipe.model?.parameter_count
+      ? `parameters: ${JSON.stringify(recipe.model.parameter_count)}`
+      : null,
+    recipe.model?.context_length ? `context_length: ${recipe.model.context_length}` : null,
+    recipe.model?.min_vllm_version ? `min_vllm_version: ${recipe.model.min_vllm_version}` : null,
+    tasks ? `tasks: [${tasks}]` : null,
+    hw ? `verified_hardware: ${JSON.stringify(hw)}` : null,
+    `canonical_url: ${canonical}`,
+    "---",
+    "",
+  ]
+    .filter((l) => l !== null)
+    .join("\n");
+
+  const sections = [];
+  sections.push(`# ${recipe.hf_id} on vLLM`);
+  if (recipe.meta?.description) {
+    sections.push("");
+    sections.push(recipe.meta.description);
+  }
+  if (recipe.meta?.performance_headline) {
+    sections.push("");
+    sections.push(`> ${recipe.meta.performance_headline}`);
+  }
+
+  // Model facts as a compact reference block. Assistants tend to lift
+  // these into responses verbatim.
+  const facts = [];
+  if (recipe.model?.parameter_count) facts.push(`- Parameters: ${recipe.model.parameter_count}`);
+  if (recipe.model?.active_parameters)
+    facts.push(`- Active parameters: ${recipe.model.active_parameters}`);
+  if (recipe.model?.context_length)
+    facts.push(`- Context length: ${recipe.model.context_length.toLocaleString()} tokens`);
+  if (recipe.model?.architecture) facts.push(`- Architecture: ${recipe.model.architecture}`);
+  if (recipe.model?.min_vllm_version)
+    facts.push(`- Minimum vLLM version: ${recipe.model.min_vllm_version}`);
+  if (hw) facts.push(`- Verified hardware: ${hw}`);
+  if (facts.length > 0) {
+    sections.push("");
+    sections.push("## Model");
+    sections.push("");
+    sections.push(facts.join("\n"));
+  }
+
+  // Variants — important because quantised variants change the model_id
+  // and the VRAM requirement, both things an assistant needs.
+  if (recipe.variants && Object.keys(recipe.variants).length > 0) {
+    sections.push("");
+    sections.push("## Variants");
+    sections.push("");
+    for (const [name, v] of Object.entries(recipe.variants)) {
+      const bits = [];
+      if (v.precision) bits.push(`precision=${v.precision}`);
+      if (v.vram_minimum_gb) bits.push(`vram_minimum_gb=${v.vram_minimum_gb}`);
+      if (v.model_id) bits.push(`model_id=${v.model_id}`);
+      sections.push(`- **${name}** — ${bits.join(", ") || "(default)"}`);
+      if (v.description) sections.push(`  ${v.description}`);
+    }
+  }
+
+  // A canonical `vllm serve` command from base_args. The site composes a
+  // richer command client-side based on user choices; this is the
+  // assistant-friendly baseline.
+  const baseArgs = recipe.model?.base_args || [];
+  const baseEnv = recipe.model?.base_env || {};
+  if (baseArgs.length > 0 || Object.keys(baseEnv).length > 0) {
+    sections.push("");
+    sections.push("## Recommended baseline command");
+    sections.push("");
+    if (baseArgs.length > 0) {
+      sections.push("```bash");
+      sections.push(`vllm serve ${recipe.model?.model_id || recipe.hf_id} \\`);
+      for (let i = 0; i < baseArgs.length; i++) {
+        const trailing = i < baseArgs.length - 1 ? " \\" : "";
+        sections.push(`  ${baseArgs[i]}${trailing}`);
+      }
+      sections.push("```");
+    }
+    if (Object.keys(baseEnv).length > 0) {
+      sections.push("");
+      sections.push("Required environment:");
+      sections.push("");
+      sections.push("```bash");
+      for (const [k, v] of Object.entries(baseEnv)) {
+        sections.push(`export ${k}=${v}`);
+      }
+      sections.push("```");
+    }
+  }
+
+  // Extra install steps (DeepGEMM pins, transformers commits, etc).
+  if (recipe.dependencies && recipe.dependencies.length > 0) {
+    sections.push("");
+    sections.push("## Additional dependencies");
+    sections.push("");
+    for (const dep of recipe.dependencies) {
+      if (!dep?.command) continue;
+      sections.push("```bash");
+      sections.push(dep.command);
+      sections.push("```");
+      if (dep.note) sections.push(`> ${dep.note}`);
+    }
+  }
+
+  // The hand-written guide is the most important section — pass it
+  // through verbatim.
+  if (recipe.guide && recipe.guide.trim()) {
+    sections.push("");
+    sections.push("## Guide");
+    sections.push("");
+    sections.push(recipe.guide.trim());
+  }
+
+  sections.push("");
+  sections.push("## Source");
+  sections.push("");
+  sections.push(`- Canonical URL: ${canonical}`);
+  sections.push(
+    `- HuggingFace: https://huggingface.co/${recipe.hf_id}`,
+  );
+  sections.push(
+    `- Edit on GitHub: https://github.com/vllm-project/recipes/edit/main/models/${recipe.hf_org}/${recipe.hf_repo}.yaml`,
+  );
+
+  return frontmatter + sections.join("\n") + "\n";
+}
+
+export async function GET(_request, { params }) {
+  const { org, repo } = await params;
+  const recipe = getRecipeByHfId(org, repo);
+  if (!recipe) {
+    return new Response("Not found", {
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+  const body = renderRecipeMarkdown(recipe);
+  const canonical = `${siteUrl}/${recipe.hf_org}/${recipe.hf_repo}`;
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      Link: `<${canonical}>; rel="canonical"; type="text/html"`,
+    },
+  });
+}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+// PROD-10 — `.md` shadow URLs for recipes.
+//
+// Anyone requesting `/<org>/<repo>.md` gets the markdown twin of the
+// rendered recipe page. This is the "fetch by URL" path AI assistants
+// take when a user pastes a link into Claude/ChatGPT/Perplexity. We
+// rewrite (server-side, transparent) rather than redirect because the
+// user should see the `.md` URL in their address bar — that's the
+// explicit "give me markdown" signal.
+//
+// Design notes:
+//   - No User-Agent sniffing. Google classifies "different bytes for the
+//     same URL based on UA" as cloaking; SEO penalty risk.
+//   - No Accept-header negotiation. Operationally fragile in caches and
+//     CDNs. The `.md` suffix is the explicit signal.
+//   - Only `/<org>/<repo>.md` matches — top-level `/<thing>.md` would
+//     conflict with future static markdown files (llms.txt, robots.txt,
+//     etc. already have their own handlers).
+
+export function middleware(request) {
+  const { pathname } = request.nextUrl;
+  if (!pathname.endsWith(".md")) return NextResponse.next();
+
+  // Expect exactly `/<org>/<repo>.md` (two segments, no extra slashes).
+  const stripped = pathname.slice(1, -".md".length);
+  const parts = stripped.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return NextResponse.next();
+  }
+  const [org, repo] = parts;
+
+  const url = request.nextUrl.clone();
+  url.pathname = `/api/recipe-md/${org}/${repo}`;
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  // Match anything that ends in `.md` but skip framework internals so
+  // static markdown files (llms.txt is text/plain, not affected) and
+  // Next's own assets don't get touched.
+  matcher: ["/((?!_next/|api/|og$|robots.txt$|sitemap.xml$|llms.txt$|llms-full.txt$).*\\.md)"],
+};


### PR DESCRIPTION
## Summary

Closes [PROD-10](https://linear.app/inferact/issue/PROD-10/c6-md-shadow-urls-recipesvllmai-vllmaiblog) (recipes side; blog side ships in [vllm_website#36](https://github.com/vllm-project/vllm_website/pull/36)).

Adds `/<org>/<repo>.md` shadow URLs that serve a canonical markdown view of every recipe. When an AI assistant (Claude, ChatGPT, Perplexity) fetches a recipe URL the user pasted, the `.md` variant returns clean markdown with metadata frontmatter, a representative `vllm serve` command, variants, dependencies, and the full guide body — exactly what an assistant needs to answer _"how do I run X with vLLM?"_.

## Why this matters here specifically

The recipes site is command-builder heavy: the canonical `vllm serve` on the rendered HTML page is composed client-side from variant + hardware + strategy state. A retriever scraping the HTML loses that synthesis. The markdown shadow serves the baseline command + every variant up front.

## How

- `src/middleware.js` detects `/<org>/<repo>.md` and rewrites to `/api/recipe-md/<org>/<repo>`. The user sees the `.md` URL; the rewrite is invisible.
- `src/app/api/recipe-md/[org]/[repo]/route.js` renders the recipe to markdown:
  - YAML frontmatter (title, hf_id, provider, dates, hardware, etc.)
  - Model facts block
  - Variants
  - Recommended baseline `vllm serve`
  - Additional dependencies
  - Recipe's guide body verbatim
  - Source links (HF, edit-on-GitHub)
- Response headers: `Content-Type: text/markdown`, `Link: <canonical>; rel="canonical"; type="text/html"`.
- `generateStaticParams` over `getAllRoutablePairs()` → every recipe is prerendered.

## Out of scope / explicitly avoided

- **No User-Agent sniffing.** Cloaking risk per Google's policy.
- **No Accept-header content negotiation.** Operationally fragile through CDNs. The `.md` suffix is the explicit signal.

## Validation

- `pnpm next build` — 226 routes still build; `/api/recipe-md/<org>/<repo>` generates for every routable pair. Sample output for `PaddlePaddle/PaddleOCR-VL` includes frontmatter, model facts, variants, baseline command, and guide body.

## Test plan

- [x] `pnpm next build` passes.
- [ ] Deploy preview; `curl https://<preview>/<org>/<repo>.md` returns 200 + `text/markdown`.
- [ ] Confirm middleware doesn't affect non-`.md` paths.
- [ ] Paste a `.md` URL into Claude/ChatGPT and confirm clean retrieval.

## Notes

PR opened from fork `zlxi02/recipes` because the autonomous session lacks write access on upstream. Mark as **draft** for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code) during the PROD-2 autonomous SEO session.