### PR TITLE
Render `vllm serve --omni` with task tabs for omni recipes

### DIFF
--- a/.claude/skills/add-recipe/SKILL.md
+++ b/.claude/skills/add-recipe/SKILL.md
@@ -210,7 +210,7 @@ If the variant is `model_id`-overridden and the override is a different base mod
 - **Feature keys**: prefer `tool_calling`, `reasoning`, `spec_decoding`. Don't use `mtp` — it's been renamed across the repo.
 - **Strategy list**: MoE recipes usually support every strategy; dense recipes are limited to `single_node_tp` and `multi_node_tp` (TEP/DEP require MoE).
 - **Variants**: quantized variants reuse the base name (`fp8`, `nvfp4`, `int4`). If the quantized checkpoint is authored by someone else (e.g. `nvidia/*-NVFP4`), set `model_id:` inside the variant.
-- **Tasks**: `omni` means served via vLLM-Omni (offline Python, no `vllm serve`). The command builder hides the serve block for omni recipes — just put the Python usage in `guide:`.
+- **Tasks**: `omni` means served via vLLM-Omni (`vllm serve <model> --omni`). Add a top-level `omni:` block listing the task ids the recipe supports — bare strings for catalog defaults (`tasks: [t2i]`) or `{ id, model_id?, vram_minimum_gb?, description?, extra_args? }` overrides when a task swaps the checkpoint (Wan2.2) or needs per-task flags. Audio-only recipes set `omni.serve_binary: "vllm-omni serve"`. The catalog is `src/lib/omni-tasks.js`; do not add `--omni` to `model.base_args` (auto-injected).
 
 ## Validation checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Top-level keys, in this order:
 - `compatible_strategies[]` — subset of the 7 strategy ids. Dense models typically only get `single_node_tp` + `multi_node_tp`; MoE models can have all seven.
 - `hardware_overrides` — optional per-generation tweaks keyed by `hopper`, `blackwell`, `amd`. Each: `{ extra_args[], extra_env{} }`.
 - `strategy_overrides` — optional per-strategy tweaks (rare).
+- `omni` (optional) — vllm-omni online-serving config. Required when `meta.tasks` includes `omni`. Shape: `{ serve_binary?, port?, tasks: [...] }`. `tasks` accepts bare ids from the catalog (`t2i`, `i2i`, `t2v`, `i2v`, `ti2v`, `t2a`) or `{ id, model_id?, vram_minimum_gb?, description?, extra_args?, curl? }` overrides — Wan2.2 uses overrides to swap the served checkpoint per task. `serve_binary: "vllm-omni serve"` swaps the binary for handlers that don't ship in the `vllm` console-script (today: stable-audio-open). Catalog lives at `src/lib/omni-tasks.js`.
 - `guide` — markdown string (`|`-block), rendered with `react-markdown` + `remark-gfm` + `rehype-slug`.
 
 **VRAM formula**: `vram_minimum_gb = ceil(params × bytes × 1.2)`. Bytes per param: bf16/fp16=2, fp8/int8/awq/gptq=1, int4/nvfp4/fp4/mxfp4=0.5. For MoE, use total params (inactive experts still live in VRAM).
@@ -74,7 +75,7 @@ Top-level keys, in this order:
 
 - **Hardware is never blocked by VRAM.** Multi-node scales VRAM, so `command-synthesis.js` only uses VRAM as a display hint. Precision constraints (NVFP4/FP4 require Blackwell) are the only things that disable a hardware pill.
 - **Default hardware is always H200** (or B200 for Blackwell-constrained variants). `pickDefaultHardware` prefers NVIDIA over AMD; `loadPreferences` deliberately ignores AMD entries from localStorage so first-page-load is always H200.
