### PR TITLE
Update the recipe for Mistral-Medium-3.5-128B on MI300X

### DIFF
--- a/models/mistralai/Mistral-Medium-3.5-128B.yaml
+++ b/models/mistralai/Mistral-Medium-3.5-128B.yaml
@@ -213,6 +213,7 @@ guide: |
     --security-opt seccomp=unconfined --group-add video \
     --privileged --ipc=host -p 8000:8000 \
     -e SAFETENSORS_FAST_GPU=1 \
+    -e VLLM_ROCM_USE_AITER=1 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     vllm/vllm-openai-rocm:nightly mistralai/Mistral-Medium-3.5-128B \
       --tokenizer_mode mistral --config_format mistral --load_format mistral \

--- a/models/mistralai/Mistral-Medium-3.5-128B.yaml
+++ b/models/mistralai/Mistral-Medium-3.5-128B.yaml
@@ -80,10 +80,6 @@ hardware_overrides:
   amd:
     extra_args:
       - "--no-enable-prefix-caching"
-      # Auto-fit picks TP=1 on MI300X (154 GB model vs 192 GB/GPU) which doesn't work in practice;
-      # override to full-node TP.
-      - "--tensor-parallel-size"
-      - "8"
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       SAFETENSORS_FAST_GPU: "1"
@@ -199,14 +195,59 @@ guide: |
 
   ### AMD MI300X (ROCm)
 
-  **Text-only** Use the command builder with Text Only tag. Default **TP=8** on a full node; set `--tensor-parallel-size` to the number of GPUs you wish to use.
+  The command builder fits the model on one GPU on MI300X. This is prone to fail due to OOM. Use the following instead.
 
-  **Single GPU** Use `--tensor-parallel-size 1` and limit context, e.g.
+  **Single GPU** - Use `--tensor-parallel-size 1` and limit context, e.g.
   `--max-model-len 131072`. Without that limit, KV-cache allocation fails at the
   default **262144** context even in text-only mode. You can also reduce
   `--max-num-batched-tokens` or change `--gpu-memory-utilization` if you still hit OOM.
+  Here is a text-only example:
 
-  **Multimodal (text + image)** Enable the image inputs and set the limit of images per prompt as necessary:
+  ```bash
+  docker run --device=/dev/kfd --device=/dev/dri \
+    --security-opt seccomp=unconfined --group-add video \
+    --privileged --ipc=host -p 8000:8000 \
+    -e VLLM_ROCM_USE_AITER=1 \
+    -e SAFETENSORS_FAST_GPU=1 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-rocm:nightly mistralai/Mistral-Medium-3.5-128B \
+      --tokenizer_mode mistral \
+      --config_format mistral \
+      --load_format mistral \
+      --tensor-parallel-size 1 \
+      --no-enable-prefix-caching \
+      --enable-auto-tool-choice \
+      --tool-call-parser mistral \
+      --reasoning-parser mistral \
+      --max-model-len 131072 \
+      --language-model-only
+  ```
+
+  **Text-only** - Set `--tensor-parallel-size` to the number of GPUs you wish to use:
+
+  ```bash
+  docker run --device=/dev/kfd --device=/dev/dri \
+    --security-opt seccomp=unconfined --group-add video \
+    --privileged --ipc=host -p 8000:8000 \
+    -e VLLM_ROCM_USE_AITER=1 \
+    -e SAFETENSORS_FAST_GPU=1 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-rocm:nightly mistralai/Mistral-Medium-3.5-128B \
+      --tokenizer_mode mistral \
+      --config_format mistral \
+      --load_format mistral \
+      --tensor-parallel-size 8 \
+      --no-enable-prefix-caching \
+      --enable-auto-tool-choice \
+      --tool-call-parser mistral \
+      --reasoning-parser mistral \
+      --language-model-only
+  ```
+  
+  For `lm_eval` against a text-only server, pass `fix_mistral_regex=True` in
+  `--model_args` (Mistral 3.5 tokenizer quirk).
+
+  **Multimodal (text + image)** - Enable the image inputs and set the limit for images per prompt, here 1, as necessary:
 
   ```bash
   docker run --device=/dev/kfd --device=/dev/dri \
@@ -218,14 +259,12 @@ guide: |
     vllm/vllm-openai-rocm:nightly mistralai/Mistral-Medium-3.5-128B \
       --tokenizer_mode mistral --config_format mistral --load_format mistral \
       --tensor-parallel-size 8 \
+      --no-enable-prefix-caching \
       --enable-mm \
       --limit-mm-per-prompt '{"image": 1}' \
       --enable-auto-tool-choice --tool-call-parser mistral \
       --reasoning-parser mistral
   ```
