### PR TITLE
Remove --no-async-scheduling from pd_cluster strategy

### DIFF
--- a/strategies/pd_cluster.yaml
+++ b/strategies/pd_cluster.yaml
@@ -23,7 +23,6 @@ prefill:
     - "--kv-transfer-config"
     - '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_load_failure_policy":"fail"}'
     - "--enforce-eager"
-    - "--no-async-scheduling"
   env:
     VLLM_USE_NCCL_SYMM_MEM: "1"
     NCCL_CUMEM_ENABLE: "1"


### PR DESCRIPTION
## Summary

Remove `--no-async-scheduling` from `strategies/pd_cluster.yaml` prefill args.

RayExecutorV2 (the default since vLLM 0.11.x) supports async scheduling, so this flag is no longer needed and was causing a performance regression for users on the default executor.

Closes #479

## Changes

- `strategies/pd_cluster.yaml`: removed `--no-async-scheduling` from prefill `vllm_args`

## Test plan

- [x] `node scripts/build-recipes-api.mjs` — JSON API builds cleanly
- [x] PD cluster commands no longer include the unnecessary `--no-async-scheduling` flag