### PR TITLE
Add NVIDIA Cosmos3 omnimodal world model recipes

### DIFF
--- a/models/nvidia/Cosmos3-Nano.yaml
+++ b/models/nvidia/Cosmos3-Nano.yaml
@@ -2,7 +2,7 @@ meta:
   title: "Cosmos3-Nano"
   slug: "cosmos3-nano"
   provider: "NVIDIA"
-  description: "Compact 16B omnimodal world model (Mixture-of-Transformers) for multimodal understanding, world simulation, future prediction, action reasoning, and Physical AI — served via vLLM-Omni for video/audio generation"
+  description: "Compact 16B omnimodal world model (Mixture-of-Transformers) for multimodal understanding, world simulation, future prediction, action reasoning, and Physical AI"
   date_updated: 2026-06-02
   difficulty: intermediate
   tasks:

--- a/models/nvidia/Cosmos3-Nano.yaml
+++ b/models/nvidia/Cosmos3-Nano.yaml
@@ -1,0 +1,192 @@
+meta:
+  title: "Cosmos3-Nano"
+  slug: "cosmos3-nano"
+  provider: "NVIDIA"
+  description: "Compact 16B omnimodal world model (Mixture-of-Transformers) for multimodal understanding, world simulation, future prediction, action reasoning, and Physical AI — served via vLLM-Omni for video/audio generation"
+  date_updated: 2026-06-02
+  difficulty: intermediate
+  tasks:
+    - omni
+  performance_headline: "16B omnimodal world model — single-GPU H200 video/audio generation"
+  related_recipes:
+    - nvidia/Cosmos3-Super
+    - nvidia/Cosmos3-Super-Text2Image
+    - nvidia/Cosmos3-Super-Image2Video
+  hardware:
+    h200: verified
+    h100: verified
+    a100: verified
+
+model:
+  model_id: "nvidia/Cosmos3-Nano"
+  min_vllm_version: "0.21.0"
+  docker_image: "vllm/vllm-omni:cosmos3"
+  install:
+    docker:
+      note: "Release-tested vLLM-Omni image bundling the Cosmos3 omni handlers."
+    pip: false
+  architecture: dense
+  parameter_count: "16B"
+  active_parameters: "16B"
+  context_length: 262144
+  base_args:
+    - "--host"
+    - "0.0.0.0"
+    - "--port"
+    - "8000"
+    - "--init-timeout"
+    - "1800"
+  base_env: {}
+
+omni:
+  # Cosmos3-Nano runs on a single H200 in omni mode. Both video tasks hit the
+  # same /v1/videos/sync endpoint; audio is generated jointly and muxed into
+  # the output MP4 (no separate audio endpoint). Prompts should be JSON-upsampled
+  # for best quality — see the guide.
+  tasks:
+    - id: t2v
+      description: "Text → video (audio muxed into the MP4)"
+      curl: |
+        curl -X POST http://localhost:8000/v1/videos/sync \
+          -H "Accept: video/mp4" \
+          -F "prompt=$(cat assets/example_t2v_prompt.json)" \
+          -F "negative_prompt=$(cat assets/negative_prompt.json)" \
+          -F "size=1280x720" \
+          -F "num_frames=189" \
+          -F "fps=24" \
+          -F "num_inference_steps=35" \
+          -F "guidance_scale=6.0" \
+          -F "max_sequence_length=4096" \
+          -F "flow_shift=10.0" \
+          -F "seed=123" \
+          --output output.mp4
+    - id: i2v
+      description: "Image → video (temporally coherent, audio muxed in)"
+      curl: |
+        curl -X POST http://localhost:8000/v1/videos/sync \
+          -H "Accept: video/mp4" \
+          -F "input_reference=@assets/example_i2v_input.jpg" \
+          -F "prompt=$(cat assets/example_i2v_prompt.json)" \
+          -F "negative_prompt=$(cat assets/negative_prompt.json)" \
+          -F "size=1280x720" \
+          -F "num_frames=189" \
+          -F "fps=24" \
+          -F "num_inference_steps=35" \
+          -F "guidance_scale=6.0" \
+          -F "max_sequence_length=4096" \
+          -F "flow_shift=10.0" \
+          -F "seed=1111" \
+          --output output.mp4
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 39
+    description: "BF16 weights — single-GPU H200 omni generation"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  **Cosmos3-Nano** is the compact (16B) member of NVIDIA's Cosmos3 family of
+  **omnimodal world models**. Built on a Mixture-of-Transformers (MoT)
+  architecture — an autoregressive tower for discrete-token generation paired
+  with a diffusion tower for continuous modalities — it generates coherent text,
+  images, video, audio, and action commands from combinations of text, image,
+  video, and action-trajectory inputs. It targets Physical AI: world
+  understanding, world simulation, future prediction, and action reasoning.
+
+  This recipe covers the **vLLM-Omni** serving path (video + muxed-audio
+  generation). The same checkpoint also serves a text/multimodal **Reasoner**
+  endpoint via standard vLLM — see [Reasoner mode](#reasoner-mode-multimodal-understanding)
+  below.
+
+  ## Prerequisites
+
+  - 1× H200 (or H100 / A100) for the documented single-GPU profile
+  - The release-tested `vllm/vllm-omni:cosmos3` container, or vLLM-Omni installed
+    on top of `vllm==0.21.0`
+  - Prompts should be JSON-upsampled for best quality (see
+    [cosmos-framework prompt upsampling](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/prompt_upsampling.md))
+
+  ## Launch command (vLLM-Omni)
+
+  ```bash
+  docker pull vllm/vllm-omni:cosmos3
+
+  vllm serve nvidia/Cosmos3-Nano \
+    --omni \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --init-timeout 1800
+  ```
+
+  To speed up inference with additional GPUs, enable context parallelism with
+  `--ulysses-degree` or switch to tensor parallelism with
+  `--tensor-parallel-size`. On memory-constrained GPUs, `--enable-layerwise-offload`
+  reduces VRAM usage at a performance cost.
+
+  ### Example: text-to-video
+
+  ```bash
+  curl -X POST http://localhost:8000/v1/videos/sync \
+    -H "Accept: video/mp4" \
+    -F "prompt=$(cat assets/example_t2v_prompt.json)" \
+    -F "negative_prompt=$(cat assets/negative_prompt.json)" \
+    -F "size=1280x720" \
+    -F "num_frames=189" \
+    -F "fps=24" \
+    -F "num_inference_steps=35" \
+    -F "guidance_scale=6.0" \
+    -F "max_sequence_length=4096" \
+    -F "flow_shift=10.0" \
+    -F "seed=123" \
+    --output output.mp4
+  ```
+
+  Image-to-video uses the same endpoint with an `input_reference` file part.
+  Audio is generated jointly and muxed into the output MP4 (48 kHz stereo AAC) —
+  there is no separate audio endpoint.
+
+  ## Reasoner mode (multimodal understanding)
+
+  The same checkpoint serves a text/multimodal **Reasoner** for world
+  understanding, future prediction, and action reasoning via the standard `vllm`
+  package (not vLLM-Omni):
+
+  ```bash
+  # CUDA 13 drivers:
+  uv pip install --torch-backend=cu130 "vllm==0.21.0" \
+    "vllm-cosmos3 @ git+https://github.com/NVIDIA/cosmos-framework.git#subdirectory=packages/vllm-cosmos3" \
+    openai
+  # CUDA 12.8 drivers: use --torch-backend=cu128 "vllm==0.19.1"
+
+  CUDA_VISIBLE_DEVICES=0 \
+  vllm serve nvidia/Cosmos3-Nano \
+    --hf-overrides '{"architectures": ["Cosmos3ReasonerForConditionalGeneration"]}' \
+    --tensor-parallel-size 1 \
+    --mm-encoder-tp-mode data \
+    --async-scheduling \
+    --allowed-local-media-path / \
+    --media-io-kwargs '{"video": {"num_frames": -1}}' \
+    --port 8000
+  ```
+
+  Then query the OpenAI-compatible `/v1/chat/completions` endpoint with text +
+  image/video content.
+
+  ## References
+
+  - [Model card](https://huggingface.co/nvidia/Cosmos3-Nano)
+  - [vLLM-Omni](https://github.com/vllm-project/vllm-omni)
+  - [cosmos-framework](https://github.com/NVIDIA/cosmos-framework)
+  - [Cosmos](https://github.com/nvidia/cosmos)

--- a/models/nvidia/Cosmos3-Super-Image2Video.yaml
+++ b/models/nvidia/Cosmos3-Super-Image2Video.yaml
@@ -1,0 +1,150 @@
+meta:
+  title: "Cosmos3-Super-Image2Video"
+  slug: "cosmos3-super-image2video"
+  provider: "NVIDIA"
+  description: "64B Cosmos3-Super specialization for temporally coherent image-to-video generation, served via vLLM-Omni"
+  date_updated: 2026-06-02
+  difficulty: advanced
+  tasks:
+    - omni
+  performance_headline: "Temporally coherent image-to-video — ~55s/video on 8×H200"
+  related_recipes:
+    - nvidia/Cosmos3-Super
+    - nvidia/Cosmos3-Nano
+    - nvidia/Cosmos3-Super-Text2Image
+  hardware:
+    h200: verified
+    h100: verified
+    a100: verified
+
+model:
+  model_id: "nvidia/Cosmos3-Super-Image2Video"
+  min_vllm_version: "0.21.0"
+  docker_image: "vllm/vllm-omni:cosmos3"
+  install:
+    docker:
+      note: "Release-tested vLLM-Omni image bundling the Cosmos3 omni handlers."
+    pip: false
+  architecture: dense
+  parameter_count: "64B"
+  active_parameters: "64B"
+  context_length: 262144
+  base_args:
+    - "--host"
+    - "0.0.0.0"
+    - "--port"
+    - "8000"
+    - "--cfg-parallel-size"
+    - "2"
+    - "--ulysses-degree"
+    - "4"
+    - "--use-hsdp"
+    - "--hsdp-shard-size"
+    - "8"
+    - "--init-timeout"
+    - "1800"
+  base_env: {}
+
+omni:
+  # Image-to-video specialization. Documented profile is an 8×H200/H100/A100 node
+  # with CFG-parallel + ulysses + HSDP (encoded in base_args). Video comes back
+  # from /v1/videos/sync with the conditioning frame supplied via input_reference.
+  tasks:
+    - id: i2v
+      description: "Image → temporally coherent video"
+      curl: |
+        curl -X POST http://localhost:8000/v1/videos/sync \
+          -H "Accept: video/mp4" \
+          -F "input_reference=@assets/example_first_frame.png" \
+          -F "prompt=$(cat assets/example_prompt.json)" \
+          -F "size=1280x720" \
+          -F "num_frames=189" \
+          -F "fps=24" \
+          -F "num_inference_steps=35" \
+          -F "guidance_scale=6.0" \
+          -F "max_sequence_length=4096" \
+          -F "flow_shift=10.0" \
+          -F "seed=1111" \
+          --output output.mp4
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 154
+    description: "BF16 weights — 8×H200/H100/A100 node recommended"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  **Cosmos3-Super-Image2Video** is a 64B specialization of NVIDIA's Cosmos3-Super
+  omnimodal world model, tuned for **temporally coherent image-to-video
+  generation**: given one input image and text instructions, it produces video
+  sequences consistent with the provided visual content. It is served via
+  **vLLM-Omni**.
+
+  For best quality, text prompts should be JSON-upsampled (see the
+  `scripts/upsample_prompt.py` helper in the model repo).
+
+  ## Prerequisites
+
+  - 8× H200, H100, or A100 for the documented full-node profile
+  - The release-tested `vllm/vllm-omni:cosmos3` container, or vLLM-Omni installed
+    on top of `vllm==0.21.0`
+
+  ## Launch command (vLLM-Omni)
+
+  Recommended configuration on 8×H200, 8×H100, or 8×A100:
+
+  ```bash
+  docker pull vllm/vllm-omni:cosmos3
+
+  vllm serve nvidia/Cosmos3-Super-Image2Video \
+    --omni \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --cfg-parallel-size 2 \
+    --ulysses-degree 4 \
+    --use-hsdp \
+    --hsdp-shard-size 8 \
+    --init-timeout 1800
+  ```
+
+  With this configuration, 50-step video generation takes ~55 seconds on H200.
+  For **2×H200**, use `--cfg-parallel-size 2 --use-hsdp --hsdp-shard-size 2`
+  (a video takes ~3 minutes). Tensor parallelism is also supported via
+  `--tensor-parallel-size`. On memory-constrained GPUs,
+  `--enable-layerwise-offload` reduces VRAM usage at a performance cost.
+
+  ### Example: image-to-video
+
+  ```bash
+  curl -X POST http://localhost:8000/v1/videos/sync \
+    -H "Accept: video/mp4" \
+    -F "input_reference=@assets/example_first_frame.png" \
+    -F "prompt=$(cat assets/example_prompt.json)" \
+    -F "size=1280x720" \
+    -F "num_frames=189" \
+    -F "fps=24" \
+    -F "num_inference_steps=35" \
+    -F "guidance_scale=6.0" \
+    -F "max_sequence_length=4096" \
+    -F "flow_shift=10.0" \
+    -F "seed=1111" \
+    --output output.mp4
+  ```
+
+  ## References
+
+  - [Model card](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video)
+  - [vLLM-Omni](https://github.com/vllm-project/vllm-omni)
+  - [Cosmos](https://github.com/nvidia/cosmos)

--- a/models/nvidia/Cosmos3-Super-Image2Video.yaml
+++ b/models/nvidia/Cosmos3-Super-Image2Video.yaml
@@ -2,7 +2,7 @@ meta:
   title: "Cosmos3-Super-Image2Video"
   slug: "cosmos3-super-image2video"
   provider: "NVIDIA"
-  description: "64B Cosmos3-Super specialization for temporally coherent image-to-video generation, served via vLLM-Omni"
+  description: "64B Cosmos3-Super specialization for temporally coherent image-to-video generation"
   date_updated: 2026-06-02
   difficulty: advanced
   tasks:

--- a/models/nvidia/Cosmos3-Super-Text2Image.yaml
+++ b/models/nvidia/Cosmos3-Super-Text2Image.yaml
@@ -1,0 +1,131 @@
+meta:
+  title: "Cosmos3-Super-Text2Image"
+  slug: "cosmos3-super-text2image"
+  provider: "NVIDIA"
+  description: "64B Cosmos3-Super specialization for high-fidelity text-to-image generation, served via vLLM-Omni"
+  date_updated: 2026-06-02
+  difficulty: advanced
+  tasks:
+    - omni
+  performance_headline: "High-fidelity text-to-image — 8×H100 with CFG-parallel + ulysses + HSDP"
+  related_recipes:
+    - nvidia/Cosmos3-Super
+    - nvidia/Cosmos3-Nano
+    - nvidia/Cosmos3-Super-Image2Video
+  hardware:
+    h200: verified
+    h100: verified
+    gb200: verified
+
+model:
+  model_id: "nvidia/Cosmos3-Super-Text2Image"
+  min_vllm_version: "0.21.0"
+  docker_image: "vllm/vllm-omni:cosmos3"
+  install:
+    docker:
+      note: "Release-tested vLLM-Omni image bundling the Cosmos3 omni handlers."
+    pip: false
+  architecture: dense
+  parameter_count: "64B"
+  active_parameters: "64B"
+  context_length: 262144
+  base_args:
+    - "--host"
+    - "0.0.0.0"
+    - "--port"
+    - "8000"
+    - "--cfg-parallel-size"
+    - "2"
+    - "--ulysses-degree"
+    - "4"
+    - "--tensor-parallel-size"
+    - "1"
+    - "--use-hsdp"
+    - "--hsdp-shard-size"
+    - "8"
+    - "--init-timeout"
+    - "1800"
+  base_env: {}
+
+omni:
+  # Text-to-image specialization. Documented profile is an 8×H100 node with
+  # CFG-parallel + ulysses + HSDP (encoded in base_args). Images come back as
+  # base64 from /v1/images/generations.
+  tasks:
+    - id: t2i
+      description: "Text → high-fidelity image"
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 154
+    description: "BF16 weights — 8×H100 node recommended"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  **Cosmos3-Super-Text2Image** is a 64B specialization of NVIDIA's Cosmos3-Super
+  omnimodal world model, tuned for **high-fidelity text-to-image generation**.
+  It is served via **vLLM-Omni**.
+
+  For best quality, text prompts should be JSON-upsampled — the model repo ships
+  an `agentic_upsampling/` package and an `AGENTIC_UPSAMPLING.md` guide.
+
+  ## Prerequisites
+
+  - 8× H100 for the documented full-node profile (4×H200 / 4×GB200 alternative below)
+  - The release-tested `vllm/vllm-omni:cosmos3` container, or vLLM-Omni installed
+    on top of `vllm==0.21.0`
+
+  ## Launch command (vLLM-Omni)
+
+  Recommended configuration on an 8×H100 node:
+
+  ```bash
+  docker pull vllm/vllm-omni:cosmos3
+
+  vllm serve nvidia/Cosmos3-Super-Text2Image \
+    --omni \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --cfg-parallel-size 2 \
+    --ulysses-degree 4 \
+    --tensor-parallel-size 1 \
+    --use-hsdp \
+    --hsdp-shard-size 8 \
+    --init-timeout 1800
+  ```
+
+  For **4×H200 or 4×GB200**, use
+  `--cfg-parallel-size 2 --ulysses-degree 2 --tensor-parallel-size 1`.
+  `--enable-layerwise-offload` can reduce VRAM usage on smaller GPUs, but for
+  text-to-image it incurs a significant performance penalty.
+
+  ### Example: text-to-image
+
+  ```bash
+  curl -X POST http://localhost:8000/v1/images/generations \
+    -H "Content-Type: application/json" \
+    -d '{
+      "prompt": "a dragon flying over the Green Mountains at sunset",
+      "size": "1024x1024",
+      "seed": 42
+    }' | jq -r '.data[0].b64_json' | base64 -d > output.png
+  ```
+
+  ## References
+
+  - [Model card](https://huggingface.co/nvidia/Cosmos3-Super-Text2Image)
+  - [Agentic prompt upsampling](https://huggingface.co/nvidia/Cosmos3-Super-Text2Image/blob/main/AGENTIC_UPSAMPLING.md)
+  - [vLLM-Omni](https://github.com/vllm-project/vllm-omni)
+  - [Cosmos](https://github.com/nvidia/cosmos)

--- a/models/nvidia/Cosmos3-Super-Text2Image.yaml
+++ b/models/nvidia/Cosmos3-Super-Text2Image.yaml
@@ -2,7 +2,7 @@ meta:
   title: "Cosmos3-Super-Text2Image"
   slug: "cosmos3-super-text2image"
   provider: "NVIDIA"
-  description: "64B Cosmos3-Super specialization for high-fidelity text-to-image generation, served via vLLM-Omni"
+  description: "64B Cosmos3-Super specialization for high-fidelity text-to-image generation"
   date_updated: 2026-06-02
   difficulty: advanced
   tasks:

--- a/models/nvidia/Cosmos3-Super.yaml
+++ b/models/nvidia/Cosmos3-Super.yaml
@@ -2,7 +2,7 @@ meta:
   title: "Cosmos3-Super"
   slug: "cosmos3-super"
   provider: "NVIDIA"
-  description: "Frontier-scale 64B omnimodal world model (Mixture-of-Transformers) for advanced multimodal understanding, world simulation, future prediction, action reasoning, and Physical AI — served via vLLM-Omni for video/audio generation"
+  description: "Frontier-scale 64B omnimodal world model (Mixture-of-Transformers) for advanced multimodal understanding, world simulation, future prediction, action reasoning, and Physical AI"
   date_updated: 2026-06-02
   difficulty: advanced
   tasks:

--- a/models/nvidia/Cosmos3-Super.yaml
+++ b/models/nvidia/Cosmos3-Super.yaml
@@ -1,0 +1,203 @@
+meta:
+  title: "Cosmos3-Super"
+  slug: "cosmos3-super"
+  provider: "NVIDIA"
+  description: "Frontier-scale 64B omnimodal world model (Mixture-of-Transformers) for advanced multimodal understanding, world simulation, future prediction, action reasoning, and Physical AI — served via vLLM-Omni for video/audio generation"
+  date_updated: 2026-06-02
+  difficulty: advanced
+  tasks:
+    - omni
+  performance_headline: "64B omnimodal world model — ~55s/video on 8×H200 with HSDP + ulysses"
+  related_recipes:
+    - nvidia/Cosmos3-Nano
+    - nvidia/Cosmos3-Super-Text2Image
+    - nvidia/Cosmos3-Super-Image2Video
+  hardware:
+    h200: verified
+    h100: verified
+    a100: verified
+
+model:
+  model_id: "nvidia/Cosmos3-Super"
+  min_vllm_version: "0.21.0"
+  docker_image: "vllm/vllm-omni:cosmos3"
+  install:
+    docker:
+      note: "Release-tested vLLM-Omni image bundling the Cosmos3 omni handlers."
+    pip: false
+  architecture: dense
+  parameter_count: "64B"
+  active_parameters: "64B"
+  context_length: 262144
+  base_args:
+    - "--host"
+    - "0.0.0.0"
+    - "--port"
+    - "8000"
+    - "--cfg-parallel-size"
+    - "2"
+    - "--ulysses-degree"
+    - "4"
+    - "--use-hsdp"
+    - "--hsdp-shard-size"
+    - "8"
+    - "--init-timeout"
+    - "1800"
+  base_env: {}
+
+omni:
+  # Cosmos3-Super is the frontier-scale model: the documented profile is an
+  # 8×H200/H100/A100 node with CFG-parallel + ulysses context parallelism +
+  # HSDP sharding (encoded in base_args). Both video tasks hit /v1/videos/sync;
+  # audio is muxed into the output MP4.
+  tasks:
+    - id: t2v
+      description: "Text → video (audio muxed into the MP4)"
+      curl: |
+        curl -X POST http://localhost:8000/v1/videos/sync \
+          -H "Accept: video/mp4" \
+          -F "prompt=$(cat assets/example_t2v_prompt.json)" \
+          -F "negative_prompt=$(cat assets/negative_prompt.json)" \
+          -F "size=1280x720" \
+          -F "num_frames=189" \
+          -F "fps=24" \
+          -F "num_inference_steps=35" \
+          -F "guidance_scale=6.0" \
+          -F "max_sequence_length=4096" \
+          -F "flow_shift=10.0" \
+          -F "seed=123" \
+          --output output.mp4
+    - id: i2v
+      description: "Image → video (temporally coherent, audio muxed in)"
+      curl: |
+        curl -X POST http://localhost:8000/v1/videos/sync \
+          -H "Accept: video/mp4" \
+          -F "input_reference=@assets/example_i2v_input.jpg" \
+          -F "prompt=$(cat assets/example_i2v_prompt.json)" \
+          -F "negative_prompt=$(cat assets/negative_prompt.json)" \
+          -F "size=1280x720" \
+          -F "num_frames=189" \
+          -F "fps=24" \
+          -F "num_inference_steps=35" \
+          -F "guidance_scale=6.0" \
+          -F "max_sequence_length=4096" \
+          -F "flow_shift=10.0" \
+          -F "seed=1111" \
+          --output output.mp4
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 154
+    description: "BF16 weights — frontier-scale; 8×H200/H100/A100 node recommended"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  **Cosmos3-Super** is the frontier-scale (64B) member of NVIDIA's Cosmos3 family
+  of **omnimodal world models**. Built on a Mixture-of-Transformers (MoT)
+  architecture — an autoregressive tower for discrete-token generation paired
+  with a diffusion tower for continuous modalities — it generates coherent text,
+  images, video, audio, and action commands from combinations of text, image,
+  video, and action-trajectory inputs, for advanced world understanding,
+  simulation, future prediction, and action reasoning.
+
+  This recipe covers the **vLLM-Omni** serving path (video + muxed-audio
+  generation). The same checkpoint also serves a text/multimodal **Reasoner**
+  endpoint via standard vLLM — see [Reasoner mode](#reasoner-mode-multimodal-understanding)
+  below.
+
+  ## Prerequisites
+
+  - 8× H200, H100, or A100 for the documented full-node profile
+  - The release-tested `vllm/vllm-omni:cosmos3` container, or vLLM-Omni installed
+    on top of `vllm==0.21.0`
+  - Prompts should be JSON-upsampled for best quality (see
+    [cosmos-framework prompt upsampling](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/prompt_upsampling.md))
+
+  ## Launch command (vLLM-Omni)
+
+  Recommended configuration on 8×H200, 8×H100, or 8×A100:
+
+  ```bash
+  docker pull vllm/vllm-omni:cosmos3
+
+  vllm serve nvidia/Cosmos3-Super \
+    --omni \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --cfg-parallel-size 2 \
+    --ulysses-degree 4 \
+    --use-hsdp \
+    --hsdp-shard-size 8 \
+    --init-timeout 1800
+  ```
+
+  With this configuration, 50-step video generation takes ~55 seconds on H200.
+  For **2×H200**, use `--cfg-parallel-size 2 --use-hsdp --hsdp-shard-size 2`
+  (a video takes ~3 minutes). Tensor parallelism is also supported via
+  `--tensor-parallel-size`. On memory-constrained GPUs,
+  `--enable-layerwise-offload` reduces VRAM usage at a performance cost.
+
+  ### Example: text-to-video
+
+  ```bash
+  curl -X POST http://localhost:8000/v1/videos/sync \
+    -H "Accept: video/mp4" \
+    -F "prompt=$(cat assets/example_t2v_prompt.json)" \
+    -F "negative_prompt=$(cat assets/negative_prompt.json)" \
+    -F "size=1280x720" \
+    -F "num_frames=189" \
+    -F "fps=24" \
+    -F "num_inference_steps=35" \
+    -F "guidance_scale=6.0" \
+    -F "max_sequence_length=4096" \
+    -F "flow_shift=10.0" \
+    -F "seed=123" \
+    --output output.mp4
+  ```
+
+  Image-to-video uses the same endpoint with an `input_reference` file part.
+  Audio is generated jointly and muxed into the output MP4 (48 kHz stereo AAC).
+
+  ## Reasoner mode (multimodal understanding)
+
+  The same checkpoint serves a text/multimodal **Reasoner** via the standard
+  `vllm` package (not vLLM-Omni):
+
+  ```bash
+  # CUDA 13 drivers:
+  uv pip install --torch-backend=cu130 "vllm==0.21.0" \
+    "vllm-cosmos3 @ git+https://github.com/NVIDIA/cosmos-framework.git#subdirectory=packages/vllm-cosmos3" \
+    openai
+  # CUDA 12.8 drivers: use --torch-backend=cu128 "vllm==0.19.1"
+
+  vllm serve nvidia/Cosmos3-Super \
+    --hf-overrides '{"architectures": ["Cosmos3ReasonerForConditionalGeneration"]}' \
+    --tensor-parallel-size 4 \
+    --mm-encoder-tp-mode data \
+    --async-scheduling \
+    --allowed-local-media-path / \
+    --media-io-kwargs '{"video": {"num_frames": -1}}' \
+    --port 8000
+  ```
+
+  Then query the OpenAI-compatible `/v1/chat/completions` endpoint with text +
+  image/video content.
+
+  ## References
+
+  - [Model card](https://huggingface.co/nvidia/Cosmos3-Super)
+  - [vLLM-Omni](https://github.com/vllm-project/vllm-omni)
+  - [cosmos-framework](https://github.com/NVIDIA/cosmos-framework)
+  - [Cosmos](https://github.com/nvidia/cosmos)

--- a/src/app/[org]/[repo]/page.js
+++ b/src/app/[org]/[repo]/page.js
@@ -189,9 +189,10 @@ export default async function RecipePage({ params }) {
               target="_blank"
               rel="noopener noreferrer"
               title="vLLM-Omni serves the generation (omni) path — nightly wheels"
-              className="inline-flex items-center rounded-md border border-amber-500/40 text-amber-600 dark:text-amber-400 px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap transition-colors hover:border-amber-500/70"
+              className="inline-flex items-center rounded-md border border-border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap transition-colors hover:border-vllm-blue/50 hover:text-vllm-blue"
             >
-              vLLM-Omni nightly
+              vLLM-Omni
+              <span className="ml-1 text-vllm-yellow">nightly</span>
               <ExternalLink size={10} className="ml-1 opacity-50" />
             </a>
           )}

--- a/src/app/[org]/[repo]/page.js
+++ b/src/app/[org]/[repo]/page.js
@@ -183,6 +183,18 @@ export default async function RecipePage({ params }) {
             vLLM {recipe.model.min_vllm_version}+
             <ExternalLink size={10} className="ml-1 opacity-50" />
           </a>
+          {recipe.meta.tasks?.includes("omni") && (
+            <a
+              href="https://github.com/vllm-project/vllm-omni"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="vLLM-Omni serves the generation (omni) path — nightly wheels"
+              className="inline-flex items-center rounded-md border border-amber-500/40 text-amber-600 dark:text-amber-400 px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap transition-colors hover:border-amber-500/70"
+            >
+              vLLM-Omni nightly
+              <ExternalLink size={10} className="ml-1 opacity-50" />
+            </a>
+          )}
           {recipe.meta.tasks?.map((t) => (
             <Badge key={t} variant="secondary" className="text-xs capitalize">{t}</Badge>
           ))}

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -1809,6 +1809,10 @@ function InstallBlock({ recipe, dockerMeta, installMode, setInstallMode, dockerC
   const [open, setOpen] = useState(false);
   const { isAmd, isTpu, image: dockerImage, brandKey, cudaMap } = dockerMeta;
   const minV = recipe.model?.min_vllm_version;
+  // Omni recipes are served by vLLM-Omni, a fast-moving companion package that
+  // tracks vLLM nightly (Wan2.2 even pins a git commit). Surface it next to the
+  // vLLM version so users know the generation path needs nightly wheels.
+  const isOmni = recipe.meta?.tasks?.includes("omni");
 
   // When a recipe's min_vllm_version hasn't shipped yet (cutting-edge models
   // that landed after the last stable release), `model.nightly_required: true`
@@ -1905,6 +1909,11 @@ uv pip install -U vllm --torch-backend auto`;
         {nightlyRequired && (
           <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30 uppercase tracking-wider">
             nightly
+          </span>
+        )}
+        {isOmni && (
+          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30 tracking-wider">
+            vLLM-Omni nightly
           </span>
         )}
         <span className="text-[11px] text-[var(--command-fg)]/40 ml-auto">

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -1904,16 +1904,11 @@ uv pip install -U vllm --torch-backend auto`;
         <Package size={12} className="text-[var(--command-fg)]/50 shrink-0" />
         <span className="text-[11px] font-semibold text-[var(--command-fg)]/70 uppercase tracking-widest">Install</span>
         <span className="text-[11px] text-[var(--command-fg)]/40 font-mono">
-          vLLM {minV}+ · {isTpu ? "TPU" : isAmd ? "ROCm" : "CUDA"}
+          vLLM {minV}+{isOmni ? " · vLLM-Omni nightly" : ""} · {isTpu ? "TPU" : isAmd ? "ROCm" : "CUDA"}
         </span>
         {nightlyRequired && (
           <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30 uppercase tracking-wider">
             nightly
-          </span>
-        )}
-        {isOmni && (
-          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30 tracking-wider">
-            vLLM-Omni nightly
           </span>
         )}
         <span className="text-[11px] text-[var(--command-fg)]/40 ml-auto">

--- a/src/components/recipes/RecipeCardGrid.jsx
+++ b/src/components/recipes/RecipeCardGrid.jsx
@@ -84,7 +84,6 @@ function RecipeCard({ recipe }) {
   const v = recipe.variants?.default || {};
   const tasks = recipe.meta?.tasks || [];
   const logo = getProviderLogo(recipe.hf_org);
-  const isOmni = tasks.includes("omni");
   const isMoe = recipe.model?.architecture === "moe";
   const ctx = recipe.model?.context_length || 0;
   const ctxLabel = ctx >= 1_000_000 ? `${Math.round(ctx / 1_000_000)}M` : ctx >= 1000 ? `${Math.round(ctx / 1000)}K` : String(ctx);
@@ -147,9 +146,6 @@ function RecipeCard({ recipe }) {
       <div className="mt-auto text-[11px] text-muted-foreground line-clamp-2 leading-snug">
         {recipe.meta?.description || recipe.meta?.performance_headline || ""}
       </div>
-      {isOmni && (
-        <div className="text-[10px] text-vllm-yellow/80 font-medium">via vLLM-Omni</div>
-      )}
     </Link>
   );
 }


### PR DESCRIPTION
## Summary

Adds vLLM-Omni serving recipes for four members of NVIDIA's **Cosmos3** family of omnimodal world models (Mixture-of-Transformers; text/image/video/audio/action generation + reasoning):

| Recipe | Params | Capability | Profile |
|--------|--------|------------|---------|
| `nvidia/Cosmos3-Nano` | 16B | Compact omnimodal world model — t2v / i2v (audio muxed) + Reasoner | 1×H200 |
| `nvidia/Cosmos3-Super` | 64B | Frontier-scale omnimodal world model — t2v / i2v + Reasoner | 8×H200/H100/A100 |
| `nvidia/Cosmos3-Super-Text2Image` | 64B | High-fidelity text-to-image | 8×H100 |
| `nvidia/Cosmos3-Super-Image2Video` | 64B | Temporally coherent image-to-video | 8×H200/H100/A100 |

All four serve via `vllm serve … --omni` using the release-tested `vllm/vllm-omni:cosmos3` container. Video tasks hit `/v1/videos/sync` (audio muxed into the MP4); text-to-image hits `/v1/images/generations`. The Nano/Super recipes also document the standard-vLLM **Reasoner** path (`--hf-overrides '{"architectures": ["Cosmos3ReasonerForConditionalGeneration"]}'`) for multimodal understanding.

## Notes

- **Cosmos3-Nano-Policy-DROID is intentionally omitted.** It is served via cosmos-framework's custom `action_policy_server_robolab`, not vLLM/vLLM-Omni — there is no `vllm serve` command, so it doesn't fit the command-builder surface.
- Metadata (architecture, context length 262144, param counts) verified against each model's `config.json` and README on HuggingFace.
- `node scripts/build-recipes-api.mjs` passes: all four parse and render with correct VRAM hints and omni task pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)