-
-  For `lm_eval` against a text-only server, pass `fix_mistral_regex=True` in
-  `--model_args` (Mistral 3.5 tokenizer quirk).
 
   ### MI300X benchmarking (text-only)
 

--- a/models/mistralai/Mistral-Medium-3.5-128B.yaml
+++ b/models/mistralai/Mistral-Medium-3.5-128B.yaml
@@ -3,13 +3,15 @@ meta:
   slug: "mistral-medium-3.5"
   provider: "Mistral AI"
   description: "Mistral Medium 3.5 (128B) dense vision-language model with native FP8 weights and 256K context"
-  date_updated: 2026-04-30
+  date_updated: 2026-05-26
   difficulty: intermediate
   tasks:
     - multimodal
   related_recipes:
     - mistralai/Mistral-Large-3-675B-Instruct-2512
     - mistralai/Ministral-3-8B-Reasoning-2512
+  hardware:
+    mi300x: verified
 
 model:
   model_id: "mistralai/Mistral-Medium-3.5-128B"
@@ -68,10 +70,7 @@ variants:
   default:
     precision: fp8
     vram_minimum_gb: 154
-    description: "Native FP8 weights (vision tower / projector / lm_head kept in BF16); recommended on 8xH200 or 4xB200"
-    extra_args:
-      - "--tensor-parallel-size"
-      - "8"
+    description: "Native FP8 weights (vision tower / projector / lm_head kept in BF16); recommended on 8xH200, 8xMI300X, or 4xB200"
 
 compatible_strategies:
   - single_node_tp
@@ -81,9 +80,14 @@ hardware_overrides:
   amd:
     extra_args:
       - "--no-enable-prefix-caching"
+      # Auto-fit picks TP=1 on MI300X (154 GB model vs 192 GB/GPU) which doesn't work in practice;
+      # override to full-node TP.
+      - "--tensor-parallel-size"
+      - "8"
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       SAFETENSORS_FAST_GPU: "1"
+
 strategy_overrides: {}
 
 guide: |
@@ -102,8 +106,8 @@ guide: |
 
   ## Prerequisites
 
-  - Hardware: 8xH200 (recommended) or 4xB200; single B200 / MI300X also fits the
-    weights (~134 GB raw) but leaves little room for the 256K KV cache.
+  - Hardware: 8xH200 (recommended), 4xB200 or 2-8xMI300X; single B200 / MI300X also fits the
+    weights (~134 GB raw) but leaves little room for the 256K KV cache - see below.
   - vLLM **nightly** (Mistral 3.5 architecture support has not yet shipped in a
     stable release).
 
