### PR TITLE
Update MiniMax M2.5 H200 recipe

### DIFF
--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "minimax-m2.5"
   provider: "MiniMax"
   description: "MiniMax M2.5 MoE language model (230B total / 10B active) for coding, agent toolchains, and long-context reasoning — native FP8 checkpoint"
-  date_updated: 2026-04-17
+  date_updated: 2026-05-18
   difficulty: intermediate
   tasks:
     - text
@@ -11,13 +11,15 @@ meta:
   related_recipes: []
   hardware:
     h100: verified
+    h200: verified
     mi300x: verified
     mi325x: verified
     mi355x: verified
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2.5"
-  min_vllm_version: "0.19.0"
+  min_vllm_version: "0.20.2"
+  docker_image: "vllm/vllm-openai:v0.20.2"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"
@@ -25,7 +27,7 @@ model:
   base_args:
     - "--trust-remote-code"
     - "--compilation-config"
-    - '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
+    - '{"mode":3,"cudagraph_mode":"PIECEWISE","pass_config":{"fuse_minimax_qk_norm":true}}'
   base_env: {}
 
 features:
@@ -69,7 +71,26 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
-hardware_overrides: {}
+hardware_overrides:
+  hopper:
+    extra_args:
+      - "--max-num-seqs"
+      - "512"
+      - "--max-num-batched-tokens"
+      - "32768"
+      - "--kv-cache-dtype"
+      - "fp8"
+      - "--moe-backend"
+      - "triton"
+      - "--attention-backend"
+      - "FLASHINFER"
+      - "--enable-flashinfer-autotune"
+    extra_env:
+      PYTHONNOUSERSITE: "1"
+      SAFETENSORS_FAST_GPU: "1"
+      VLLM_USE_DEEP_GEMM: "0"
+      VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: "0"
+      VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
 strategy_overrides:
   single_node_tp:
@@ -108,25 +129,47 @@ guide: |
     -p 8000:8000 \
     --ipc=host \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai:minimax27 MiniMaxAI/MiniMax-M2.5 \
+    -e PYTHONNOUSERSITE=1 \
+    -e SAFETENSORS_FAST_GPU=1 \
+    -e VLLM_USE_DEEP_GEMM=0 \
+    -e VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER=0 \
+    -e VLLM_FLOAT32_MATMUL_PRECISION=high \
+    vllm/vllm-openai:v0.20.2 MiniMaxAI/MiniMax-M2.5 \
         --tensor-parallel-size 4 \
+        --max-num-seqs 512 \
+        --max-num-batched-tokens 32768 \
+        --kv-cache-dtype fp8 \
+        --moe-backend triton \
+        --attention-backend FLASHINFER \
+        --enable-flashinfer-autotune \
         --tool-call-parser minimax_m2 \
         --reasoning-parser minimax_m2 \
         --enable-auto-tool-choice \
-        --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+        --compilation-config '{"mode":3,"cudagraph_mode":"PIECEWISE","pass_config":{"fuse_minimax_qk_norm":true}}' \
         --trust-remote-code
   ```
 
   ## Launching the Server
 
-  ### NVIDIA — TP4
+  ### NVIDIA H200 — TP4
 
   ```bash
+  PYTHONNOUSERSITE=1 \
+  SAFETENSORS_FAST_GPU=1 \
+  VLLM_USE_DEEP_GEMM=0 \
+  VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER=0 \
+  VLLM_FLOAT32_MATMUL_PRECISION=high \
   vllm serve MiniMaxAI/MiniMax-M2.5 \
     --tensor-parallel-size 4 \
+    --max-num-seqs 512 \
+    --max-num-batched-tokens 32768 \
+    --kv-cache-dtype fp8 \
+    --moe-backend triton \
+    --attention-backend FLASHINFER \
+    --enable-flashinfer-autotune \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --compilation-config '{"mode":3,"cudagraph_mode":"PIECEWISE","pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice \
     --trust-remote-code
   ```


### PR DESCRIPTION
Summary: Mark MiniMax-M2.5 verified on H200 and align the recipe with SemiAnalysisAI/InferenceX#1354. Pin vLLM image/min version to v0.20.2 and add the FP8 KV cache, FlashInfer attention/autotune, Triton MoE, and MiniMax QK norm fusion settings.