### PR TITLE
Add DGX Station GB300 recipe support

### DIFF
--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -15,6 +15,7 @@ meta:
     mi300x: verified
     mi325x: verified
     mi355x: verified
+    dgx_station_gb300: verified
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2.7"

--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -13,6 +13,7 @@ meta:
     h100: verified
     h200: verified
     b200: verified
+    dgx_station_gb300: verified
 
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
@@ -133,6 +134,27 @@ guide: |
     --tool-call-parser qwen3_coder \
     --reasoning-parser nemotron_v3
   ```
+
+  ### Single GB300 GPU / DGX Station — NVFP4
+
+  Use the same single-GPU command on DGX Station or on one GPU from a GB300
+  NVL4 tray. The NVFP4 weights fit comfortably in 288 GB HBM3e:
+
+  ```bash
+  export CUDA_DEVICE_ORDER=PCI_BUS_ID
+  export CUDA_VISIBLE_DEVICES=1
+
+  vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
+    --trust-remote-code
+  ```
+
+  For higher throughput, consider adding `--enable-prefix-caching`,
+  `--mamba-cache-mode all`, `--mamba-ssm-cache-dtype float16`, and
+  `--moe-backend flashinfer_trtllm`. Set
+  `VLLM_NVFP4_GEMM_BACKEND=flashinfer-trtllm` if you want to force the
+  FlashInfer-TRTLLM NVFP4 GEMM path. Tune batching for the workload.
+  MTP speculative decoding can also be enabled with
+  `--speculative-config '{"model":"nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4","method":"mtp","num_speculative_tokens":3}'`.
 
   ## Benchmarking
 

--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -135,27 +135,6 @@ guide: |
     --reasoning-parser nemotron_v3
   ```
 
-  ### Single GB300 GPU / DGX Station — NVFP4
-
-  Use the same single-GPU command on DGX Station or on one GPU from a GB300
-  NVL4 tray. The NVFP4 weights fit comfortably in 288 GB HBM3e:
-
-  ```bash
-  export CUDA_DEVICE_ORDER=PCI_BUS_ID
-  export CUDA_VISIBLE_DEVICES=1
-
-  vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
-    --trust-remote-code
-  ```
-
-  For higher throughput, consider adding `--enable-prefix-caching`,
-  `--mamba-cache-mode all`, `--mamba-ssm-cache-dtype float16`, and
-  `--moe-backend flashinfer_trtllm`. Set
-  `VLLM_NVFP4_GEMM_BACKEND=flashinfer-trtllm` if you want to force the
-  FlashInfer-TRTLLM NVFP4 GEMM path. Tune batching for the workload.
-  MTP speculative decoding can also be enabled with
-  `--speculative-config '{"model":"nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4","method":"mtp","num_speculative_tokens":3}'`.
-
   ## Benchmarking
 
   ```bash

--- a/src/components/recipes/BrowseList.jsx
+++ b/src/components/recipes/BrowseList.jsx
@@ -79,6 +79,7 @@ const HW_BRANDS = [
       { id: "b300", label: "B300" },
       { id: "gb200", label: "GB200" },
       { id: "gb300", label: "GB300" },
+      { id: "dgx_station_gb300", label: "DGX Station" },
     ],
   },
   {

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -561,7 +561,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   // All hardware profiles grouped by brand, sorted by architectural generation
   // within brand (oldest → newest; matches the semianalysis GPU timeline).
   const hwByBrand = useMemo(() => {
-    const NVIDIA_ORDER = ["h100", "h200", "b200", "gb200", "b300", "gb300"];
+    const NVIDIA_ORDER = ["h100", "h200", "b200", "gb200", "b300", "gb300", "dgx_station_gb300"];
     const AMD_ORDER = ["mi300x", "mi325x", "mi355x"];
     const rankIn = (list, id) => {
       const i = list.indexOf(id);

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -15,10 +15,6 @@ const NVL4_ONLY_ENV_KEYS = new Set([
   "UCX_NET_DEVICES",
 ]);
 const NVL4_HW_IDS = new Set(["gb200", "gb300"]);
-const DGX_STATION_GB300_ENV = {
-  CUDA_DEVICE_ORDER: "PCI_BUS_ID",
-  CUDA_VISIBLE_DEVICES: "1",
-};
 
 /**
  * Normalize gpu_generation to a single string for hardware_overrides lookup.
@@ -568,11 +564,6 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
       Object.assign(env, strategy.env || {});
     } else if (roleOverride && strategy[roleOverride]?.env) {
       Object.assign(env, strategy[roleOverride].env);
-    }
-
-    // DGX Station exposes the GB300 GPU as CUDA device 1 on the tested setup.
-    if (hwProfileId === "dgx_station_gb300") {
-      Object.assign(env, DGX_STATION_GB300_ENV);
     }
 
     // PD: pin GPUs per role via CUDA_VISIBLE_DEVICES.

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -15,6 +15,10 @@ const NVL4_ONLY_ENV_KEYS = new Set([
   "UCX_NET_DEVICES",
 ]);
 const NVL4_HW_IDS = new Set(["gb200", "gb300"]);
+const DGX_STATION_GB300_ENV = {
+  CUDA_DEVICE_ORDER: "PCI_BUS_ID",
+  CUDA_VISIBLE_DEVICES: "1",
+};
 
 /**
  * Normalize gpu_generation to a single string for hardware_overrides lookup.
@@ -564,6 +568,11 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
       Object.assign(env, strategy.env || {});
     } else if (roleOverride && strategy[roleOverride]?.env) {
       Object.assign(env, strategy[roleOverride].env);
+    }
+
+    // DGX Station exposes the GB300 GPU as CUDA device 1 on the tested setup.
+    if (hwProfileId === "dgx_station_gb300") {
+      Object.assign(env, DGX_STATION_GB300_ENV);
     }
 
     // PD: pin GPUs per role via CUDA_VISIBLE_DEVICES.

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -60,6 +60,19 @@ hardware_profiles:
     vram_gb: 1152
     multi_node: false
 
+  # DGX Station — single-GPU Grace-Blackwell Ultra desktop workstation.
+  # `restricted: true` keeps it out of the picker unless a recipe explicitly
+  # lists it in `meta.hardware` (same pattern as the TPU profiles).
+  dgx_station_gb300:
+    brand: NVIDIA
+    generation: blackwell
+    display_name: "DGX Station (GB300)"
+    description: "NVIDIA DGX Station · 1× GB300 Grace-Blackwell Ultra Superchip · 288 GB HBM3e (desktop workstation)"
+    gpu_count: 1
+    vram_gb: 288
+    multi_node: false
+    restricted: true
+
   # ── AMD Instinct ──
   mi300x:
     brand: AMD


### PR DESCRIPTION
## Summary
- Add restricted DGX Station GB300 hardware profile and picker support
- Mark MiniMax M2.7 and Nemotron-3 Super recipes as verified on DGX Station
- Add DGX Station CUDA device defaults for generated commands
- Add a single-GPU DGX Station launch section for Nemotron-3 Super NVFP4

## Testing
- ruby -ryaml parse for all recipe, strategy, and taxonomy YAML files
- command synthesis smoke test for DGX Station CUDA device env