### PR TITLE
Add DGX Station guidance for DeepSeek V4 Flash

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -89,17 +89,22 @@ hardware_overrides:
   blackwell:
     extra_args:
       - "--attention_config.use_fp4_indexer_cache=True"
+      - "--moe-backend"
+      - "deep_gemm_mega_moe"
 
 strategy_overrides:
   single_node_tp:
     # Latency-oriented TP-only deployment: no expert parallelism (single_node_tp
-    # strategy doesn't add --enable-expert-parallel). Autotune is disabled to
-    # minimize startup time.
+    # strategy doesn't add --enable-expert-parallel) and no MoE mega-kernel
+    # backend on Blackwell. Autotune is disabled to minimize startup time.
     tp: 8
     extra_args:
       - "--no-enable-flashinfer-autotune"
     hardware_overrides:
       blackwell:
+        # Replaces recipe-level blackwell override: keeps the FP4 indexer cache
+        # but drops --moe-backend deep_gemm_mega_moe (TP-only path uses the
+        # default MoE backend).
         extra_args:
           - "--attention_config.use_fp4_indexer_cache=True"
   single_node_dep:

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -89,22 +89,17 @@ hardware_overrides:
   blackwell:
     extra_args:
       - "--attention_config.use_fp4_indexer_cache=True"
-      - "--moe-backend"
-      - "deep_gemm_mega_moe"
 
 strategy_overrides:
   single_node_tp:
     # Latency-oriented TP-only deployment: no expert parallelism (single_node_tp
-    # strategy doesn't add --enable-expert-parallel) and no MoE mega-kernel
-    # backend on Blackwell. Autotune is disabled to minimize startup time.
+    # strategy doesn't add --enable-expert-parallel). Autotune is disabled to
+    # minimize startup time.
     tp: 8
     extra_args:
       - "--no-enable-flashinfer-autotune"
     hardware_overrides:
       blackwell:
-        # Replaces recipe-level blackwell override: keeps the FP4 indexer cache
-        # but drops --moe-backend deep_gemm_mega_moe (TP-only path uses the
-        # default MoE backend).
         extra_args:
           - "--attention_config.use_fp4_indexer_cache=True"
   single_node_dep:

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -241,7 +241,7 @@ guide: |
     --tokenizer-mode deepseek_v4 --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice --reasoning-parser deepseek_v4 \
     --max-cudagraph-capture-size 128 \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"rejection_sample_method":"synthetic","synthetic_acceptance_length":3}'
+    --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
   ```
 
   ### H200 Single-Node PD (Mooncake)

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -233,21 +233,15 @@ guide: |
 
   ```bash
   vllm serve deepseek-ai/DeepSeek-V4-Flash \
-    --host 0.0.0.0 --port 8888 \
     --tensor-parallel-size 1 --pipeline-parallel-size 1 \
     --kv-cache-dtype fp8 --trust-remote-code --block-size 256 \
-    --enable-prefix-caching --gpu-memory-utilization 0.92 \
+    --gpu-memory-utilization 0.92 \
     --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
     --attention_config.use_fp4_indexer_cache True \
     --tokenizer-mode deepseek_v4 --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice --reasoning-parser deepseek_v4 \
-    --no-disable-hybrid-kv-cache-manager --disable-uvicorn-access-log \
     --max-cudagraph-capture-size 128 \
-    --prefix-cache-retention-interval auto \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"rejection_sample_method":"synthetic","synthetic_acceptance_length":3}' \
-    --max-model-len 1048576 \
-    --max-num-batched-tokens 8192 \
-    --max-num-seqs 16
+    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"rejection_sample_method":"synthetic","synthetic_acceptance_length":3}'
   ```
 
   ### H200 Single-Node PD (Mooncake)

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "deepseek-v4-flash"
   provider: "DeepSeek"
   description: "DeepSeek V4 MoE model with hybrid CSA+HCA attention, manifold-constrained hyper-connections, and three-tier reasoning (Non-think / Think High / Think Max)."
-  date_updated: 2026-04-24
+  date_updated: 2026-05-28
   difficulty: hard
   tasks:
     - text
@@ -15,6 +15,7 @@ meta:
     gb200: verified
     b300: verified
     gb300: verified
+    dgx_station_gb300: verified
     mi300x: unsupported
     mi325x: unsupported
     mi355x: unsupported
@@ -222,10 +223,32 @@ guide: |
 
   ## Recommended deployment
 
-  Non-disaggregated serving on any supported hardware: single-node DP + EP with
+  Non-disaggregated serving on multi-GPU supported hardware: single-node DP + EP with
   `--data-parallel-size 4`. Fills a GB200 NVL4 tray exactly; uses 4 of 8 GPUs per
   replica on H200/B200/B300 (leaving headroom for throughput-vs-latency tuning).
-  For disaggregated prefill/decode on GB200, use the PD Cluster tab.
+  On DGX Station, use the single-GPU launch below. For disaggregated prefill/decode
+  on GB200, use the PD Cluster tab.
+
+  ### DGX Station Single-GPU
+
+  ```bash
+  vllm serve deepseek-ai/DeepSeek-V4-Flash \
+    --host 0.0.0.0 --port 8888 \
+    --tensor-parallel-size 1 --pipeline-parallel-size 1 \
+    --kv-cache-dtype fp8 --trust-remote-code --block-size 256 \
+    --enable-prefix-caching --gpu-memory-utilization 0.92 \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
+    --attention_config.use_fp4_indexer_cache True \
+    --tokenizer-mode deepseek_v4 --tool-call-parser deepseek_v4 \
+    --enable-auto-tool-choice --reasoning-parser deepseek_v4 \
+    --no-disable-hybrid-kv-cache-manager --disable-uvicorn-access-log \
+    --max-cudagraph-capture-size 128 \
+    --prefix-cache-retention-interval auto \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"rejection_sample_method":"synthetic","synthetic_acceptance_length":3}' \
+    --max-model-len 1048576 \
+    --max-num-batched-tokens 8192 \
+    --max-num-seqs 16
+  ```
 
   ### H200 Single-Node PD (Mooncake)
 


### PR DESCRIPTION
## Summary
- Mark DeepSeek-V4-Flash as verified on DGX Station.
- Add the DGX Station single-GPU launch command with DeepSeek V4 parsers, Blackwell FP4 indexer cache, compilation/cudagraph tuning, and MTP speculative decoding.
- Clarify that the DP+EP recommendation applies to multi-GPU hardware.

## Testing
- ruby -e 'require "yaml"; files=Dir["{models,strategies}/*.yaml"]+Dir["models/**/*.yaml"]+["taxonomy.yaml"]; files.uniq.each{|f| YAML.load_file(f)}; puts "all-yaml-ok"'\n- git diff --check