### PR TITLE
[ROCm] update the minimax recipe to explicitly specify the attn backend

### DIFF
--- a/MiniMax/MiniMax-M2.md
+++ b/MiniMax/MiniMax-M2.md
@@ -177,8 +177,10 @@ You can use 2x or 4x MI300X/MI325X/MI350X/MI355X GPUs to launch this model with 
 
 - TP2 (2x MI300X/MI325X/MI350X/MI355X)
 ```bash
-VLLM_ROCM_USE_AITER=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
+VLLM_ROCM_USE_AITER=1 VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
   --tensor-parallel-size 2 \
+  --attention-backend ROCM_AITER_FA \
+  --block-size 16 \
   --tool-call-parser minimax_m2 \
   --reasoning-parser minimax_m2 \
   --enable-auto-tool-choice \
@@ -187,8 +189,10 @@ VLLM_ROCM_USE_AITER=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
 
 - TP4 (4x MI300X/MI325X/MI350X/MI355X)
 ```bash
-VLLM_ROCM_USE_AITER=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
+VLLM_ROCM_USE_AITER=1 VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
   --tensor-parallel-size 4 \
+  --attention-backend ROCM_AITER_FA \
+  --block-size 16 \
   --tool-call-parser minimax_m2 \
   --reasoning-parser minimax_m2 \
   --enable-auto-tool-choice \

--- a/MiniMax/MiniMax-M2.md
+++ b/MiniMax/MiniMax-M2.md
@@ -173,14 +173,15 @@ vllm serve MiniMaxAI/MiniMax-M2.7 \
 
 ### AMD GPU (ROCm)
 
-You can use 2x or 4x MI300X/MI325X/MI350X/MI355X GPUs to launch this model with [AITER](https://github.com/ROCm/aiter) acceleration enabled:
+You can use 2x or 4x MI300X/MI325X/MI350X/MI355X GPUs to launch this model with [AITER](https://github.com/ROCm/aiter) acceleration enabled.
+
+> **Note**: On vLLM v0.21.0+, dense full-attention models on ROCm landed on `ROCM_ATTN` default after [vLLM PR #36702](https://github.com/vllm-project/vllm/pull/36702). The commands below restore the aiter flash-attn by passing `--attention-backend ROCM_AITER_FA` and enable the AITER asm/hip paged-attention auto-dispatch with `VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1`.
 
 - TP2 (2x MI300X/MI325X/MI350X/MI355X)
 ```bash
 VLLM_ROCM_USE_AITER=1 VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
   --tensor-parallel-size 2 \
   --attention-backend ROCM_AITER_FA \
-  --block-size 16 \
   --tool-call-parser minimax_m2 \
   --reasoning-parser minimax_m2 \
   --enable-auto-tool-choice \
@@ -192,7 +193,6 @@ VLLM_ROCM_USE_AITER=1 VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1 vllm serve MiniMaxAI/M
 VLLM_ROCM_USE_AITER=1 VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1 vllm serve MiniMaxAI/MiniMax-M2.7 \
   --tensor-parallel-size 4 \
   --attention-backend ROCM_AITER_FA \
-  --block-size 16 \
   --tool-call-parser minimax_m2 \
   --reasoning-parser minimax_m2 \
   --enable-auto-tool-choice \

--- a/models/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.1.yaml
@@ -59,7 +59,14 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
-hardware_overrides: {}
+hardware_overrides:
+  amd:
+    extra_args:
+      - "--attention-backend"
+      - "ROCM_AITER_FA"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT: "1"
 
 strategy_overrides:
   single_node_tp:

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -91,6 +91,13 @@ hardware_overrides:
       VLLM_USE_DEEP_GEMM: "0"
       VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: "0"
       VLLM_FLOAT32_MATMUL_PRECISION: "high"
+  amd:
+    extra_args:
+      - "--attention-backend"
+      - "ROCM_AITER_FA"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT: "1"
 
 strategy_overrides:
   single_node_tp:

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -70,7 +70,14 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
-hardware_overrides: {}
+hardware_overrides:
+  amd:
+    extra_args:
+      - "--attention-backend"
+      - "ROCM_AITER_FA"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT: "1"
 
 strategy_overrides:
   single_node_tp:

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -79,9 +79,12 @@ hardware_overrides:
   amd:
     # First launch JIT-compiles AITER kernels (CK FP8 MoE, RMSNorm, activation);
     # expect a slow cold start on MI300X/MI325X/MI350X/MI355X.
-    extra_args: []
+    extra_args:
+      - "--attention-backend"
+      - "ROCM_AITER_FA"
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT: "1"
 
 strategy_overrides:
   single_node_tp:


### PR DESCRIPTION
Update MiniMax recipe on ROCm for MI300X/MI325X(gfx942), MI350X/MI355X(gfx950).

Related issue:
https://github.com/vllm-project/vllm/issues/43029

changes:
env: VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1 for extra perf
flag: --attention-backend ROCM_AITER_FA (restores v0.18.0 default backend for dense models after [PR #36702]