-- **Omni recipes skip the command builder entirely** — `CommandBuilder` returns an "Served via vLLM-Omni" notice instead, because these models use offline Python scripts, not `vllm serve`. Detection: `meta.tasks` includes `omni`.
+- **Omni recipes render `vllm serve --omni`** via a dedicated `resolveOmniCommand` path (no strategy / multi-node / pd). The command builder adds a Task pill row (T2I / I2I / T2V / I2V / TI2V / T2A) above Hardware, with task-specific cURL examples in the popover. Detection: `meta.tasks` includes `omni`. The `--omni` flag is auto-injected, so don't add it to `model.base_args`.
 - **Multi-node uses vLLM mp (multiprocessing) backend**, not Ray. For TP/TEP every node runs the same command varying `--node-rank`; rank>0 adds `--headless`. For DEP, Node N adds `--data-parallel-start-rank = N × gpus_per_node`. The UI shows exactly two tabs (Head + Node 1) as a 2-node example.
 - **Taxonomy hardware specs** follow [inferencex.semianalysis.com/gpu-specs](https://inferencex.semianalysis.com/gpu-specs): B200 SXM is 180 GB/GPU (not the nameplate 192, which is pre-ECC), GB200/GB300 are **4-GPU compute trays** (NVL4, the NVL72 rack unit), B300 is 268 GB/GPU.
 - **Legacy Markdown under `DeepSeek/`, `Qwen/` etc. is read-only reference.** When migrating or updating a recipe, read those to extract flags and env, but write the YAML; don't edit the Markdown.

--- a/models/Qwen/Qwen-Image.yaml
+++ b/models/Qwen/Qwen-Image.yaml
@@ -20,6 +20,10 @@ model:
   base_args: []
   base_env: {}
 
+omni:
+  tasks:
+    - t2i
+
 dependencies:
   - note: "vLLM-Omni must be installed from source and pins vllm==0.18.0 for diffusion support"
     command: "git clone https://github.com/vllm-project/vllm-omni.git && cd vllm-omni && uv pip install -e . vllm==0.18.0"
@@ -36,11 +40,19 @@ variants:
   fp8:
     precision: fp8
     vram_minimum_gb: 24
-    description: "FP8 quantization (`--quantization fp8`). Recommended to pass `--ignored-layers \"img_mlp\"` for better quality."
+    description: "FP8 quantization with `img_mlp` kept at full precision for quality."
+    extra_args:
+      - "--quantization"
+      - "fp8"
+      - "--ignored-layers"
+      - "img_mlp"
   int8:
     precision: int8
     vram_minimum_gb: 24
     description: "INT8 quantization (`--quantization int8`)."
+    extra_args:
+      - "--quantization"
+      - "int8"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers.yaml
+++ b/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers.yaml
@@ -19,6 +19,23 @@ model:
   base_args: []
   base_env: {}
 
+omni:
+  # Each task picks a different Wan2.2 checkpoint — T2V/I2V are MoE-14B, TI2V
+  # is dense-5B. The model_id, VRAM hint, and description swap together when
+  # the user clicks a Task pill.
+  tasks:
+    - id: t2v
+      vram_minimum_gb: 152
+      description: "T2V MoE — 14B active parameters"
+    - id: i2v
+      model_id: "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+      vram_minimum_gb: 40
+      description: "I2V MoE — 14B active parameters"
+    - id: ti2v
+      model_id: "Wan-AI/Wan2.2-TI2V-5B-Diffusers"
+      vram_minimum_gb: 20
+      description: "Unified Text+Image-to-Video — dense 5B"
+
 dependencies:
   - note: "Pin vllm==0.12.0 for Wan2.2"
     command: "uv pip install vllm==0.12.0"
@@ -33,19 +50,7 @@ variants:
   default:
     precision: bf16
     vram_minimum_gb: 152
-    description: "T2V MoE with 14B active parameters"
-
-  i2v:
-    model_id: "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
-    precision: bf16
-    vram_minimum_gb: 40
-    description: "Image-to-Video MoE with 14B active parameters"
-
-  ti2v_5b:
-    model_id: "Wan-AI/Wan2.2-TI2V-5B-Diffusers"
-    precision: bf16
-    vram_minimum_gb: 20
-    description: "Unified Text-to-Video + Image-to-Video dense 5B"
+    description: "BF16 — variants moved to omni.tasks (T2V / I2V / TI2V each pick a different checkpoint)"
 
 compatible_strategies: []
 

--- a/models/meituan-longcat/LongCat-Image-Edit.yaml
+++ b/models/meituan-longcat/LongCat-Image-Edit.yaml
@@ -19,6 +19,10 @@ model:
   base_args: []
   base_env: {}
 
+omni:
+  tasks:
+    - i2i
+
 dependencies:
   - note: "vLLM-Omni must be installed from source with vllm==0.12.0 for LongCat-Image-Edit"
     command: "git clone https://github.com/vllm-project/vllm-omni.git && cd vllm-omni && uv pip install -e . vllm==0.12.0"
@@ -35,7 +39,7 @@ variants:
   default:
     precision: bf16
     vram_minimum_gb: 36
-    description: "BF16 weights; served via vLLM-Omni (offline inference)"
+    description: "BF16 weights; served via vLLM-Omni"
 
 compatible_strategies: []
 

--- a/models/stabilityai/stable-audio-open-1.0.yaml
+++ b/models/stabilityai/stable-audio-open-1.0.yaml
@@ -17,8 +17,20 @@ model:
   parameter_count: "1.2B"
   active_parameters: "1.2B"
   context_length: 0
-  base_args: []
+  base_args:
+    - "--trust-remote-code"
+    - "--enforce-eager"
+    - "--gpu-memory-utilization"
+    - "0.9"
   base_env: {}
+
+omni:
+  # Audio handler isn't shipped in the `vllm` console-script, so vllm-omni
+  # publishes its own `vllm-omni serve` entrypoint with the right model
+  # handler registered.
+  serve_binary: "vllm-omni serve"
+  tasks:
+    - t2a
 
 dependencies:
   - note: "Pin vllm==0.14.1 for Stable Audio Open"

--- a/models/stabilityai/stable-diffusion-3.5-medium.yaml
+++ b/models/stabilityai/stable-diffusion-3.5-medium.yaml
@@ -20,6 +20,10 @@ model:
   base_args: []
   base_env: {}
 
+omni:
+  tasks:
+    - t2i
+
 dependencies:
   - note: "Pin vllm==0.12.0 for Stable Diffusion 3.5"
     command: "uv pip install vllm==0.12.0"

--- a/models/stabilityai/stable-diffusion-3.5-medium.yaml
+++ b/models/stabilityai/stable-diffusion-3.5-medium.yaml
@@ -36,17 +36,20 @@ opt_in_features: []
 
 variants:
   default:
+    label: "Medium"
     precision: bf16
     vram_minimum_gb: 44
     description: "Stable Diffusion 3.5 medium (2.5B)"
 
   large:
+    label: "Large"
     model_id: "stabilityai/stable-diffusion-3.5-large"
     precision: bf16
     vram_minimum_gb: 24
     description: "Stable Diffusion 3.5 large (8.1B)"
 
   large_turbo:
+    label: "Large Turbo"
     model_id: "stabilityai/stable-diffusion-3.5-large-turbo"
     precision: bf16
     vram_minimum_gb: 24

--- a/models/zai-org/GLM-Image.yaml
+++ b/models/zai-org/GLM-Image.yaml
@@ -20,9 +20,16 @@ model:
   active_parameters: "16B"
   context_length: 4096
   base_args:
-    - "--omni"
     - "--trust-remote-code"
   base_env: {}
+
+omni:
+  # Same checkpoint serves both T2I and I2I — the task toggle in the UI just
+  # rewires the cURL endpoint (T2I → /v1/images/generations,
+  # I2I → /v1/chat/completions with a multimodal user turn).
+  tasks:
+    - t2i
+    - i2i
 
 dependencies:
   - note: "vllm-omni provides the diffusion decoder path"

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -4,7 +4,8 @@ import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package, Info, Zap, Globe, Wrench, Brain } from "lucide-react";
-import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, fitsSingleNode, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun } from "@/lib/command-synthesis";
+import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, fitsSingleNode, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun, resolveOmniCommand } from "@/lib/command-synthesis";
+import { resolveOmniTasks } from "@/lib/omni-tasks";
 import { TooltipProvider, InfoTip } from "@/components/ui/tooltip";
 import { detectPlaceholdersAll, substitute, substituteEnv, loadEndpoints, saveEndpoint, clearEndpoints } from "@/lib/cluster-endpoints";
 