@@ -193,10 +197,52 @@ guide: |
   )
   ```
 
+  ### AMD MI300X (ROCm)
+
+  **Text-only** Use the command builder with Text Only tag. Default **TP=8** on a full node; set `--tensor-parallel-size` to the number of GPUs you wish to use.
+
+  **Single GPU** Use `--tensor-parallel-size 1` and limit context, e.g.
+  `--max-model-len 131072`. Without that limit, KV-cache allocation fails at the
+  default **262144** context even in text-only mode. You can also reduce
+  `--max-num-batched-tokens` or change `--gpu-memory-utilization` if you still hit OOM.
+
+  **Multimodal (text + image)** Enable the image inputs and set the limit of images per prompt as necessary:
+
+  ```bash
+  docker run --device=/dev/kfd --device=/dev/dri \
+    --security-opt seccomp=unconfined --group-add video \
+    --privileged --ipc=host -p 8000:8000 \
+    -e SAFETENSORS_FAST_GPU=1 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-rocm:nightly mistralai/Mistral-Medium-3.5-128B \
+      --tokenizer_mode mistral --config_format mistral --load_format mistral \
+      --tensor-parallel-size 8 \
+      --enable-mm \
+      --limit-mm-per-prompt '{"image": 1}' \
+      --enable-auto-tool-choice --tool-call-parser mistral \
+      --reasoning-parser mistral
+  ```
+
+  For `lm_eval` against a text-only server, pass `fix_mistral_regex=True` in
+  `--model_args` (Mistral 3.5 tokenizer quirk).
+
+  ### MI300X benchmarking (text-only)
+
+  Serving benchmark: `vllm bench serve` with 100 requests, max concurrency 32,
+  1024 input + 1024 output tokens per request.
+  Accuracy: `lm_eval` GSM8k (5-shot), `local-completions` backend.
+
+  | TP | Output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | GSM8k flexible | GSM8k strict |
+  |----|-------------:|---------------:|---------------:|---------------:|-------------:|
+  | 1  | 438 | 5719 | 55.2 | 0.928 | 0.876 |
+  | 2  | 530 | 5310 | 45.0 | 0.923 | 0.867 |
+  | 4  | 729 | 3317 | 33.0 | 0.928 | 0.873 |
+  | 8  | 915 | 2522 | 26.1 | 0.929 | 0.876 |
+
   ## Troubleshooting
 
-  - OOM at full 256K context on H200: drop `--max-model-len` to 131072 or 65536,
-    or set `--language-model-only` if you don't need vision.
+  - **OOM at full 256K context** on H200 or MI300X: drop `--max-model-len` to
+    **131072** or **65536**, or set `--language-model-only` if you don't need vision.
   - `reasoning_effort` rejected: only `"none"` and `"high"` are accepted by the
     chat template — anything else raises an exception.
 


### PR DESCRIPTION
## Summary
 * Adds MI300X (ROCm) verification and serving guidance for mistralai/Mistral-Medium-3.5-128B.
 * ~~Changes the MI300X recipe default TP from 1 to 8. The 1 is produced by auto-fit and results in OOM. TP 8 actually successfully serves the model.~~ edit. The default TP left as is, because currently there's no way to limit the change to single node MI300X, or even single node AMD hardware recipes.
 * Adds to the Guide: notes on running the model Text Only on a single or several MI300X GPUs, a multimodal docker example, some benchmark results.
 * Removes the misleading TP 8 from the recipe's default extra args. It will always be overwritten, and hence only serves to confuse.

 ## Evidence
  * Tested on a 8x MI300X node.
  * Tested the current builder generated version of the MI300X recipe with Text Only. Results in OOM.
  * Successfully served the model with Text Only with either setting `--max-model-len 131072` (for TP 1) or setting `--tensor-parallel-size` to 2,4 or 8. See the results from benchmarking and lm-eval below.
  * Debatable if the verification tag is justified, since the command builder recipe fails as is. 
  * In support of the tag being justified: five different versions of the model serving were tested successfully on MI300X end-to-end, and instructions for these servings are now detailed in the Guide section.
  * The `vllm/vllm-openai-rocm:nightly` digest at test time was `sha256:9b9f7a81cf07d3dab931b87a9ad3807da141a55494e639f0e091df0af82fd62f`
 * The multimodal serving was tested by curling to confirm reasonable responses. For example, "What is in this image?" with image url https://images.unsplash.com/photo-1501785888041-af3ef285b470 resulted in *"The image showcases a stunning natural landscape dominated by a pristine, turquoise lake surrounded by towering, rugged mountains. The lake is incredibly clear, reflecting the vivid colors of the surroundings. There are several wooden rowboats on the lake, with a couple of people in some of them. The mountains are steep and forested, covered with dense green trees up to a certain altitude, beyond which the rocky, craggy peaks rise sharply. The sky is mostly clear with some wispy clouds, and the overall scene is bathed in bright, natural sunlight, enhancing the vividness of the colors. The environment exudes a sense of tranquility and untouched beauty, characteristic of remote alpine regions."*
 * The changes have been verified with `node scripts/build-recipes-api.mjs`
### Mistral-Medium-3.5-128B on MI300X — benchmarks
**Setup:** 8× MI300X · `vllm/vllm-openai-rocm:nightly` · `mistralai/Mistral-Medium-3.5-128B` · text-only · `vllm bench serve` (100 req, concurrency 32, 1024 in + 1024 out tokens per req)

| TP | Output tok/s | Mean TTFT (ms) | Mean TPOT (ms) | Duration (s) |
|----|-------------:|---------------:|---------------:|-------------:|
| 1  | 438 | 5719 | 55.2 | 234 |
| 2  | 530 | 5310 | 45.0 | 193 |
| 4  | 729 | 3317 | 33.0 | 141 |
| 8  | 915 | 2522 | 26.1 | 112 |

### GSM8k (`lm_eval`, 5-shot)

| TP | flexible | strict |
|----|----------|--------|
| 1  | 0.928 | 0.876 |
| 2  | 0.923 | 0.867 |
| 4  | 0.928 | 0.873 |
| 8  | 0.929 | 0.876 |
