### PR TITLE
Step-3.7-Flash: pin dedicated Docker image, prefer over pip

### DIFF
--- a/models/stepfun-ai/Step-3.7-Flash.yaml
+++ b/models/stepfun-ai/Step-3.7-Flash.yaml
@@ -18,6 +18,10 @@ model:
   model_id: "stepfun-ai/Step-3.7-Flash"
   min_vllm_version: "nightly"
   nightly_required: true
+  docker_image: "vllm/vllm-openai:stepfun37"
+  install:
+    docker:
+      note: "Dedicated Step-3.7 image — preferred over the nightly pip wheel until support lands in vllm:latest."
   architecture: moe
   parameter_count: "198B"
   active_parameters: "11B"


### PR DESCRIPTION
## Summary

Adds a dedicated Docker install option for **Step-3.7-Flash** and makes it the preferred install path over the nightly pip wheel.

- Pin `model.docker_image: "vllm/vllm-openai:stepfun37"` so the Install block's Docker tab (and the `docker run` wrapping) uses the dedicated Step-3.7 image instead of the generic `vllm/vllm-openai:nightly` default.
- Declare `install.docker` first so Docker is the default install mode in the command builder, taking priority over pip until support lands in `vllm:latest`.

The guide already references `docker pull vllm/vllm-openai:stepfun37`, so the structured Install block is now consistent with it.

## Validation

`node scripts/build-recipes-api.mjs` → `✓ JSON API: 98 models, 8 strategies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)