### PR TITLE
add attention backend recommendation for Minimax 2.5

### DIFF
--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -187,6 +187,11 @@ guide: |
     --trust-remote-code
   ```
 
+  For H200 FP8, choose the attention backend by sequence length for best performance:
+  shorter sequences (e.g. 1024) should keep the command above with `--attention-backend FLASHINFER`
+  and `--enable-flashinfer-autotune`, while longer input sequences (e.g. 8192)
+  can prefer FlashAttention by replacing those flags with `--attention-backend FLASH_ATTN`.
+
   Pure TP8 is not supported. For >4 GPUs use DP+EP or TP+EP.
 
   ### TP4+EP (recommended for H100)


### PR DESCRIPTION
For longer sequence lengths, use flash attention backend for best performance for minimax on H200 FP8. 

Reference: https://github.com/SemiAnalysisAI/InferenceX/pull/1668