### PR TITLE
Add OpenBMB MiniCPM-V 4.6 + MiniCPM5-1B recipes

### DIFF
--- a/models/openbmb/MiniCPM-V-4.6.yaml
+++ b/models/openbmb/MiniCPM-V-4.6.yaml
@@ -1,0 +1,120 @@
+meta:
+  title: "MiniCPM-V 4.6"
+  slug: "minicpm-v-4-6"
+  provider: "MiniCPM (OpenBMB)"
+  description: "MiniCPM-V 4.6 (1.3B) — pocket-sized multimodal LLM for ultra-efficient single-image, multi-image, and video understanding, built on SigLIP2-400M + a Qwen3.5-0.8B hybrid-attention backbone"
+  date_updated: 2026-06-02
+  difficulty: beginner
+  tasks:
+    - multimodal
+  performance_headline: "~1.5× token throughput vs Qwen3.5-0.8B with mixed 4×/16× visual token compression"
+  related_recipes:
+    - openbmb/MiniCPM5-1B
+
+model:
+  model_id: "openbmb/MiniCPM-V-4.6"
+  min_vllm_version: "0.22.0"
+  architecture: dense
+  parameter_count: "1.3B"
+  active_parameters: "1.3B"
+  context_length: 262144
+  base_args:
+    - "--trust-remote-code"
+  base_env: {}
+
+dependencies:
+  - note: "MiniCPM-V 4.6 ships as a standalone architecture (MiniCPMV4_6ForConditionalGeneration) only in transformers >= 5.7.0"
+    command: 'uv pip install -U "transformers>=5.7.0"'
+  - note: "Video understanding support (decoders for the video input path)"
+    command: 'uv pip install -U "vllm[video]"'
+    optional: true
+
+features:
+  tool_calling:
+    description: "Function/tool calling via the qwen3_coder parser (the v4.6 chat template emits Qwen3-Coder-style <tool_call> blocks)"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "qwen3_coder"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 4
+    description: "BF16 weights (~1.3B params) — tiny footprint, runs comfortably on a single consumer GPU"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  **MiniCPM-V 4.6** is OpenBMB's most edge-friendly multimodal model to date.
+  It pairs a **SigLIP2-400M** vision encoder with a **Qwen3.5-0.8B** hybrid
+  linear/full-attention language backbone (~1.3B params total). It handles
+  single-image, multi-image, and video understanding, and introduces **mixed
+  4×/16× visual token compression** — switch the `downsample_mode` per request
+  to trade accuracy for speed.
+
+  > MiniCPM-V 4.6 ships as **two independent checkpoints** — this recipe covers
+  > the Instruct model (`openbmb/MiniCPM-V-4.6`). For chain-of-thought output,
+  > use the separate `openbmb/MiniCPM-V-4.6-Thinking` checkpoint instead (unlike
+  > v4.5, the mode is no longer toggled at runtime).
+
+  ## Prerequisites
+
+  - **vLLM ≥ 0.22.0** — the `MiniCPMV4_6ForConditionalGeneration` architecture
+    landed via [PR #43213](https://github.com/vllm-project/vllm/pull/43213)
+    (merged 2026-05-22) and first shipped in the v0.22.0 release. No fork is
+    required.
+  - **transformers ≥ 5.7.0** — the model is merged as a standalone architecture
+    only in this version.
+  - For video inputs, install the `vllm[video]` extra.
+
+  ## Launch command
+
+  Use the command builder above. The baseline is simply:
+
+  ```bash
+  vllm serve openbmb/MiniCPM-V-4.6 --trust-remote-code --port 8000
+  ```
+
+  Enable the **Tool calling** feature to add `--enable-auto-tool-choice
+  --tool-call-parser qwen3_coder`. The model emits a Qwen3-Coder-style
+  `<tool_call>` block inside the message content.
+
+  At 1.3B params the model fits on a single GPU (TP=1). v4.6 supports context up
+  to 256K, but start with a smaller `--max-model-len` (e.g. `8192`) and raise it
+  to fit your GPU memory and workload.
+
+  ## Client usage
+
+  **Image:**
+
+  ```bash
+  curl -s http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
+    "model": "openbmb/MiniCPM-V-4.6",
+    "messages": [{"role": "user", "content": [
+      {"type": "image_url", "image_url": {"url": "https://huggingface.co/datasets/openbmb/DemoCase/resolve/main/refract.png"}},
+      {"type": "text", "text": "What causes this phenomenon?"}
+    ]}]
+  }'
+  ```
+
+  > **Stop tokens:** v4.6 uses the Qwen3.5 backbone with a new vocab. If you see
+  > runaway generations, pass `"stop_token_ids": [248044, 248046]` in your
+  > request body.
+
+  ## References
+
+  - [Model card](https://huggingface.co/openbmb/MiniCPM-V-4.6)
+  - [Thinking checkpoint](https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking)
+  - [vLLM deployment guide (Cookbook)](https://github.com/OpenSQZ/MiniCPM-V-CookBook/blob/main/deployment/vllm/minicpm-v4_6_vllm.md)
+  - [vLLM support PR #43213](https://github.com/vllm-project/vllm/pull/43213)

--- a/models/openbmb/MiniCPM5-1B.yaml
+++ b/models/openbmb/MiniCPM5-1B.yaml
@@ -1,0 +1,124 @@
+meta:
+  title: "MiniCPM5-1B"
+  slug: "minicpm5-1b"
+  provider: "MiniCPM (OpenBMB)"
+  description: "MiniCPM5-1B — dense 1B on-device LLM with hybrid Think/No-Think reasoning, native 128K context, and strong agentic tool use, built on the standard Llama architecture"
+  date_updated: 2026-06-02
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "1B-class open-source SOTA on tool use, code, and reasoning"
+  related_recipes:
+    - openbmb/MiniCPM-V-4.6
+
+model:
+  model_id: "openbmb/MiniCPM5-1B"
+  min_vllm_version: "0.21.0"
+  architecture: dense
+  parameter_count: "1.1B"
+  active_parameters: "1.1B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+features:
+  reasoning:
+    description: "Enable hybrid deep-thinking mode — the chat template wraps a <think> block before the answer. Recommended sampling shifts to temperature=0.9, top_p=0.95. Leave off for fast No-Think responses (temperature=0.7)."
+    args:
+      - "--default-chat-template-kwargs"
+      - '{"enable_thinking": true}'
+
+opt_in_features:
+  - reasoning
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 3
+    description: "BF16 weights (~1.1B params) — tiny footprint, runs on a single consumer GPU"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  **MiniCPM5-1B** is the first checkpoint in OpenBMB's MiniCPM5 series — a dense
+  1B model built for on-device and resource-constrained deployment, reaching
+  1B-class open-source SOTA on agentic tool use, code generation, and difficult
+  reasoning. It uses the **standard `LlamaForCausalLM` architecture**, so vLLM
+  loads it natively with no custom kernels or model-code fork.
+
+  Its headline feature is **hybrid reasoning**: a single checkpoint serves as
+  both a fast assistant (No-Think) and a deliberate reasoner (Think), toggled by
+  the chat template's `enable_thinking` flag.
+
+  ## Prerequisites
+
+  - **vLLM ≥ 0.21.0** — MiniCPM5-1B is supported natively as of the v0.21.0
+    release. (For CUDA 12.x driver hosts, the cookbook suggests `vllm==0.10.1.1`
+    as a fallback.)
+
+  ## Launch command
+
+  Use the command builder above. The baseline is simply:
+
+  ```bash
+  vllm serve openbmb/MiniCPM5-1B --port 8000
+  ```
+
+  At ~1.1B params the model fits on a single GPU (TP=1). It supports the full
+  native 128K context; drop `--max-model-len` to `8192` / `32768` to free KV
+  cache on small GPUs, and set `--enforce-eager` if CUDA graphs OOM on a tiny
+  VRAM budget.
+
+  ## Reasoning modes
+
+  Toggle the **Reasoning** feature to serve with deep-thinking on by default
+  (`--default-chat-template-kwargs '{"enable_thinking": true}'`). You can also
+  flip it per request via `chat_template_kwargs`:
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "openbmb/MiniCPM5-1B",
+      "messages": [{"role": "user", "content": "Explain GQA in one sentence."}],
+      "temperature": 0.9, "top_p": 0.95, "max_tokens": 1024,
+      "chat_template_kwargs": {"enable_thinking": true}
+    }'
+  ```
+
+  | Mode | `enable_thinking` | `temperature` | `top_p` |
+  | --- | --- | --- | --- |
+  | Think | `true` | 0.9 | 0.95 |
+  | No-Think | `false` | 0.7 | 0.95 |
+
+  ## Tool calling
+
+  MiniCPM5-1B emits **XML-style** tool calls. The vLLM-side `minicpm5` parser
+  ([PR #43175](https://github.com/vllm-project/vllm/pull/43175)) merged to `main`
+  on 2026-05-27 but is **not in v0.21.0 or v0.22.0** — those releases were cut
+  before the merge. Until a release bakes it in (v0.23+), load it as a plugin
+  from the [MiniCPM repo](https://github.com/OpenBMB/MiniCPM):
+
+  ```bash
+  vllm serve openbmb/MiniCPM5-1B --port 8000 \
+    --enable-auto-tool-choice \
+    --tool-parser-plugin /path/to/MiniCPM/tool_parsers/minicpm5xml_tool_parser.py \
+    --tool-call-parser minicpm5
+  ```
+
+  SGLang ships the `minicpm5` parser built-in and is the author-recommended
+  backend for tool calling.
+
+  ## References
+
+  - [Model card](https://huggingface.co/openbmb/MiniCPM5-1B)
+  - [vLLM deployment cookbook](https://github.com/OpenBMB/MiniCPM/blob/main/docs/deployment/vllm.md)
+  - [MiniCPM Tech Report](https://arxiv.org/pdf/2506.07900)

--- a/src/lib/providers.js
+++ b/src/lib/providers.js
@@ -37,6 +37,7 @@ export const PROVIDERS = {
   "stepfun-ai":      { display_name: "StepFun",                  logo: "/providers/stepfun-ai.png" },
   "poolside":        { display_name: "Poolside",                 logo: "/providers/poolside.png" },
   "JetBrains":       { display_name: "JetBrains",                 logo: "/providers/JetBrains.png" },
+  "openbmb":         { display_name: "MiniCPM (OpenBMB)",          logo: "/providers/openbmb.png" },
 };
 
 export function getProviderLogo(hfOrg) {


### PR DESCRIPTION
## Summary

Adds two OpenBMB recipes and registers the new `openbmb` provider.

### MiniCPM-V 4.6 (`openbmb/MiniCPM-V-4.6`)
- 1.3B multimodal (single-image / multi-image / video) VL model — SigLIP2-400M vision encoder + Qwen3.5-0.8B hybrid-attention backbone.
- `min_vllm_version: 0.22.0` — `MiniCPMV4_6ForConditionalGeneration` landed via [vllm#43213](https://github.com/vllm-project/vllm/pull/43213) (merged 2026-05-22); v0.22.0 is the first stable release containing it (verified in the v0.22.0 registry).
- Tool-calling feature via the `qwen3_coder` parser; `transformers>=5.7.0` and optional `vllm[video]` dependencies.
- Single-GPU (`tp: 1`), `single_node_tp` + `multi_node_tp`.

### MiniCPM5-1B (`openbmb/MiniCPM5-1B`)
- Dense 1B text model on the standard `LlamaForCausalLM` architecture, native 128K context.
- `min_vllm_version: 0.21.0` — supported natively (no fork/custom kernels), per the model card and cookbook.
- Hybrid Think/No-Think **reasoning** feature via `--default-chat-template-kwargs '{"enable_thinking": true}'`.
- Tool calling is documented in the guide (parser [vllm#43175](https://github.com/vllm-project/vllm/pull/43175) is not yet in any release; bridged via `--tool-parser-plugin`) rather than shipped as a pill on the pinned version.

## Validation
`node scripts/build-recipes-api.mjs` → `✓ JSON API: 106 models, 8 strategies` with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)