@@ -321,8 +322,20 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   const router = useRouter();
   const pathname = usePathname();
 
+  // ── Omni tasks ── resolved from the recipe (catalog lookup); declared up here
+  // because both the omni and non-omni return paths reference these hooks.
+  const omniTasks = useMemo(() => resolveOmniTasks(recipe), [recipe]);
+
   // ── State ──
   const [variant, setVariant] = useState(searchParams.get("variant") || "default");
+
+  // Active omni task — drives the `vllm serve --omni` model_id swap (Wan2.2's
+  // T2V/I2V/TI2V) and the cURL endpoint/body shown in the Try-it popover.
+  const [omniTask, setOmniTask] = useState(() => {
+    const fromUrl = searchParams.get("task");
+    if (fromUrl && omniTasks.some((t) => t.id === fromUrl)) return fromUrl;
+    return omniTasks[0]?.id || "";
+  });
 
   // Compute default hardware: URL param > stored preference (if compatible) > smallest compatible profile
   // Smart default hardware: picks a profile compatible with the URL's variant
@@ -650,11 +663,14 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   );
 
   // Visual feedback when any rendered command changes. Covers single-node
-  // (result.command), multi-node (headCommand), and pd_cluster (prefill.command).
-  const commandFingerprint = result.command
+  // (result.command), multi-node (headCommand), pd_cluster (prefill.command),
+  // and omni (resolveCommand's modelId doesn't reflect omni task swaps, so
+  // include omniTask explicitly).
+  const commandFingerprint = (result.command
     || result.headCommand
     || result.prefill?.command
-    || "";
+    || "")
+    + (omniTask ? `|task:${omniTask}` : "");
   const [changed, setChanged] = useState(false);
   useEffect(() => {
     setChanged(true);
@@ -679,6 +695,14 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   );
 
   // ── Handlers ──
+  const selectOmniTask = (id) => {
+    setOmniTask(id);
+    // Default task id is omitted from the URL so a fresh page-load lands on
+    // the recipe author's intended starting task without a noisy `?task=…`.
+    const defaultId = omniTasks[0]?.id;
+    syncUrl({ task: id === defaultId ? "" : id });
+  };
+
   const selectVariant = (key) => {
     setVariant(key);
     syncUrl({ variant: key });
@@ -1000,13 +1024,71 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
         ? "pip"
         : installMode;
 
-  // Omni models are served via vLLM-Omni (offline Python inference), not `vllm serve`.
-  // Skip the command/strategy/feature UI but still surface Install + Hardware + Variant
-  // selectors so users can pick CUDA tag / pip vs docker and see which GPU and
-  // precision the recipe targets before jumping to the Guide for the actual script.
+  // Omni recipes serve via `vllm serve <model> --omni`. The command shape is
+  // simpler than the regular path (no strategy / multi-node / pd), but the
+  // surrounding affordances (Install tabs, Hardware pills, Variant pills) all
+  // still apply. Plus a Task pill row that swaps endpoint + curl body — and,
+  // for multi-checkpoint families like Wan2.2, the served model_id too.
   const isOmni = (recipe.meta?.tasks || []).includes("omni");
   if (isOmni) {
     const omniVariants = Object.entries(recipe.variants || {});
+    const showOmniVariants = omniVariants.length > 1;
+    const showOmniTaskRow = omniTasks.length > 1;
+    const activeTask = omniTasks.find((t) => t.id === omniTask) || omniTasks[0] || null;
+
+    // Render the `vllm serve --omni` command via the shared omni resolver.
+    // Falls back to a stub when the recipe has no omni.tasks declared yet
+    // (legacy omni-tagged recipes that haven't been migrated).
+    const omniRendered = activeTask
+      ? resolveOmniCommand(recipe, variant, activeTask, hwProfile)
+      : {
+          command: `${recipe.omni?.serve_binary || "vllm serve"} ${currentVariant.model_id || recipe.model?.model_id || "model"} --omni`,
+          env: {},
+          modelId: currentVariant.model_id || recipe.model?.model_id || "model",
+        };
+    const omniSubbedCommand = substitute(omniRendered.command, effectiveEndpoints);
+    const omniSubbedEnv = substituteEnv(omniRendered.env, effectiveEndpoints);
+
+    // Per-task verify command. `activeTask.example` knows the right endpoint
+    // (e.g. /v1/images/generations vs /v1/chat/completions multimodal) and
+    // payload shape; no chance for the generic /v1/chat/completions curl to
+    // mislead the user into hitting the wrong route.
+    const omniCurl = activeTask?.example
+      ? activeTask.example({
+          host: clientHost,
+          port: clientPortStr,
+          modelId: omniRendered.modelId,
+          prompt: undefined,
+        })
+      : verifyCmd;
+
+    // Recompute placeholders against the omni command set rather than the
+    // (unused-here) `result` from resolveCommand.
+    const omniPlaceholders = detectPlaceholdersAll(
+      omniRendered.command,
+      omniCurl,
+      ...Object.values(omniRendered.env || {}).filter((v) => typeof v === "string"),
+    );
+
+    const omniEndpointsControls = (
+      <EndpointsPopoverButton
+        isPd={false}
+        isMultiNode={false}
+        placeholders={omniPlaceholders}
+        endpoints={endpoints}
+        onChange={updateEndpoint}
+        onReset={resetEndpoints}
+      />
+    );
+
+    // Config caption: hw · task · precision. Same shape as the non-omni
+    // summary so the command-card header reads consistently across recipes.
+    const omniConfigSummary = [
+      hwProfile?.display_name || hwId,
+      activeTask?.label,
+      currentVariant.precision?.toUpperCase(),
+    ].filter(Boolean).join(" · ");
+
     return (
       <TooltipProvider>
         <div className="space-y-4">
@@ -1024,15 +1106,20 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
             <DependenciesBlock deps={dependencies} />
           )}
 
-          <div className="rounded-2xl border border-border bg-muted/20 px-5 py-4 text-sm">
-            <div className="font-medium mb-1 flex items-center gap-2">
-              <Sparkles size={14} className="text-vllm-yellow" />
-              Served via vLLM-Omni (offline inference)
-            </div>
-            <p className="text-muted-foreground text-xs leading-relaxed">
-              This model runs as an offline Python workflow, not a long-running <code className="font-mono text-[11px] px-1 py-0.5 rounded bg-foreground/5">vllm serve</code> endpoint.
-              See the <strong>Guide</strong> below for the exact inference script and parameters.
-            </p>
+          <div
+            className={`rounded-2xl overflow-hidden bg-[var(--command-bg)] border border-border transition-shadow ${changed ? "ring-2 ring-vllm-blue/30" : ""}`}
+          >
+            <SingleCommandBlock
+              command={omniSubbedCommand}
+              env={omniSubbedEnv}
+              verifyCmd={omniCurl}
+              benchCmd={benchCmd}
+              statusHeader={statusHeader}
+              installMode={effectiveInstallMode}
+              dockerMeta={dockerMeta}
+              configSummary={omniConfigSummary}
+              endpointsControls={omniEndpointsControls}
+            />
           </div>
 
           <div className="rounded-xl border border-border divide-y divide-border">
@@ -1081,7 +1168,35 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
               </div>
             </ConfigRow>
 
-            {omniVariants.length > 1 && (
+            {showOmniTaskRow && (
+              <ConfigRow
+                label="Task"
+                hint="Each task picks a vllm-omni handler endpoint and example payload. For multi-checkpoint families (Wan2.2 T2V/I2V/TI2V) the task also swaps the served model_id."
+              >
+                <PillGroup>
+                  {omniTasks.map((t) => (
+                    <Pill
+                      key={t.id}
+                      active={activeTask?.id === t.id}
+                      onClick={() => selectOmniTask(t.id)}
+                      title={[t.description, `Endpoint: ${t.endpoint}`].filter(Boolean).join("\n\n")}
+                    >
+                      <span className="font-semibold">{t.label}</span>
+                      {t.vramMinimumGb && (
+                        <span className="text-muted-foreground ml-1.5 font-mono">{t.vramMinimumGb} GB</span>
+                      )}
+                    </Pill>
+                  ))}
+                </PillGroup>
+                {activeTask?.description && (
+                  <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
+                    {activeTask.description}
+                  </p>
+                )}
+              </ConfigRow>
+            )}
+
+            {showOmniVariants && (
               <ConfigRow
                 label="Variant"
                 hint="VRAM shown is the minimum to LOAD the model (weights + runtime overhead). vLLM-Omni inference may need more for activations and intermediate tensors."

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -328,6 +328,125 @@ export function buildDockerArgv({ argv, env, meta, port = 8000 }) {
   ];
 }
 
+// Dedupe `--flag value` pairs by keeping only the LAST occurrence of each
+// flag. Matches shell "last wins" semantics and makes recipe/variant/
+// hardware overrides transparently shadow strategy defaults — the strategy
+// YAML sets a baseline, anything the recipe author writes later overrides
+// it without leaving stale pairs in the rendered command.
+function dedupeArgs(args) {
+  // Parse into units so (flag, value) stay together.
+  const units = [];
+  for (let i = 0; i < args.length; i++) {
+    const cur = args[i];
+    if (typeof cur === "string" && cur.startsWith("-")) {
+      const next = args[i + 1];
+      if (next !== undefined && !(typeof next === "string" && next.startsWith("-"))) {
+        units.push({ flag: cur, value: next });
+        i++;
+      } else {
+        units.push({ flag: cur });
+      }
+    } else {
+      units.push({ positional: cur });
+    }
+  }
+  // Last-wins: walk backward, mark first sighting of each flag as keep.
+  const seen = new Set();
+  const keep = new Array(units.length).fill(false);
+  for (let i = units.length - 1; i >= 0; i--) {
+    const u = units[i];
+    if (u.positional !== undefined) {
+      keep[i] = true;
+    } else if (!seen.has(u.flag)) {
+      seen.add(u.flag);
+      keep[i] = true;
+    }
+  }
+  const out = [];
+  for (let i = 0; i < units.length; i++) {
+    if (!keep[i]) continue;
+    const u = units[i];
+    if (u.positional !== undefined) out.push(u.positional);
+    else {
+      out.push(u.flag);
+      if (u.value !== undefined) out.push(u.value);
+    }
+  }
+  return out;
+}
+
+// Wrap values containing shell-special chars in single quotes so the rendered
+// command is paste-safe. Without this, JSON values like
+// `{"cudagraph_mode":"FULL_AND_PIECEWISE"}` trigger brace expansion and get
+// their double quotes stripped by bash.
+function shellQuote(s) {
+  if (typeof s !== "string" || s.length === 0) return s;
+  // Bare $VAR references must stay unquoted so bash expands them at runtime.
+  if (/^\$[A-Z_][A-Z0-9_]*$/.test(s)) return s;
+  if (/^[A-Za-z0-9_./=:@,+%-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Resolve the `vllm serve --omni` command for a vllm-omni recipe.
+ *
+ * Much simpler than the regular `resolveCommand`: no strategy logic, no
+ * multi-node, no router. Just a single online-serving process whose model id
+ * (and optionally extra args) can be swapped per omni task — e.g. Wan2.2 picks
+ * a different checkpoint for T2V vs I2V vs TI2V.
+ *
+ * `task` is the resolved entry from `resolveOmniTasks(recipe)`:
+ *   { id, modelId?, extraArgs?, ... }
+ *
+ * Outliers:
+ *   - `recipe.omni.serve_binary: "vllm-omni serve"` swaps the binary (today's
+ *     only user is stable-audio-open, whose handler doesn't ship in `vllm`).
+ *   - `recipe.omni.port` overrides the rendered `--port` flag (default 8000).
+ */
+export function resolveOmniCommand(recipe, variantKey, task, hwProfile) {
+  const variant = recipe.variants?.[variantKey] || recipe.variants?.default || {};
+  const modelId = task?.modelId || variant.model_id || recipe.model?.model_id || "unknown";
+  const gen = normalizeGeneration(hwProfile?.generation || hwProfile?.gpu_generation);
+  const isNvidia = hwProfile?.brand === "NVIDIA";
+
+  const env = {};
+  Object.assign(env, recipe.model?.base_env || {});
+  if (variantKey !== "default" && variant.extra_env) Object.assign(env, variant.extra_env);
+  const ho = recipe.hardware_overrides?.[gen]
+    || (isNvidia ? recipe.hardware_overrides?.nvidia : null);
+  if (ho?.extra_env) Object.assign(env, ho.extra_env);
+
+  const args = [];
+  if (recipe.model?.base_args) args.push(...recipe.model.base_args);
+  if (variantKey !== "default" && variant.extra_args) args.push(...variant.extra_args);
+  if (task?.extraArgs?.length) args.push(...task.extraArgs);
+  if (ho?.extra_args) args.push(...ho.extra_args);
+  // --omni is the toggle that puts vllm into omni-handler mode. Always emit it
+  // last — dedupeArgs's last-wins rule keeps it idempotent if the recipe also
+  // declares it in base_args.
+  args.push("--omni");
+
+  const serveBinary = recipe.omni?.serve_binary || "vllm serve";
+
+  const filtered = dedupeArgs(args.filter(Boolean));
+  const lines = [];
+  for (let i = 0; i < filtered.length; i++) {
+    const cur = filtered[i];
+    const next = filtered[i + 1];
+    if (cur.startsWith("-") && next !== undefined && !next.startsWith("-")) {
+      lines.push(`${cur} ${shellQuote(next)}`);
+      i++;
+    } else {
+      lines.push(cur);
+    }
+  }
+  const command = lines.length === 0
+    ? `${serveBinary} ${modelId}`
+    : `${serveBinary} ${modelId} \\\n  ${lines.join(" \\\n  ")}`;
+
+  return { command, env, modelId };
+}
+
 /**
  * Resolve a complete vllm serve command from recipe + user selections.
  *
@@ -659,65 +778,6 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
     }
 
     return env;
-  }
-
-  // Dedupe `--flag value` pairs by keeping only the LAST occurrence of each
-  // flag. Matches shell "last wins" semantics and makes recipe/variant/
-  // hardware overrides transparently shadow strategy defaults — the strategy
-  // YAML sets a baseline, anything the recipe author writes later overrides
-  // it without leaving stale pairs in the rendered command.
-  function dedupeArgs(args) {
-    // Parse into units so (flag, value) stay together.
-    const units = [];
-    for (let i = 0; i < args.length; i++) {
-      const cur = args[i];
-      if (typeof cur === "string" && cur.startsWith("-")) {
-        const next = args[i + 1];
-        if (next !== undefined && !(typeof next === "string" && next.startsWith("-"))) {
-          units.push({ flag: cur, value: next });
-          i++;
-        } else {
-          units.push({ flag: cur });
-        }
-      } else {
-        units.push({ positional: cur });
-      }
-    }
-    // Last-wins: walk backward, mark first sighting of each flag as keep.
-    const seen = new Set();
-    const keep = new Array(units.length).fill(false);
-    for (let i = units.length - 1; i >= 0; i--) {
-      const u = units[i];
-      if (u.positional !== undefined) {
-        keep[i] = true;
-      } else if (!seen.has(u.flag)) {
-        seen.add(u.flag);
-        keep[i] = true;
-      }
-    }
-    const out = [];
-    for (let i = 0; i < units.length; i++) {
-      if (!keep[i]) continue;
-      const u = units[i];
-      if (u.positional !== undefined) out.push(u.positional);
-      else {
-        out.push(u.flag);
-        if (u.value !== undefined) out.push(u.value);
-      }
-    }
-    return out;
-  }
-
-  // Wrap values containing shell-special chars in single quotes so the rendered
-  // command is paste-safe. Without this, JSON values like
-  // `{"cudagraph_mode":"FULL_AND_PIECEWISE"}` trigger brace expansion and get
-  // their double quotes stripped by bash.
-  function shellQuote(s) {
-    if (typeof s !== "string" || s.length === 0) return s;
-    // Bare $VAR references must stay unquoted so bash expands them at runtime.
-    if (/^\$[A-Z_][A-Z0-9_]*$/.test(s)) return s;
-    if (/^[A-Za-z0-9_./=:@,+%-]+$/.test(s)) return s;
-    return `'${s.replace(/'/g, "'\\''")}'`;
   }
 
   function formatCommand(args) {

--- a/src/lib/omni-tasks.js
+++ b/src/lib/omni-tasks.js
@@ -1,0 +1,253 @@
+/**
+ * Built-in catalog of vllm-omni online-serving task templates.
+ *
+ * Each task id maps to:
+ *   - label:       short pill text ("Text → Image")
+ *   - endpoint:    HTTP path the model handler binds to ("/v1/images/generations")
+ *   - method:      always "POST" today; carried so future GET endpoints don't need a schema bump
+ *   - example:     ({ host, port, modelId, prompt? }) → ready-to-paste curl command string
+ *
+ * Recipes opt in by listing task ids under `omni.tasks` in their YAML; per-task
+ * overrides (model_id swap, extra args, custom curl body) live next to the id.
+ * Source: docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/examples/online_serving/
+ */
+
+const SAMPLE_PROMPTS = {
+  t2i: "a dragon flying over the Green Mountains at sunset",
+  i2i: "Convert this image to a watercolor painting with soft pastel tones",
+  t2v: "A cinematic view of a futuristic city at sunset, smooth camera pan",
+  i2v: "A bear playing with yarn, smooth motion",
+  ti2v: "A bear playing with yarn, smooth motion",
+  t2a: "The sound of a cat purring softly",
+};
+
+function jsonCurl({ host, port, endpoint, body }) {
+  // jq-friendly pretty-printed JSON so the rendered curl reads cleanly even
+  // when copy-pasted into a terminal.
+  const indented = JSON.stringify(body, null, 2)
+    .split("\n")
+    .map((line, i) => (i === 0 ? line : `    ${line}`))
+    .join("\n");
+  return `curl -X POST http://${host}:${port}${endpoint} \\
+  -H "Content-Type: application/json" \\
+  -d '${indented}'`;
+}
+
+function formCurl({ host, port, endpoint, fields, outFile }) {
+  const lines = [`curl -X POST http://${host}:${port}${endpoint}`];
+  for (const [k, v] of Object.entries(fields)) {
+    lines.push(`  -F "${k}=${v}"`);
+  }
+  if (outFile) lines.push(`  --output ${outFile}`);
+  return lines.join(" \\\n");
+}
+
+export const OMNI_TASKS = {
+  t2i: {
+    label: "Text → Image",
+    endpoint: "/v1/images/generations",
+    method: "POST",
+    example: ({ host, port, prompt }) =>
+      `${jsonCurl({
+        host,
+        port,
+        endpoint: "/v1/images/generations",
+        body: {
+          prompt: prompt || SAMPLE_PROMPTS.t2i,
+          size: "1024x1024",
+          seed: 42,
+        },
+      })} \\
+  | jq -r '.data[0].b64_json' | base64 -d > output.png`,
+  },
+
+  i2i: {
+    label: "Image → Image",
+    endpoint: "/v1/chat/completions",
+    method: "POST",
+    example: ({ host, port, modelId, prompt }) =>
+      jsonCurl({
+        host,
+        port,
+        endpoint: "/v1/chat/completions",
+        body: {
+          model: modelId,
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: prompt || SAMPLE_PROMPTS.i2i },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: "data:image/png;base64,<BASE64_IMAGE>",
+                  },
+                },
+              ],
+            },
+          ],
+          extra_body: {
+            height: 1024,
+            width: 1024,
+            num_inference_steps: 50,
+            guidance_scale: 4.5,
+            seed: 42,
+          },
+        },
+      }),
+  },
+
+  t2v: {
+    label: "Text → Video",
+    endpoint: "/v1/videos",
+    method: "POST",
+    example: ({ host, port, prompt }) =>
+      formCurl({
+        host,
+        port,
+        endpoint: "/v1/videos/sync",
+        fields: {
+          prompt: prompt || SAMPLE_PROMPTS.t2v,
+          width: 832,
+          height: 480,
+          num_frames: 81,
+          fps: 16,
+          num_inference_steps: 40,
+          guidance_scale: 4.0,
+          seed: 42,
+        },
+        outFile: "output.mp4",
+      }),
+  },
+
+  i2v: {
+    label: "Image → Video",
+    endpoint: "/v1/videos",
+    method: "POST",
+    example: ({ host, port, prompt }) =>
+      formCurl({
+        host,
+        port,
+        endpoint: "/v1/videos/sync",
+        fields: {
+          prompt: prompt || SAMPLE_PROMPTS.i2v,
+          input_reference: "@/path/to/input.png",
+          width: 832,
+          height: 480,
+          num_frames: 81,
+          fps: 16,
+          num_inference_steps: 40,
+          guidance_scale: 5.0,
+          seed: 42,
+        },
+        outFile: "output.mp4",
+      }),
+  },
+
+  ti2v: {
+    label: "Text+Image → Video",
+    endpoint: "/v1/videos",
+    method: "POST",
+    example: ({ host, port, prompt }) =>
+      formCurl({
+        host,
+        port,
+        endpoint: "/v1/videos/sync",
+        fields: {
+          prompt: prompt || SAMPLE_PROMPTS.ti2v,
+          input_reference: "@/path/to/input.png",
+          width: 832,
+          height: 480,
+          num_frames: 81,
+          fps: 16,
+          num_inference_steps: 40,
+          guidance_scale: 5.0,
+          seed: 42,
+        },
+        outFile: "output.mp4",
+      }),
+  },
+
+  t2a: {
+    label: "Text → Audio",
+    endpoint: "/v1/audio/generate",
+    method: "POST",
+    example: ({ host, port, prompt }) =>
+      `${jsonCurl({
+        host,
+        port,
+        endpoint: "/v1/audio/generate",
+        body: {
+          input: prompt || SAMPLE_PROMPTS.t2a,
+          audio_length: 10.0,
+          negative_prompt: "Low quality",
+          guidance_scale: 7.0,
+          num_inference_steps: 100,
+          seed: 42,
+        },
+      })} --output output.wav`,
+  },
+};
+
+/**
+ * Resolve a recipe's task list to the catalog entries it actually uses.
+ *
+ * Accepts either:
+ *   omni: { tasks: ["t2i"] }                              — bare ids
+ *   omni: { tasks: [{ id: "i2i", model_id, vram_minimum_gb, description,
+ *                     extra_args, curl }, ...] }           — per-task overrides
+ *
+ * Per-task fields:
+ *   - model_id          swap the served checkpoint (Wan2.2 picks a different
+ *                       HF repo for T2V/I2V/TI2V)
+ *   - vram_minimum_gb   drives the hardware-fit hint when set (otherwise
+ *                       falls back to the recipe's default variant VRAM)
+ *   - description       short blurb shown next to the task pill
+ *   - extra_args        appended to the rendered `vllm serve --omni` command
+ *   - curl              static curl override (otherwise the built-in renderer
+ *                       interpolates host/port/modelId into a sample request)
+ *
+ * Returns: [{ id, label, endpoint, method, modelId?, vramMinimumGb?,
+ *             description?, extraArgs?, example }]
+ */
+export function resolveOmniTasks(recipe) {
+  const decl = recipe?.omni?.tasks;
+  if (!Array.isArray(decl) || decl.length === 0) return [];
+  const out = [];
+  for (const t of decl) {
+    const id = typeof t === "string" ? t : t?.id;
+    if (!id) continue;
+    const base = OMNI_TASKS[id];
+    if (!base) continue;
+    const override = typeof t === "string" ? {} : t;
+    const customCurl = override.curl;
+    out.push({
+      id,
+      label: override.label || base.label,
+      endpoint: override.endpoint || base.endpoint,
+      method: base.method,
+      modelId: override.model_id,
+      vramMinimumGb: override.vram_minimum_gb,
+      description: override.description,
+      extraArgs: override.extra_args || [],
+      example: customCurl ? () => customCurl : base.example,
+    });
+  }
+  return out;
+}
+
+/**
+ * Returns true when the recipe opts into vllm-omni online serving.
+ * Distinct from `meta.tasks` containing "omni" — a recipe can be omni-tagged
+ * (offline-only doc) without yet declaring `omni.tasks` for the command builder.
+ */
+export function hasOmniTasks(recipe) {
+  return resolveOmniTasks(recipe).length > 0;
+}
+
+/**
+ * Default render-time port for the omni command card.
+ * Same 8000 the rest of the site uses; recipe authors can override via
+ * `omni.port` (rendered into the served --port flag).
+ */
+export const OMNI_DEFAULT_PORT = 8000;


### PR DESCRIPTION
## Summary

Follow-up to #486. Replaces the "Served via vLLM-Omni (offline inference)" placeholder on omni recipe pages with a real `vllm serve --omni` command block, plus a **Task pill row** (T2I / I2I / T2V / I2V / TI2V / T2A) that swaps the example cURL between handler endpoints (e.g. `/v1/images/generations` vs multimodal `/v1/chat/completions`). For multi-checkpoint families like Wan2.2, the task also swaps the served `model_id`.

vLLM-Omni now ships a long-running serve binary (`vllm serve <model> --omni`), so the offline-only framing was out of date — these recipes deserve the same hardware / variant / install affordances every other recipe page has.

### What changed

- **New `src/lib/omni-tasks.js`** — catalog of vllm-omni task templates (`{ label, endpoint, method, example(host, port, modelId, prompt?) → curl }`) and `resolveOmniTasks(recipe)` resolver. Accepts bare ids (`tasks: [t2i]`) or `{ id, model_id?, vram_minimum_gb?, description?, extra_args?, curl? }` overrides.
- **New `resolveOmniCommand(recipe, variant, task, hwProfile)`** in `command-synthesis.js` — emits `vllm serve <model_id> [args] --omni`. `--omni` is auto-injected (last-wins dedupe makes it idempotent for recipes that previously declared it in `base_args`). `omni.serve_binary: "vllm-omni serve"` swaps the binary for handlers that don't ship in the `vllm` console-script (today: stable-audio-open).
- **`CommandBuilder.jsx`** — omni branch now renders the standard `SingleCommandBlock` with a per-task cURL popover, a Hardware pill row, an (optional) Task pill row when ≥2 tasks are declared, and the precision Variant row when ≥2 variants exist. URL syncs `?task=…` so links round-trip.
- **Recipes:**
  - `Wan2.2-T2V-A14B-Diffusers` — moved T2V/I2V/TI2V from `variants` into `omni.tasks` with per-task `model_id` + `vram_minimum_gb`. These were task variants, not precision variants.
  - `GLM-Image`, `Qwen-Image`, `stable-diffusion-3.5-medium`, `LongCat-Image-Edit`, `stable-audio-open-1.0` — declare `omni.tasks`. Removed redundant `--omni` from `base_args` (auto-injected).

### Schema additions (`omni:` block)

```yaml
omni:
  serve_binary: "vllm-omni serve"  # optional, default "vllm serve"
  tasks:
    - t2i                          # bare catalog id
    - id: i2v                      # OR a per-task override
      model_id: "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
      vram_minimum_gb: 40
      description: "I2V MoE — 14B active parameters"
```

Documented in `CLAUDE.md` and `.claude/skills/add-recipe/SKILL.md`.

## Test plan

- [ ] `node scripts/build-recipes-api.mjs` — 97 models, no parse errors
- [ ] Open `/Wan-AI/Wan2.2-T2V-A14B-Diffusers` → Task pills T2V/I2V/TI2V toggle the served model_id and the VRAM hint
- [ ] Open `/zai-org/GLM-Image` → Task pills T2I/I2I switch the cURL endpoint (one image-generations, one chat-completions multimodal)
- [ ] Open `/stabilityai/stable-audio-open-1.0` → command renders `vllm-omni serve …` not `vllm serve …`
- [ ] `?task=i2v` in URL restores the right task on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)