### PR TITLE
Fix restricted hardware leaking into global preference

### DIFF
--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -364,7 +364,13 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     if (!searchParams.get("hardware") && prefs.hardware) {
       const v = recipe.variants?.[variant] || recipe.variants?.default || {};
       const prefProfile = taxonomy.hardware_profiles?.[prefs.hardware];
-      if (prefProfile?.brand === "NVIDIA" && isPrecisionCompatible(prefProfile, v) && isHardwareSupported(recipe, prefs.hardware)) {
+      // Mirror the picker filter: a `restricted` profile (DGX Station, TPU)
+      // only applies to recipes that explicitly declare it in `meta.hardware`.
+      // Without this, selecting DGX on one recipe would leak into the global
+      // preference and leave every other recipe with no rendered pill selected.
+      const declaredHere = prefs.hardware in (recipe.meta?.hardware || {});
+      const restrictedElsewhere = prefProfile?.restricted && !declaredHere;
+      if (prefProfile?.brand === "NVIDIA" && !restrictedElsewhere && isPrecisionCompatible(prefProfile, v) && isHardwareSupported(recipe, prefs.hardware)) {
         setHwId(prefs.hardware);
         restoredFitsHw = prefProfile;
       }


### PR DESCRIPTION
Selecting a `restricted` profile (DGX Station, TPU) on a recipe that declares it saved that id as the global hardware preference. Other recipes then restored it on mount even though the picker hides restricted profiles they don't declare — so no hardware pill rendered as selected (the "no default selection" regression after DGX shipped).

Mirror the picker's filter in the preference-restoration guard: a restricted profile is only restored for recipes that declare it in `meta.hardware`. Otherwise restoration is skipped and hwId falls back to the recipe's default hardware as before.