### PR TITLE
Promote variants to HF-URL JSON endpoints + PD fitness check

### DIFF
--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -365,7 +365,12 @@ function renderAndWriteVariant(recipe, variantKey, altBaseHfId, strategies, taxo
 
   const hwProfiles = taxonomy.hardware_profiles || {};
   const defaultHw = pickDefaultHardware(hwProfiles, variant, recipe);
-  const compatibleHw = listCompatibleHardware(hwProfiles, variant, recipe);
+  // Mirror the UI rule: `restricted` profiles (TPU, etc.) only surface for
+  // recipes that explicitly opt in via `meta.hardware.<id>`. Otherwise we'd
+  // emit speculative TPU commands for every NVIDIA recipe.
+  const declaredHw = recipe.meta?.hardware || {};
+  const compatibleHw = listCompatibleHardware(hwProfiles, variant, recipe)
+    .filter((id) => !hwProfiles[id]?.restricted || id in declaredHw);
   // Ensure default is first; de-dupe.
   const hwIds = Array.from(new Set([defaultHw, ...compatibleHw]));
 

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -3,12 +3,15 @@
  * writes static JSON files for the API.
  *
  * API URLs (friendly, no /api/ prefix):
- *   /models.json                    — all recipes index
- *   /{hf_id}.json                   — single recipe (e.g. /deepseek-ai/DeepSeek-V3.2.json)
- *   /strategies.json                — all strategies
- *   /strategies/single_node_tp.json — single strategy
- *   /taxonomy.json                  — controlled vocabulary
- *   /quickstart/8x-h100.json       — hardware quickstart
+ *   /models.json                                — all recipes index
+ *   /{hf_id}.json                               — single recipe (default-hw rendering)
+ *   /{hf_id}/strategies/{strategy}.json         — default-hw alternative (per strategy)
+ *   /{hf_id}/hw/{hw}.json                       — per-hardware rendering
+ *   /{hf_id}/hw/{hw}/strategies/{strategy}.json — per-(hw, strategy) alternative
+ *   /strategies.json                            — all strategies
+ *   /strategies/{strategy}.json                 — single strategy spec
+ *   /taxonomy.json                              — controlled vocabulary
+ *   /quickstart/8x-h100.json                    — hardware quickstart
  *
  * Run: node scripts/build-recipes-api.mjs
  */
@@ -18,6 +21,7 @@ import path from "path";
 import yaml from "js-yaml";
 import {
   pickDefaultHardware,
+  listCompatibleHardware,
   recommendStrategy,
   fitsSingleNode,
   pdFitsSingleNode,
@@ -230,17 +234,17 @@ function renderCommand(recipe, variantKey, strategy, hwId, nodeCount, features, 
 }
 
 // Build the canonical "recommended" rendering plus per-strategy alternatives
-// for one variant of a recipe. Inlines the strategy/hardware spec used by the
-// recommended choice so agents don't need to fetch /strategies/<id>.json or
-// /taxonomy.json. Returns { recommended, alternatives: { <strategy>: <rendered> } }
-// where the caller writes each alternative to its own file and replaces it
-// with a path link. Null for omni recipes or unknown variants.
-function buildVariantRendering(recipe, variantKey, strategies, taxonomy) {
+// for one variant of a recipe ON A SPECIFIC HARDWARE. Inlines the strategy/
+// hardware spec used by the recommended choice so agents don't need to fetch
+// /strategies/<id>.json or /taxonomy.json. Returns
+// { recommended, alternatives: { <strategy>: <rendered> } } where the caller
+// writes each alternative to its own file and replaces it with a path link.
+// Null for omni recipes or unknown variants.
+function buildVariantRendering(recipe, variantKey, hwId, strategies, taxonomy) {
   const variant = recipe.variants?.[variantKey];
   if (!variant) return null;
   if ((recipe.meta?.tasks || []).includes("omni")) return null;
 
-  const hwId = pickDefaultHardware(taxonomy.hardware_profiles || {}, variant, recipe);
   const hwProfile = taxonomy.hardware_profiles?.[hwId] || {};
   const compatible = recipe.compatible_strategies || [];
   const supportsMultiNode = compatible.some((s) => s.startsWith("multi_node_"));
@@ -338,24 +342,64 @@ function writeRecipeJson(hfId, payload) {
   return ordered;
 }
 
-// Render one variant's recommended_command + alternatives and write the
-// per-strategy alternative files; returns the recommended_command (with
-// `alternatives` populated as path strings) or null if the variant can't be
-// rendered. `altBaseHfId` controls the directory the alternative files land in
-// — for the parent variant it's the parent's hf_id; for a promoted variant
-// it's the variant's own model_id.
+// Render one variant's full hardware × strategy matrix and write all the
+// per-resource JSON files. Returns the parent's `recommended_command` object
+// (the default-hardware rendering with `alternatives` path map + `by_hardware`
+// path map) or null if the variant can't be rendered on its default hardware.
+//
+// `altBaseHfId` is the base directory for written files — the parent recipe's
+// hf_id, or a promoted variant's hf_id (e.g. zai-org/GLM-5.1-FP8). Output:
+//
+//   /<base>.json                          (parent — written by caller)
+//   /<base>/strategies/<s>.json           (default-hw alternatives — legacy path)
+//   /<base>/hw/<hw>.json                  (per-hw recommended + alternatives index)
+//   /<base>/hw/<hw>/strategies/<s>.json   (per-(hw, strategy) — non-default hw only)
+//
+// The default-hw entry in `by_hardware` re-uses the legacy `/strategies/`
+// paths to avoid duplicating identical files; non-default hw entries each get
+// their own `/hw/<hw>/strategies/` subtree.
 function renderAndWriteVariant(recipe, variantKey, altBaseHfId, strategies, taxonomy) {
-  const built = buildVariantRendering(recipe, variantKey, strategies, taxonomy);
-  if (!built) return null;
-  const { recommended, alternatives } = built;
-  const altLinks = {};
-  for (const [s, rendered] of Object.entries(alternatives)) {
-    const altPath = `${altBaseHfId}/strategies/${s}.json`;
-    writeJson(altPath, rendered);
-    altLinks[s] = `/${altPath}`;
+  const variant = recipe.variants?.[variantKey];
+  if (!variant) return null;
+  if ((recipe.meta?.tasks || []).includes("omni")) return null;
+
+  const hwProfiles = taxonomy.hardware_profiles || {};
+  const defaultHw = pickDefaultHardware(hwProfiles, variant, recipe);
+  const compatibleHw = listCompatibleHardware(hwProfiles, variant, recipe);
+  // Ensure default is first; de-dupe.
+  const hwIds = Array.from(new Set([defaultHw, ...compatibleHw]));
+
+  // Render every (variant × hardware) combo up front.
+  const renderedByHw = {};
+  for (const hwId of hwIds) {
+    const built = buildVariantRendering(recipe, variantKey, hwId, strategies, taxonomy);
+    if (built) renderedByHw[hwId] = built;
   }
-  if (Object.keys(altLinks).length) recommended.alternatives = altLinks;
-  return recommended;
+  if (!renderedByHw[defaultHw]) return null;
+
+  const byHardware = {};
+  for (const [hwId, { recommended, alternatives }] of Object.entries(renderedByHw)) {
+    const isDefault = hwId === defaultHw;
+    const stratDir = isDefault
+      ? `${altBaseHfId}/strategies`
+      : `${altBaseHfId}/hw/${hwId}/strategies`;
+    const altLinks = {};
+    for (const [s, rendered] of Object.entries(alternatives)) {
+      const altPath = `${stratDir}/${s}.json`;
+      writeJson(altPath, rendered);
+      altLinks[s] = `/${altPath}`;
+    }
+    if (Object.keys(altLinks).length) recommended.alternatives = altLinks;
+
+    const hwPath = `${altBaseHfId}/hw/${hwId}.json`;
+    writeJson(hwPath, recommended);
+    byHardware[hwId] = `/${hwPath}`;
+  }
+
+  // Parent's recommended_command = default-hw rendering + by_hardware index.
+  // Shallow clone so the on-disk per-hw default file stays clean of the index.
+  const defaultRecommended = { ...renderedByHw[defaultHw].recommended, by_hardware: byHardware };
+  return defaultRecommended;
 }
 
 const recipes = [];
@@ -500,13 +544,18 @@ const rcCount = recipes.filter((r) => r.recommended_command).length;
 const altCount = recipes.reduce(
   (n, r) => n + Object.keys(r.recommended_command?.alternatives || {}).length, 0
 );
+const hwIndexedCount = recipes.reduce(
+  (n, r) => n + Object.keys(r.recommended_command?.by_hardware || {}).length, 0
+);
 console.log(
-  `✓ JSON API: ${recipes.length} models (${rcCount} with recommended_command, ${altCount} alternative renderings), ${promotedCount} promoted variants, ${Object.keys(strategies).length} strategies` +
+  `✓ JSON API: ${recipes.length} models (${rcCount} with recommended_command, ${altCount} default-hw alternatives, ${hwIndexedCount} per-hw renderings), ${promotedCount} promoted variants, ${Object.keys(strategies).length} strategies` +
   (collisionCount ? ` (${collisionCount} variant collision${collisionCount > 1 ? "s" : ""} skipped)` : "")
 );
 console.log(`  /models.json`);
-console.log(`  /{hf_id}.json                       (e.g. /moonshotai/Kimi-K2.5.json)`);
-console.log(`  /{hf_id}/strategies/{strategy}.json (alternative renderings)`);
-console.log(`  /{variant_hf_id}.json               (promoted variants, e.g. /zai-org/GLM-5.1-FP8.json)`);
+console.log(`  /{hf_id}.json                                (e.g. /moonshotai/Kimi-K2.5.json)`);
+console.log(`  /{hf_id}/strategies/{strategy}.json          (default-hw alternatives)`);
+console.log(`  /{hf_id}/hw/{hw}.json                        (per-hardware rendering)`);
+console.log(`  /{hf_id}/hw/{hw}/strategies/{strategy}.json  (per-(hw, strategy) alternatives)`);
+console.log(`  /{variant_hf_id}.json                        (promoted variants, e.g. /zai-org/GLM-5.1-FP8.json)`);
 console.log(`  /strategies.json`);
 console.log(`  /taxonomy.json`);

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -263,7 +263,6 @@ function buildVariantRendering(recipe, variantKey, strategies, taxonomy) {
   recommended.strategy_spec = strategies[recommendedStrategy];
   recommended.hardware_profile = hwProfile;
 
-  const fitsSingle = fitsSingleNode(hwProfile, variant);
   const alternatives = {};
   for (const s of compatible) {
     if (s === recommendedStrategy) continue;
@@ -273,17 +272,8 @@ function buildVariantRendering(recipe, variantKey, strategies, taxonomy) {
       pdNodes = pickPdNodes(hwProfile, variant);
       if (pdNodes === "skip") continue;
       nc = 1;
-    } else if (s.startsWith("multi_node_")) {
-      // Skip multi-node alternatives when the variant fits on a single node —
-      // the recommended single-node form is already the right answer; emitting
-      // a 2-node command would imply TP=16 is needed when TP=8 suffices.
-      if (fitsSingle) continue;
-      nc = 2;
     } else {
-      // Skip single-node alternatives when the variant doesn't fit one node —
-      // the command would be syntactically valid but won't start.
-      if (!fitsSingle) continue;
-      nc = 1;
+      nc = s.startsWith("multi_node_") ? 2 : 1;
     }
     const feats = defaultFeaturesFor(recipe, hwId);
     const rendered = renderCommand(recipe, variantKey, s, hwId, nc, feats, strategies, taxonomy, pdNodes);

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -263,6 +263,7 @@ function buildVariantRendering(recipe, variantKey, strategies, taxonomy) {
   recommended.strategy_spec = strategies[recommendedStrategy];
   recommended.hardware_profile = hwProfile;
 
+  const fitsSingle = fitsSingleNode(hwProfile, variant);
   const alternatives = {};
   for (const s of compatible) {
     if (s === recommendedStrategy) continue;
@@ -272,8 +273,17 @@ function buildVariantRendering(recipe, variantKey, strategies, taxonomy) {
       pdNodes = pickPdNodes(hwProfile, variant);
       if (pdNodes === "skip") continue;
       nc = 1;
+    } else if (s.startsWith("multi_node_")) {
+      // Skip multi-node alternatives when the variant fits on a single node —
+      // the recommended single-node form is already the right answer; emitting
+      // a 2-node command would imply TP=16 is needed when TP=8 suffices.
+      if (fitsSingle) continue;
+      nc = 2;
     } else {
-      nc = s.startsWith("multi_node_") ? 2 : 1;
+      // Skip single-node alternatives when the variant doesn't fit one node —
+      // the command would be syntactically valid but won't start.
+      if (!fitsSingle) continue;
+      nc = 1;
     }
     const feats = defaultFeaturesFor(recipe, hwId);
     const rendered = renderCommand(recipe, variantKey, s, hwId, nc, feats, strategies, taxonomy, pdNodes);

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -20,6 +20,7 @@ import {
   pickDefaultHardware,
   recommendStrategy,
   fitsSingleNode,
+  pdFitsSingleNode,
   resolveCommand,
   computeDockerMeta,
   buildDockerRun,
@@ -139,25 +140,40 @@ function dockerize(command, argv, env, dockerMeta, port = 8000) {
   };
 }
 
+// Pick the per-role node count for a `pd_cluster` rendering.
+//   null   → co-located on a single node (variant fits the 2× PD VRAM budget)
+//   {prefill,decode} → one full node per role × N, derived from
+//                       ceil(variant.vram_minimum_gb / hwProfile.vram_gb)
+//   "skip" → would need >4 nodes per role; don't emit a fantasy cluster
+function pickPdNodes(hwProfile, variant) {
+  if (pdFitsSingleNode(hwProfile, variant)) return null;
+  const nodeVram = typeof hwProfile?.vram_gb === "number" ? hwProfile.vram_gb : 0;
+  const modelVram = variant?.vram_minimum_gb || 0;
+  if (nodeVram <= 0 || modelVram <= 0) return null;
+  const nodesPerRole = Math.ceil(modelVram / nodeVram);
+  if (nodesPerRole > 4) return "skip";
+  return { prefill: nodesPerRole, decode: nodesPerRole };
+}
+
 // Render one (recipe × variant × strategy × hardware × nodeCount) into the
 // public JSON shape — handles all three deploy_types (single_node, multi_node,
 // pd_cluster), snake_cases the keys, and attaches docker_run wrappers
 // alongside the pip-mode command/argv. The `features` argument controls
 // command synthesis but is intentionally NOT echoed back in the output —
 // agents read the actual args from `command`/`argv`.
-function renderCommand(recipe, strategy, hwId, nodeCount, features, strategies, taxonomy) {
+function renderCommand(recipe, variantKey, strategy, hwId, nodeCount, features, strategies, taxonomy, pdNodes = null) {
   let result;
   try {
     result = resolveCommand(
-      recipe, "default", strategy, hwId, features, strategies, taxonomy, [], nodeCount, null
+      recipe, variantKey, strategy, hwId, features, strategies, taxonomy, [], nodeCount, pdNodes
     );
   } catch (e) {
-    console.warn(`  ⚠ command synthesis failed for ${recipe.hf_id} / ${strategy}: ${e.message}`);
+    console.warn(`  ⚠ command synthesis failed for ${recipe.hf_id} / ${variantKey} / ${strategy}: ${e.message}`);
     return null;
   }
   if (!result) return null;
 
-  const variant = recipe.variants?.default || {};
+  const variant = recipe.variants?.[variantKey] || recipe.variants?.default || {};
   const hwProfile = taxonomy.hardware_profiles?.[hwId] || {};
   const dockerMeta = computeDockerMeta(recipe, variant, hwProfile);
   const env = result.env || {};
@@ -165,7 +181,7 @@ function renderCommand(recipe, strategy, hwId, nodeCount, features, strategies, 
   const base = {
     hardware: hwId,
     strategy,
-    variant: "default",
+    variant: variantKey,
     node_count: nodeCount,
     deploy_type: result.deployType,
     env,
@@ -213,16 +229,14 @@ function renderCommand(recipe, strategy, hwId, nodeCount, features, strategies, 
   };
 }
 
-// Build the canonical "recommended" rendering for an agent: default variant,
-// preferred hardware, recipe's default strategy (or recommendStrategy fallback),
-// and YAML-default feature set. Inlines the strategy/hardware spec used by the
+// Build the canonical "recommended" rendering plus per-strategy alternatives
+// for one variant of a recipe. Inlines the strategy/hardware spec used by the
 // recommended choice so agents don't need to fetch /strategies/<id>.json or
-// /taxonomy.json. Returns:
-//   { recommended, alternatives: { <strategy>: <rendered> } }
+// /taxonomy.json. Returns { recommended, alternatives: { <strategy>: <rendered> } }
 // where the caller writes each alternative to its own file and replaces it
-// with a path link in the recipe JSON. Null for omni recipes.
-function buildRecommendedCommand(recipe, strategies, taxonomy) {
-  const variant = recipe.variants?.default;
+// with a path link. Null for omni recipes or unknown variants.
+function buildVariantRendering(recipe, variantKey, strategies, taxonomy) {
+  const variant = recipe.variants?.[variantKey];
   if (!variant) return null;
   if ((recipe.meta?.tasks || []).includes("omni")) return null;
 
@@ -234,8 +248,15 @@ function buildRecommendedCommand(recipe, strategies, taxonomy) {
   const recommendedStrategy = recommendStrategy(recipe, hwProfile, recommendedNodeCount);
   const recommendedFeatures = defaultFeaturesFor(recipe, hwId);
 
+  // PD's node-count is independent of nodeCount — it lives in pdNodes per role.
+  const recommendedPdNodes = recommendedStrategy === "pd_cluster"
+    ? pickPdNodes(hwProfile, variant)
+    : null;
+  if (recommendedPdNodes === "skip") return null;
+
   const recommended = renderCommand(
-    recipe, recommendedStrategy, hwId, recommendedNodeCount, recommendedFeatures, strategies, taxonomy
+    recipe, variantKey, recommendedStrategy, hwId, recommendedNodeCount,
+    recommendedFeatures, strategies, taxonomy, recommendedPdNodes
   );
   if (!recommended) return null;
 
@@ -245,9 +266,17 @@ function buildRecommendedCommand(recipe, strategies, taxonomy) {
   const alternatives = {};
   for (const s of compatible) {
     if (s === recommendedStrategy) continue;
-    const nc = s.startsWith("multi_node_") ? 2 : 1;
+    let nc;
+    let pdNodes = null;
+    if (s === "pd_cluster") {
+      pdNodes = pickPdNodes(hwProfile, variant);
+      if (pdNodes === "skip") continue;
+      nc = 1;
+    } else {
+      nc = s.startsWith("multi_node_") ? 2 : 1;
+    }
     const feats = defaultFeaturesFor(recipe, hwId);
-    const rendered = renderCommand(recipe, s, hwId, nc, feats, strategies, taxonomy);
+    const rendered = renderCommand(recipe, variantKey, s, hwId, nc, feats, strategies, taxonomy, pdNodes);
     if (rendered) alternatives[s] = rendered;
   }
   return { recommended, alternatives };
@@ -283,7 +312,57 @@ writeJson("strategies.json", strategies);
 
 // ── Recipes ── (walks models/<hf_org>/<hf_repo>.yaml)
 const modelsDir = path.join(ROOT, "models");
+
+// Pre-scan: collect every recipe's hf_id so variant-promotion can detect
+// collisions with standalone YAMLs (e.g. inclusionAI/Ring-1T-FP8.yaml exists
+// as its own recipe, so a sibling recipe must not also promote a "Ring-1T-FP8"
+// variant).
+const allRecipeHfIds = new Set();
+for (const file of findYamlFiles(modelsDir)) {
+  const rel = path.relative(modelsDir, file);
+  const parts = rel.split(path.sep);
+  if (parts.length >= 2) {
+    const org = parts[0];
+    const repo = parts[parts.length - 1].replace(/\.(yaml|yml)$/, "");
+    allRecipeHfIds.add(`${org}/${repo}`);
+  }
+}
+
+// Write the public recipe JSON (parent or promoted) with HEAD_KEYS ordering.
+function writeRecipeJson(hfId, payload) {
+  const HEAD_KEYS = ["hf_id", "meta", "recommended_command"];
+  const ordered = {};
+  for (const k of HEAD_KEYS) if (k in payload) ordered[k] = payload[k];
+  for (const [k, v] of Object.entries(payload)) if (!HEAD_KEYS.includes(k)) ordered[k] = v;
+  writeJson(`${hfId}.json`, ordered);
+  return ordered;
+}
+
+// Render one variant's recommended_command + alternatives and write the
+// per-strategy alternative files; returns the recommended_command (with
+// `alternatives` populated as path strings) or null if the variant can't be
+// rendered. `altBaseHfId` controls the directory the alternative files land in
+// — for the parent variant it's the parent's hf_id; for a promoted variant
+// it's the variant's own model_id.
+function renderAndWriteVariant(recipe, variantKey, altBaseHfId, strategies, taxonomy) {
+  const built = buildVariantRendering(recipe, variantKey, strategies, taxonomy);
+  if (!built) return null;
+  const { recommended, alternatives } = built;
+  const altLinks = {};
+  for (const [s, rendered] of Object.entries(alternatives)) {
+    const altPath = `${altBaseHfId}/strategies/${s}.json`;
+    writeJson(altPath, rendered);
+    altLinks[s] = `/${altPath}`;
+  }
+  if (Object.keys(altLinks).length) recommended.alternatives = altLinks;
+  return recommended;
+}
+
 const recipes = [];
+const promotedIndexEntries = [];
+let promotedCount = 0;
+let collisionCount = 0;
+
 for (const file of findYamlFiles(modelsDir)) {
   const r = normalizeDates(readYaml(file));
   // Derive HF identity from path. Only `hf_id` is exposed in the public JSON;
@@ -310,53 +389,102 @@ for (const file of findYamlFiles(modelsDir)) {
     r.model = { install };
   }
   delete r.dependencies;
-  // Pre-render the canonical deploy command so agents don't have to reimplement
-  // command-synthesis. Mirrors the website's default selections.
-  const built = buildRecommendedCommand(r, strategies, taxonomy);
-  if (built) {
-    const { recommended, alternatives } = built;
-    // Write each alternative to its own file under /<hf_id>/strategies/<s>.json
-    // so the recipe JSON stays slim. The recipe links to them by path.
-    const altLinks = {};
-    for (const [s, rendered] of Object.entries(alternatives)) {
-      const altPath = `${hfOrg}/${hfRepo}/strategies/${s}.json`;
-      writeJson(altPath, rendered);
-      altLinks[s] = `/${altPath}`;
+  // Pre-render the canonical deploy command (default variant) so agents don't
+  // have to reimplement command-synthesis. Mirrors the website's default
+  // selections.
+  const parentHfId = `${hfOrg}/${hfRepo}`;
+  const defaultRecommended = renderAndWriteVariant(r, "default", parentHfId, strategies, taxonomy);
+  if (defaultRecommended) r.recommended_command = defaultRecommended;
+
+  // Promote each non-default variant whose `model_id` points at a distinct HF
+  // repo to its own top-level JSON endpoint, mirroring the HF URL convention.
+  // Renderings for promoted variants are gathered here and written after the
+  // parent JSON so we can store `json:` pointers in parent.variants.<v>.
+  const promotedRenderings = [];  // { variantKey, variantHfId, recommended }
+  for (const [variantKey, variantCfg] of Object.entries(r.variants || {})) {
+    if (variantKey === "default") continue;
+    const variantModelId = variantCfg?.model_id;
+    if (!variantModelId || typeof variantModelId !== "string" || !variantModelId.includes("/")) continue;
+    if (allRecipeHfIds.has(variantModelId)) {
+      // A standalone recipe at models/<variantModelId>.yaml exists — let it win.
+      console.warn(`  ⚠ skipping variant promotion: ${variantModelId} (variant of ${parentHfId}) collides with standalone recipe`);
+      collisionCount++;
+      continue;
     }
-    if (Object.keys(altLinks).length) recommended.alternatives = altLinks;
-    r.recommended_command = recommended;
+    const variantRecommended = renderAndWriteVariant(r, variantKey, variantModelId, strategies, taxonomy);
+    if (!variantRecommended) continue;
+    promotedRenderings.push({ variantKey, variantModelId, recommended: variantRecommended });
   }
+
+  // Annotate parent variants with `json:` pointers so consumers can navigate.
+  if (r.variants) {
+    for (const { variantKey, variantModelId } of promotedRenderings) {
+      r.variants[variantKey] = { ...r.variants[variantKey], json: `/${variantModelId}.json` };
+    }
+  }
+
   // strategy_overrides, compatible_strategies, default_strategy are synthesis
   // inputs whose effects are already baked into recommended_command + the
   // per-strategy alternative files (whose keys are the compatible_strategies
-  // set; the recommended one comes from default_strategy). Drop AFTER
-  // synthesis runs — buildRecommendedCommand reads them. The YAML on GitHub
-  // is the source of truth for anyone re-synthesizing.
+  // set; the recommended one comes from default_strategy). Drop AFTER all
+  // renderings (parent + promoted) have run — buildVariantRendering reads
+  // them. The YAML on GitHub is the source of truth for anyone re-synthesizing.
   delete r.strategy_overrides;
   delete r.compatible_strategies;
   delete r.default_strategy;
-  // Build the output object with `recommended_command` near the top — agents
-  // hit it before scrolling past the YAML body. Order: identity → headline →
-  // details → guide.
-  const HEAD_KEYS = ["hf_id", "meta", "recommended_command"];
-  const out = {};
-  for (const k of HEAD_KEYS) if (k in r) out[k] = r[k];
-  for (const [k, v] of Object.entries(r)) if (!HEAD_KEYS.includes(k)) out[k] = v;
+  // JSON at /<org>/<repo>.json — mirrors HF URL scheme.
+  const out = writeRecipeJson(parentHfId, r);
   recipes.push(out);
-  // JSON at /<org>/<repo>.json — mirrors HF URL scheme
-  writeJson(`${hfOrg}/${hfRepo}.json`, out);
+
+  // Now write the promoted-variant JSONs. Each is a self-contained recipe
+  // shape with hf_id / model.model_id rewritten and `variants.default` set to
+  // the variant's config (model_id stripped — it's at top-level now). The
+  // sibling-variant info is lost on purpose; consumers can follow
+  // `meta.derived_from` back to the parent for the full family view.
+  for (const { variantKey, variantModelId, recommended } of promotedRenderings) {
+    const variantCfg = r.variants?.[variantKey] || {};
+    const { model_id: _vMid, json: _vJson, ...variantCore } = variantCfg;
+    const promoted = {
+      ...r,  // share meta/features/guide/etc. with the parent
+      hf_id: variantModelId,
+      meta: { ...r.meta, derived_from: parentHfId, variant: variantKey },
+      model: { ...r.model, model_id: variantModelId },
+      variants: { default: variantCore },
+      recommended_command: recommended,
+    };
+    writeRecipeJson(variantModelId, promoted);
+    promotedIndexEntries.push({
+      hf_id: variantModelId,
+      title: promoted.meta?.title,
+      provider: promoted.meta?.provider,
+      derived_from: parentHfId,
+    });
+    promotedCount++;
+  }
 }
 
 // /models.json — slim discovery index (~5 KB). For agents that want to
 // enumerate recipes and follow links; per-recipe data lives at
-// `/<hf_id>.json` (the `json` pointer below).
-const index = recipes.map((r) => ({
-  hf_id: r.hf_id,
-  title: r.meta.title,
-  provider: r.meta.provider,
-  url: `/${r.hf_id}`,
-  json: `/${r.hf_id}.json`,
-}));
+// `/<hf_id>.json` (the `json` pointer below). Promoted variants (e.g.
+// zai-org/GLM-5.1-FP8) appear alongside parents so consumers can discover
+// them directly.
+const index = [
+  ...recipes.map((r) => ({
+    hf_id: r.hf_id,
+    title: r.meta.title,
+    provider: r.meta.provider,
+    url: `/${r.hf_id}`,
+    json: `/${r.hf_id}.json`,
+  })),
+  ...promotedIndexEntries.map((e) => ({
+    hf_id: e.hf_id,
+    title: e.title,
+    provider: e.provider,
+    url: `/${e.derived_from}`,  // site route — variant lives under the parent page
+    json: `/${e.hf_id}.json`,
+    derived_from: e.derived_from,
+  })),
+];
 writeJson("models.json", index);
 
 // ── Quickstart ──
@@ -373,10 +501,12 @@ const altCount = recipes.reduce(
   (n, r) => n + Object.keys(r.recommended_command?.alternatives || {}).length, 0
 );
 console.log(
-  `✓ JSON API: ${recipes.length} models (${rcCount} with recommended_command, ${altCount} alternative renderings), ${Object.keys(strategies).length} strategies`
+  `✓ JSON API: ${recipes.length} models (${rcCount} with recommended_command, ${altCount} alternative renderings), ${promotedCount} promoted variants, ${Object.keys(strategies).length} strategies` +
+  (collisionCount ? ` (${collisionCount} variant collision${collisionCount > 1 ? "s" : ""} skipped)` : "")
 );
 console.log(`  /models.json`);
 console.log(`  /{hf_id}.json                       (e.g. /moonshotai/Kimi-K2.5.json)`);
 console.log(`  /{hf_id}/strategies/{strategy}.json (alternative renderings)`);
+console.log(`  /{variant_hf_id}.json               (promoted variants, e.g. /zai-org/GLM-5.1-FP8.json)`);
 console.log(`  /strategies.json`);
 console.log(`  /taxonomy.json`);


### PR DESCRIPTION
## Summary

Two related gaps in the static JSON API, both surfaced on `zai-org/GLM-5.1`:

1. **`/zai-org/GLM-5.1/strategies/pd_cluster.json` was unusable.** The build script hardcoded `nodeCount=1` for every non-`multi_node_*` alternative. For PD that means co-located prefill + decode on a single node (TP=4 each). GLM-5.1 BF16 is 1786 GB; 4×H200=564 GB can't hold it. The emitted command was syntactically valid but wouldn't start.
2. **`/zai-org/GLM-5.1-FP8.json` 404'd.** FP8 ships as a variant inside `GLM-5.1.yaml` (`model_id: zai-org/GLM-5.1-FP8`), but the build script hardcoded `variantKey = "default"`, so no FP8 command was ever rendered. Consumers calling `get_model_recipe("zai-org/GLM-5.1-FP8")` walked into a dead link.

## Changes (all in `scripts/build-recipes-api.mjs`)

- `pickPdNodes(hwProfile, variant)` — derives per-role node count from `pdFitsSingleNode` + `ceil(vram_minimum_gb / node_vram_gb)`. Caps at 4 nodes/role to skip fantasy clusters.
- `renderCommand` and `buildVariantRendering` (renamed from `buildRecommendedCommand`) now take `variantKey` and `pdNodes`. The PD alternative loop picks `pdNodes` per variant; non-PD strategies are unchanged.
- **Variant promotion**: variants whose `model_id` points at a distinct HF repo (e.g. `zai-org/GLM-5.1-FP8`, `nvidia/GLM-5-NVFP4`) get top-level JSON endpoints mirroring the HF URL convention. Each promoted JSON is self-contained: `hf_id` and `model.model_id` rewritten, `variants.default` = the variant config, `meta.derived_from` points back to the parent.
- Parent JSONs gain `variants.<v>.json` pointers so consumers can navigate.
- `/models.json` includes promoted variants (`derived_from` set; `url` keeps pointing at the parent's site page since the website renders all variants on one page via `?variant=`).
- Collision check: standalone recipes like `inclusionAI/Ring-1T-FP8.yaml` win over any sibling's variant promotion. No collisions today, but the check is in place.

## Effects

| URL | Before | After |
|---|---|---|
| `/zai-org/GLM-5.1/strategies/pd_cluster.json` | BF16 co-located TP=4 (doesn't fit) | BF16 multi-node TP=16/role, `--nnodes 2 --master-addr \$PREFILL_NODE_1` |
| `/zai-org/GLM-5.1-FP8.json` | 404 | Self-contained FP8 recipe, `recommended_command` = single_node_tp on H200 |
| `/zai-org/GLM-5.1-FP8/strategies/pd_cluster.json` | Did not exist | TP=8 per role, 2-node NIXL PD — the endpoint users actually deploy |
| `/models.json` | 97 entries | 190 entries (97 parent + 93 promoted variants) |

No YAML schema changes. No Next.js route changes (CommandBuilder already switches variants via URL query on the parent page).

## Test plan

- [x] `node scripts/build-recipes-api.mjs` — `✓ JSON API: 97 models (91 with recommended_command, 334 alternative renderings), 93 promoted variants, 8 strategies`
- [x] `/zai-org/GLM-5.1-FP8.json` exists with `recommended_command.variant == "fp8"` and `argv` contains `zai-org/GLM-5.1-FP8`
- [x] `/zai-org/GLM-5.1-FP8/strategies/pd_cluster.json` shows `prefill.tp == 8`, `prefill.nodes == 1`, FP8 model_id in argv
- [x] `/zai-org/GLM-5.1/strategies/pd_cluster.json` shows `prefill.tp == 16`, `prefill.nodes == 2`, `--nnodes 2` in command
- [x] `/zai-org/GLM-5.1.json` has `variants.fp8.json == "/zai-org/GLM-5.1-FP8.json"`
- [x] `/nvidia/GLM-5-NVFP4.json` exists (cross-org variant), recommended hardware is B200 (NVFP4 → Blackwell)
- [x] `/inclusionAI/Ring-1T-FP8.json` (standalone recipe) untouched, no `derived_from`
- [x] Re-running the build is idempotent