### PR TITLE
[Hardware] Add minimal Ascend NPU Docker foundation

### DIFF
--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -32,6 +32,8 @@ import {
   computeDockerMeta,
   buildDockerRun,
   buildDockerArgv,
+  buildAscendDockerRun,
+  buildAscendDockerArgv,
 } from "../src/lib/command-synthesis.js";
 
 const ROOT = process.cwd();
@@ -139,6 +141,14 @@ function defaultFeaturesFor(recipe, hwId) {
 // Wrap a rendered (command, argv) pair in `docker run`. Returns
 // { docker_command, docker_argv } so each form has its docker counterpart.
 function dockerize(command, argv, env, dockerMeta, port = 8000) {
+  if (dockerMeta.isAscend) {
+    return {
+      docker_command: buildAscendDockerRun({
+        command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, port,
+      }),
+      docker_argv: buildAscendDockerArgv({ argv, env, meta: dockerMeta, port }),
+    };
+  }
   return {
     docker_command: buildDockerRun({
       command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, port,

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package, Info, Zap, Globe, Wrench, Brain } from "lucide-react";
-import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, isVariantHardwareSupported, fitsSingleNode, isHardwareScalable, isKvStoreBrandSupported, variantRunsOnHardware, pickFittingVariant, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun, resolveOmniCommand, pdPoolModes, defaultModeFor, isModeSupported, isModeAllowedForVariant, resolveModeKey, isFeatureAllowedForStrategy, isKvOffloadAllowedForStrategy } from "@/lib/command-synthesis";
+import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, isVariantHardwareSupported, fitsSingleNode, isHardwareScalable, isKvStoreBrandSupported, variantRunsOnHardware, pickFittingVariant, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun, buildAscendDockerRun, resolveOmniCommand, pdPoolModes, defaultModeFor, isModeSupported, isModeAllowedForVariant, resolveModeKey, isFeatureAllowedForStrategy, isKvOffloadAllowedForStrategy } from "@/lib/command-synthesis";
 import { resolveOmniTasks } from "@/lib/omni-tasks";
 import { TooltipProvider, InfoTip } from "@/components/ui/tooltip";
 import { detectPlaceholdersAll, substitute, substituteEnv, loadEndpoints, saveEndpoint, clearEndpoints } from "@/lib/cluster-endpoints";
@@ -1549,9 +1549,10 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   // in sync without requiring the user to re-click.
   const pipEffectivelyHidden =
     recipe.model?.install?.pip === false || hwProfile?.generation === "tpu";
+  const ascendPipHidden = dockerMeta.isAscend;
   const dockerEffectivelyHidden = recipe.model?.install?.docker === false;
   const effectiveInstallMode =
-    installMode === "pip" && pipEffectivelyHidden
+    installMode === "pip" && (pipEffectivelyHidden || ascendPipHidden)
       ? "docker"
       : installMode === "docker" && dockerEffectivelyHidden
         ? "pip"
@@ -2645,7 +2646,9 @@ function SingleCommandBlock({ command, env, companions, verifyCmd, benchCmd, sta
   // block tabs above). Pip mode: prelude = `export KEY=VAL` lines.
   const prelude = isDocker ? "" : envToExports(env);
   const displayCommand = isDocker
-    ? buildDockerRun({ command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+    ? dockerMeta.isAscend
+      ? buildAscendDockerRun({ command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+      : buildDockerRun({ command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
     : command;
   // A companion process may ride along (`companions[]` from resolveCommand —
   // a feature's `companion:` or the active kv_offload option's, e.g.
@@ -2774,7 +2777,7 @@ function InstallBlock({ recipe, variant, dockerMeta, installMode, setInstallMode
   const pipHidden = pipCfg === false;
   const dockerHidden = dockerCfg === false;
   const [open, setOpen] = useState(false);
-  const { isAmd, isTpu, image: dockerImage, brandKey, cudaMap } = dockerMeta;
+  const { isAmd, isTpu, isAscend, image: dockerImage, brandKey, cudaMap } = dockerMeta;
   // A variant may require a newer vLLM than the recipe baseline (e.g. the DSpark
   // checkpoint needs 0.25.0, currently nightly). Take the higher version and OR
   // the nightly flag so the Install block reflects the selected checkpoint.
@@ -2823,10 +2826,13 @@ uv pip install -U vllm --torch-backend auto`;
   // override at `model.install.docker.command` still wins for recipes that
   // need a custom build step. The CUDA-version selector (below, next to Copy)
   // drives the tag suffix for NVIDIA; AMD / TPU pull a single image.
+  // Ascend also uses one image selected for the active Atlas generation.
   const defaultDockerCmd = `docker pull ${dockerImage}`;
   const dockerCmd = dockerCfg?.command || defaultDockerCmd;
   const defaultDockerNote = isTpu
     ? "TPU builds are published by vllm-project/tpu-inference. See the Trillium and Ironwood tpu-recipes for pinned image tags and exact deployment flags."
+    : isAscend
+      ? "Ascend recipes should pin the vLLM Ascend image tested on the selected Atlas system."
     : isAmd
       ? undefined
       : cudaMap
@@ -2849,9 +2855,11 @@ uv pip install -U vllm --torch-backend auto`;
 
   // TPU has no pip wheel — force-hide the pip tab regardless of recipe overrides.
   const effectivePipHidden = pipHidden || isTpu;
-  const dockerLabel = isTpu ? "Docker (TPU)" : isAmd ? "Docker (ROCm)" : "Docker";
+  // Ascend requires a matched vLLM Ascend image in this foundation phase.
+  const ascendPipHidden = isAscend;
+  const dockerLabel = isTpu ? "Docker (TPU)" : isAscend ? "Docker (Ascend)" : isAmd ? "Docker (ROCm)" : "Docker";
   const tabs = [
-    !effectivePipHidden && {
+    !(effectivePipHidden || ascendPipHidden) && {
       id: "pip",
       label: isAmd ? "pip / uv (ROCm)" : "pip / uv",
       code: pipCmd,
@@ -2877,7 +2885,7 @@ uv pip install -U vllm --torch-backend auto`;
         <Package size={12} className="text-[var(--command-fg)]/50 shrink-0" />
         <span className="text-[11px] font-semibold text-[var(--command-fg)]/70 uppercase tracking-widest">Install</span>
         <span className="text-[11px] text-[var(--command-fg)]/40 font-mono">
-          vLLM {minV}+{isOmni ? " · vLLM-Omni nightly" : ""} · {isTpu ? "TPU" : isAmd ? "ROCm" : "CUDA"}
+          vLLM {minV}+{isOmni ? " · vLLM-Omni nightly" : ""} · {isTpu ? "TPU" : isAscend ? "Ascend" : isAmd ? "ROCm" : "CUDA"}
         </span>
         {nightlyRequired && (
           <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30 uppercase tracking-wider">
@@ -2998,7 +3006,9 @@ function MultiNodeBlock({ result, verifyCmd, benchCmd, statusHeader, installMode
   const isDocker = installMode === "docker";
   const wrap = (cmd) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env: result.env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+      ? dockerMeta.isAscend
+        ? buildAscendDockerRun({ command: cmd, env: result.env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+        : buildDockerRun({ command: cmd, env: result.env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
       : cmd;
   const tabs = [
     { id: "head", label: "Head", command: wrap(result.headCommand) },
@@ -3056,7 +3066,9 @@ function PdClusterBlock({ result, verifyCmd, benchCmd, statusHeader, onRankChang
   // it stays as-is with its pip-install hint regardless of install mode.
   const wrap = (cmd, env) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+      ? dockerMeta.isAscend
+        ? buildAscendDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+        : buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
       : cmd;
   // Mooncake composed into PD (result.mooncake): a "Mooncake Config" tab
   // (launch step 0) writes the shared config file(s) once — every
@@ -3190,7 +3202,9 @@ function KvStoreLbBlock({ result, verifyCmd, benchCmd, statusHeader, onInstanceC
   const isDocker = installMode === "docker";
   const wrap = (cmd, env) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+      ? dockerMeta.isAscend
+        ? buildAscendDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+        : buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
       : cmd;
 
   const instances = result.instances || 2;

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -48,6 +48,22 @@ function autoFitTp(vramMinGb, perGpuVram, gpuCount) {
 export function resolveSingleNodeTp(recipe, variant, hwProfile, strategyName = "single_node_tp") {
   const gpuCount = typeof hwProfile?.gpu_count === "number" ? hwProfile.gpu_count : 1;
   if (strategyName !== "single_node_tp") return gpuCount;
+  // Atlas A3 requires at least two Ascend NPUs. Keep this vendor-specific
+  // constraint ahead of the unchanged default auto-fit path used elsewhere.
+  if (hwProfile?.generation === "ascend" && hwProfile?.minimum_tp > 1) {
+    const minimumTp = Math.min(hwProfile.minimum_tp, gpuCount);
+    const variantTp = variant?.tp;
+    if (typeof variantTp === "number" && variantTp > 0) {
+      return Math.max(minimumTp, Math.min(variantTp, gpuCount));
+    }
+    const declaredTp = recipe?.strategy_overrides?.[strategyName]?.tp;
+    if (typeof declaredTp === "number" && declaredTp > 0) {
+      return Math.max(minimumTp, Math.min(declaredTp, gpuCount));
+    }
+    const perGpuVram = hwProfile?.vram_gb && gpuCount ? hwProfile.vram_gb / gpuCount : 0;
+    const vramMinGb = variant?.vram_minimum_gb || 0;
+    return Math.max(minimumTp, autoFitTp(vramMinGb, perGpuVram, gpuCount));
+  }
   // Variant-level override beats recipe-level. Used when a non-default variant
   // (typically an FP8-block-quantized sibling) needs a smaller TP than the
   // bf16 default — e.g. moe_intermediate_size=1536 demands TP ≤ 4 under FP8
@@ -394,16 +410,65 @@ export function pickDefaultHardware(hwProfiles, variant, recipe) {
 //
 // `docker_image` shapes:
 //   "vllm/vllm-openai:x"               (NVIDIA-only)
-//   { nvidia, amd, tpu }               (brand-keyed; each value is a string)
+//   { nvidia, amd, tpu, intel, ascend } (brand-keyed; each value is a string)
 //   { cu129, cu130 }                   (NVIDIA CUDA-keyed — explicit paired tags,
 //                                        auto-suffix is skipped in favor of these)
-//   { nvidia: { cu129, cu130 }, amd, tpu }  (mixed: NVIDIA value may be a CUDA map)
+//   { nvidia: { cu129, cu130 }, amd, tpu, intel, ascend }
+//                                        (mixed: NVIDIA value may be a CUDA map)
 // Exact variant+hardware overrides may also set
 //   variants.<key>.hardware_overrides.<hw_id>.docker_image
 //
 // When a CUDA map is in play, `cudaMap` is returned so the caller can pick by
 // the user's `dockerCudaVariant` toggle instead of appending `-cu129`/`-cu130`.
+function computeAscendDockerMeta(recipe, variant, hwProfile, hwId) {
+  const nightlyRequired = recipe.model?.nightly_required === true;
+  const ascendDeviceCount = Math.max(1, hwProfile?.gpu_count || 8);
+  const isAscendA3 = hwId === "atlas_800i_a3" || ascendDeviceCount > 8;
+  const defaultTag = nightlyRequired ? "nightly-main" : "main";
+  const defaultImage = `quay.io/ascend/vllm-ascend:${defaultTag}${isAscendA3 ? "-a3" : ""}`;
+  const exactHardwareOverride = hwId
+    ? variant?.hardware_overrides?.[hwId]?.docker_image
+    : null;
+  let pinned = typeof exactHardwareOverride === "string" ? exactHardwareOverride : null;
+
+  function applyAscendOverride(override) {
+    if (!override || pinned || typeof override !== "object") return;
+    if (typeof override.ascend === "string") pinned = override.ascend;
+  }
+
+  applyAscendOverride(variant?.docker_image);
+  applyAscendOverride(recipe.model?.docker_image);
+
+  const gpuFlags = [
+    "--net=host --shm-size=1g",
+    "--device=/dev/davinci_manager --device=/dev/devmm_svm --device=/dev/hisi_hdc",
+    Array.from({ length: ascendDeviceCount }, (_, i) => `--device=/dev/davinci${i}`).join(" "),
+    "-v /usr/local/dcmi:/usr/local/dcmi",
+    "-v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool",
+    "-v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi",
+    "-v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/",
+    "-v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info",
+    "-v /etc/ascend_install.info:/etc/ascend_install.info",
+  ].join(" \\\n  ");
+  return {
+    image: pinned || defaultImage,
+    gpuFlags,
+    brandKey: "ascend",
+    isAmd: false,
+    isTpu: false,
+    isIntel: false,
+    pinned,
+    cudaMap: null,
+    nightlyRequired,
+    isAscend: true,
+    ascendDeviceCount,
+  };
+}
+
 export function computeDockerMeta(recipe, variant, hwProfile, hwId = null) {
+  if (hwProfile?.generation === "ascend" || hwProfile?.brand === "Huawei") {
+    return computeAscendDockerMeta(recipe, variant, hwProfile, hwId);
+  }
   // When `model.nightly_required: true` and no explicit `docker_image` pin,
   // swap the brand defaults to nightly tags so the Install block matches the
   // nightly pip wheel that's also being rendered. vLLM publishes `:nightly`
@@ -467,7 +532,7 @@ export function computeDockerMeta(recipe, variant, hwProfile, hwId = null) {
     : isAmd
       ? "--device=/dev/kfd --device=/dev/dri \\\n  --security-opt seccomp=unconfined --group-add video"
     : isIntel
-      ? "--shm-size=16g"	
+      ? "--shm-size=16g"
       : "--gpus all";
   return { image, gpuFlags, brandKey, isAmd, isTpu, isIntel, pinned, cudaMap, nightlyRequired };
 }
@@ -486,7 +551,7 @@ function dockerGpuArgv(meta) {
   }
   if (meta.isIntel) {
     return ["--shm-size", "16g"];
-  }	
+  }
   return ["--gpus", "all"];
 }
 
@@ -503,6 +568,21 @@ export function buildDockerRun({ command, env, image, gpuFlags, port = 8000 }) {
   --privileged --ipc=host -p ${port}:${port} \\
   -v ~/.cache/huggingface:/root/.cache/huggingface \\${envFlags ? `\n  ${envFlags} \\` : ""}
   ${image} ${modelId}${serveBody ? ` \\\n  ${serveBody}` : ""}`;
+}
+
+// vLLM Ascend images use `vllm` as the entrypoint, so retain the `serve`
+// subcommand explicitly. This separate builder leaves all existing images on
+// the original Docker command path above.
+export function buildAscendDockerRun({ command, env, image, gpuFlags, port = 8000 }) {
+  const envFlags = Object.entries(env || {})
+    .map(([k, v]) => `-e ${k}=${v}`)
+    .join(" \\\n  ");
+  const modelId = command.match(/^vllm serve (\S+)/)?.[1] || "MODEL";
+  const serveBody = command.replace(/^vllm serve \S+\s*\\?\n?\s*/, "");
+  return `docker run ${gpuFlags} --entrypoint vllm \\
+  --privileged --ipc=host -p ${port}:${port} \\
+  -v ~/.cache/huggingface:/root/.cache/huggingface \\${envFlags ? `\n  ${envFlags} \\` : ""}
+  ${image} serve ${modelId}${serveBody ? ` \\\n  ${serveBody}` : ""}`;
 }
 
 // argv companion to buildDockerRun. `argv` here is the inner command's argv —
@@ -524,6 +604,39 @@ export function buildDockerArgv({ argv, env, meta, port = 8000 }) {
     "-v", "~/.cache/huggingface:/root/.cache/huggingface",
     ...envFlags,
     meta.image,
+    ...cmdArgs,
+  ];
+}
+
+// argv companion for the Ascend-only Docker builder.
+export function buildAscendDockerArgv({ argv, env, meta, port = 8000 }) {
+  const envFlags = [];
+  for (const [k, v] of Object.entries(env || {})) {
+    envFlags.push("-e", `${k}=${v}`);
+  }
+  const cmdArgs = argv[0] === "vllm" && argv[1] === "serve" ? argv.slice(2) : argv;
+  const deviceCount = meta.ascendDeviceCount || 8;
+  const ascendGpuArgv = [
+    "--net=host", "--shm-size=1g",
+    "--device=/dev/davinci_manager", "--device=/dev/devmm_svm", "--device=/dev/hisi_hdc",
+    ...Array.from({ length: deviceCount }, (_, i) => `--device=/dev/davinci${i}`),
+    "-v", "/usr/local/dcmi:/usr/local/dcmi",
+    "-v", "/usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool",
+    "-v", "/usr/local/bin/npu-smi:/usr/local/bin/npu-smi",
+    "-v", "/usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/",
+    "-v", "/usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info",
+    "-v", "/etc/ascend_install.info:/etc/ascend_install.info",
+  ];
+  return [
+    "docker", "run",
+    ...ascendGpuArgv,
+    "--privileged", "--ipc=host",
+    "-p", `${port}:${port}`,
+    "-v", "~/.cache/huggingface:/root/.cache/huggingface",
+    ...envFlags,
+    "--entrypoint", "vllm",
+    meta.image,
+    "serve",
     ...cmdArgs,
   ];
 }

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -119,6 +119,31 @@ hardware_profiles:
     vram_gb: 2304
     multi_node: false
 
+  # ── Huawei Ascend NPU ──
+  # `restricted: true` follows the TPU pattern: these profiles stay hidden
+  # unless a recipe explicitly lists them in `meta.hardware`. A later recipe
+  # PR must pin a tested vLLM Ascend image before declaring either verified.
+  atlas_800i_a2:
+    brand: Huawei
+    generation: ascend
+    display_name: "Atlas 800I A2"
+    description: "Huawei Ascend Atlas 800I A2 · 8-NPU server · served via vLLM Ascend"
+    gpu_count: 8
+    vram_gb: 512
+    multi_node: false
+    restricted: true
+
+  atlas_800i_a3:
+    brand: Huawei
+    generation: ascend
+    display_name: "Atlas 800I A3"
+    description: "Huawei Ascend Atlas 800I A3 · 16-NPU server · served via vLLM Ascend"
+    gpu_count: 16
+    vram_gb: 1024
+    multi_node: false
+    minimum_tp: 2
+    restricted: true
+
   # ── Google Cloud TPU ──
   # `restricted: true` hides these from the hardware picker unless the recipe
   # explicitly lists them in `meta.hardware` — TPU support requires a separate

--- a/tests/command-synthesis.test.mjs
+++ b/tests/command-synthesis.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildAscendDockerArgv,
+  buildAscendDockerRun,
+  buildDockerArgv,
+  buildDockerRun,
+  computeDockerMeta,
+  resolveSingleNodeTp,
+} from "../src/lib/command-synthesis.js";
+
+const recipe = { model: {} };
+const variant = {};
+
+test("Atlas A2 uses the Ascend image and exposes eight NPU devices", () => {
+  const meta = computeDockerMeta(
+    recipe,
+    variant,
+    { brand: "Huawei", generation: "ascend", gpu_count: 8 },
+    "atlas_800i_a2",
+  );
+
+  assert.equal(meta.brandKey, "ascend");
+  assert.equal(meta.isAscend, true);
+  assert.equal(meta.image, "quay.io/ascend/vllm-ascend:main");
+  assert.match(meta.gpuFlags, /--device=\/dev\/davinci0(?:\s|\\)/);
+  assert.match(meta.gpuFlags, /--device=\/dev\/davinci7(?:\s|\\)/);
+  assert.doesNotMatch(meta.gpuFlags, /--device=\/dev\/davinci8(?:\s|\\)/);
+  assert.match(meta.gpuFlags, /--device=\/dev\/davinci_manager/);
+  assert.match(meta.gpuFlags, /\/usr\/local\/dcmi:\/usr\/local\/dcmi/);
+});
+
+test("Atlas A3 uses the A3 image and exposes sixteen NPU devices", () => {
+  const meta = computeDockerMeta(
+    recipe,
+    variant,
+    { brand: "Huawei", generation: "ascend", gpu_count: 16 },
+    "atlas_800i_a3",
+  );
+
+  assert.equal(meta.image, "quay.io/ascend/vllm-ascend:main-a3");
+  assert.match(meta.gpuFlags, /--device=\/dev\/davinci15(?:\s|\\)/);
+  assert.doesNotMatch(meta.gpuFlags, /--device=\/dev\/davinci16(?:\s|\\)/);
+
+  const nightly = computeDockerMeta(
+    { model: { nightly_required: true } },
+    variant,
+    { brand: "Huawei", generation: "ascend", gpu_count: 16 },
+    "atlas_800i_a3",
+  );
+  assert.equal(nightly.image, "quay.io/ascend/vllm-ascend:nightly-main-a3");
+});
+
+test("Atlas A3 enforces two NPUs without changing other hardware", () => {
+  const smallVariant = { vram_minimum_gb: 20 };
+  const a3 = { brand: "Huawei", generation: "ascend", gpu_count: 16, vram_gb: 1024, minimum_tp: 2 };
+  const a2 = { brand: "Huawei", generation: "ascend", gpu_count: 8, vram_gb: 512 };
+  const nvidia = { brand: "NVIDIA", generation: "hopper", gpu_count: 8, vram_gb: 640 };
+  const amd = { brand: "AMD", generation: "amd", gpu_count: 8, vram_gb: 1536 };
+  const tpu = { brand: "Google", generation: "tpu", gpu_count: 8, vram_gb: 256 };
+
+  assert.equal(resolveSingleNodeTp(recipe, smallVariant, a3), 2);
+  assert.equal(resolveSingleNodeTp(recipe, smallVariant, a2), 1);
+  assert.equal(resolveSingleNodeTp(recipe, smallVariant, nvidia), 1);
+  assert.equal(resolveSingleNodeTp(recipe, smallVariant, amd), 1);
+  assert.equal(resolveSingleNodeTp(recipe, smallVariant, tpu), 1);
+});
+
+test("Ascend accepts brand and exact hardware image pins", () => {
+  const brandPinned = computeDockerMeta(
+    { model: { docker_image: { ascend: "quay.io/ascend/vllm-ascend:v0.18.0" } } },
+    variant,
+    { brand: "Huawei", generation: "ascend", gpu_count: 8 },
+    "atlas_800i_a2",
+  );
+  assert.equal(brandPinned.image, "quay.io/ascend/vllm-ascend:v0.18.0");
+
+  const hardwarePinned = computeDockerMeta(
+    recipe,
+    {
+      hardware_overrides: {
+        atlas_800i_a3: {
+          docker_image: "quay.io/ascend/vllm-ascend:v0.18.0-a3",
+        },
+      },
+    },
+    { brand: "Huawei", generation: "ascend", gpu_count: 16 },
+    "atlas_800i_a3",
+  );
+  assert.equal(hardwarePinned.image, "quay.io/ascend/vllm-ascend:v0.18.0-a3");
+});
+
+test("Ascend docker commands set the vllm entrypoint and preserve serve", () => {
+  const meta = computeDockerMeta(
+    recipe,
+    variant,
+    { brand: "Huawei", generation: "ascend", gpu_count: 8 },
+    "atlas_800i_a2",
+  );
+  const argv = buildAscendDockerArgv({
+    argv: ["vllm", "serve", "org/model", "--max-model-len", "4096"],
+    env: {},
+    meta,
+  });
+
+  const shell = buildAscendDockerRun({
+    command: "vllm serve org/model \\\n  --max-model-len 4096",
+    env: {},
+    image: meta.image,
+    gpuFlags: meta.gpuFlags,
+  });
+
+  assert.ok(argv.includes("--device=/dev/davinci0"));
+  assert.ok(argv.includes("--device=/dev/davinci7"));
+  assert.ok(!argv.includes("--device=/dev/davinci8"));
+  assert.ok(argv.includes("--device=/dev/davinci_manager"));
+  assert.ok(argv.includes("/usr/local/dcmi:/usr/local/dcmi"));
+  const imageIndex = argv.indexOf(meta.image);
+  assert.deepEqual(argv.slice(imageIndex - 2, imageIndex + 3), [
+    "--entrypoint", "vllm", meta.image, "serve", "org/model",
+  ]);
+  assert.match(shell, /--entrypoint vllm/);
+  assert.match(shell, /quay\.io\/ascend\/vllm-ascend:main serve org\/model/);
+});
+
+test("existing Docker brands keep their current defaults", () => {
+  const nvidia = computeDockerMeta(recipe, variant, { brand: "NVIDIA" });
+  assert.equal(nvidia.brandKey, "nvidia");
+  assert.equal(nvidia.image, "vllm/vllm-openai:latest");
+  assert.equal(nvidia.gpuFlags, "--gpus all");
+  const nvidiaShell = buildDockerRun({
+    command: "vllm serve org/model",
+    env: {},
+    image: nvidia.image,
+    gpuFlags: nvidia.gpuFlags,
+  });
+  assert.doesNotMatch(nvidiaShell, /--entrypoint/);
+  assert.match(nvidiaShell, /vllm\/vllm-openai:latest org\/model/);
+  const nvidiaArgv = buildDockerArgv({
+    argv: ["vllm", "serve", "org/model"],
+    env: {},
+    meta: nvidia,
+  });
+  assert.deepEqual(nvidiaArgv.slice(-2), [nvidia.image, "org/model"]);
+
+  const amd = computeDockerMeta(recipe, variant, { brand: "AMD" });
+  assert.equal(amd.brandKey, "amd");
+  assert.equal(amd.image, "vllm/vllm-openai-rocm:latest");
+  assert.match(amd.gpuFlags, /--device=\/dev\/kfd/);
+
+  const tpu = computeDockerMeta(recipe, variant, {
+    brand: "Google",
+    generation: "tpu",
+  });
+  assert.equal(tpu.brandKey, "tpu");
+  assert.equal(tpu.image, "vllm/vllm-tpu:latest");
+  assert.match(tpu.gpuFlags, /--privileged --network host/);
+});


### PR DESCRIPTION
## Summary

This PR adds the minimal shared foundation required for future Huawei Ascend
NPU recipes. It follows the existing restricted Google TPU hardware pattern
without changing the TPU or other vendor implementations.

- add restricted Atlas 800I A2 and Atlas 800I A3 hardware profiles;
- add Ascend-only Docker metadata and command builders;
- add official Ascend Docker device mappings and host mounts;
- select the existing A2/A3 rolling image tags without globally pinning a
  release candidate;
- use the `vllm` entrypoint required by the official vLLM Ascend images;
- enforce the Atlas A3 minimum of two NPUs through profile metadata;
- keep Ascend Docker-first so the Install and command cards stay synchronized.

Part of #498.

## Scope

This PR only adds shared taxonomy and Ascend command-generation plumbing.
Ascend dispatches to dedicated metadata, shell, and argv builders; the existing
generic Docker builders and Google TPU/NVIDIA/AMD/Intel execution paths remain
unchanged.

It does not:

- mark any model as verified on Ascend;
- add or modify model recipes;
- expose Ascend in Browse filters or search;
- change default hardware selection;
- modify or remove existing NVIDIA, AMD, Google TPU, or Intel behavior;
- include unrelated refactors or file-wide formatting changes.

Exact release images will be pinned by model recipes after end-to-end
validation.

## Validation

- `node --test tests/command-synthesis.test.mjs` — 6/6 passed
- full command probe — Atlas A3 renders `--tensor-parallel-size 2`
- `node scripts/build-recipes-api.mjs` — 148 models, 8 strategies
- taxonomy assertion — Ascend profiles restricted; existing profiles preserved
- Quay tag check — `main`, `main-a3`, `nightly-main`, and `nightly-main-a3` exist
- `git diff --check origin/main..HEAD`

`pnpm lint` is not usable non-interactively in this checkout because the
repository has no ESLint configuration and `next lint` opens the setup prompt.