### PR TITLE
[Gemma4] Add official QAT W4A16 and mobile quantized variants

### DIFF
--- a/Google/Gemma4.md
+++ b/Google/Gemma4.md
@@ -1031,6 +1031,44 @@ Higher `num_speculative_tokens` increases draft overhead per cycle. The optimal 
 > These recommendations were benchmarked on NVIDIA A100 and H100 servers. Optimal settings may vary on different hardware platforms — experimentation is recommended.
 
 
+## Quantized Models (QAT W4A16)
+
+Google provides official QAT (Quantization-Aware Training) W4A16 checkpoints for the Gemma 4 dense model family. These use 4-bit integer weights with 16-bit activations (group_size=32) in `compressed-tensors` format, delivering significant memory savings and throughput improvements with minimal quality loss.
+
+### Available Checkpoints
+
+| Base Model | QAT W4A16 Checkpoint | Memory Savings |
+|---|---|---|
+| google/gemma-4-E2B-it | [google/gemma-4-E2B-it-qat-w4a16-ct](https://huggingface.co/google/gemma-4-E2B-it-qat-w4a16-ct) | ~26% (9.8→7.3 GB) |
+| google/gemma-4-E4B-it | [google/gemma-4-E4B-it-qat-w4a16-ct](https://huggingface.co/google/gemma-4-E4B-it-qat-w4a16-ct) | ~36% (15.2→9.8 GB) |
+| google/gemma-4-12B-it | [google/gemma-4-12B-it-qat-w4a16-ct](https://huggingface.co/google/gemma-4-12B-it-qat-w4a16-ct) | ~64% (22.8→8.3 GB) |
+| google/gemma-4-31B-it | [google/gemma-4-31B-it-qat-w4a16-ct](https://huggingface.co/google/gemma-4-31B-it-qat-w4a16-ct) | ~66% (59.0→19.8 GB) |
+
+> ℹ️ **Note**
+> The 26B-A4B MoE model is not included — its small expert dimensions (704) cause excessive quality loss with 4-bit quantization. For the MoE model, use `--quantization int8_per_channel_weight_only` (online, no checkpoint needed) which provides ~47% memory savings with negligible quality impact.
+
+### Serving a QAT W4A16 Checkpoint
+
+No `--quantization` flag is needed — vLLM auto-detects the quantization config from the checkpoint:
+
+```bash
+vllm serve google/gemma-4-31B-it-qat-w4a16-ct \
+  --max-model-len 32768 \
+  --gpu-memory-utilization 0.90
+```
+
+### 26B MoE: Int8 Per-Channel Quantization
+
+The 26B-A4B MoE model uses online int8 per-channel weight-only quantization instead of W4A16 — its small expert dimensions (128 experts × 704 intermediate size) are sensitive to 4-bit quantization:
+
+```bash
+vllm serve google/gemma-4-26B-A4B-it \
+  --quantization int8_per_channel_weight_only \
+  --max-model-len 32768 \
+  --gpu-memory-utilization 0.90
+```
+
+
 ## Benchmarking
 
 ### Launch Server for Benchmarking

--- a/Google/Gemma4.md
+++ b/Google/Gemma4.md
@@ -1068,6 +1068,29 @@ vllm serve google/gemma-4-26B-A4B-it \
   --gpu-memory-utilization 0.90
 ```
 
+### Quantized Models (QAT Mobile — Mixed Int2/4/8)
+
+Google also provides **mobile-optimized QAT checkpoints** for the E2B and E4B models. Unlike the uniform W4A16 variants above, these use a mixed-precision `compressed-tensors` scheme with per-layer bitwidth assignment — including int2 embeddings and lm_head, which are typically left unquantized:
+
+| Component | Weight Bits | Notes |
+|---|---|---|
+| Embeddings + lm_head | **2-bit** | Channel-quantized, pack-quantized format |
+| Audio tower linears | **2-bit** | W2A8 (int2 weights, int8 activations) |
+| LLM attention + MLP | **4-bit** (E4B) / **2–4-bit** (E2B) | E2B drops deeper MLP layers (15–34) to int2 |
+| Per-layer gates/projections + vision tower | **8-bit** | W8A8 (int8 weights, int8 activations) |
+
+| Base Model | Mobile QAT Checkpoint | Weight Memory | Compression vs BF16 |
+|---|---|---|---|
+| google/gemma-4-E2B-it | [google/gemma-4-E2B-it-qat-mobile-ct](https://huggingface.co/google/gemma-4-E2B-it-qat-mobile-ct) | 2.7 GB | 3.6× smaller |
+| google/gemma-4-E4B-it | [google/gemma-4-E4B-it-qat-mobile-ct](https://huggingface.co/google/gemma-4-E4B-it-qat-mobile-ct) | 3.7 GB | 4.1× smaller |
+
+**Performance (A100-80GB, 1024in/1024out text requests):** E4B mobile delivers **up to 1.5× higher output throughput** vs BF16 at low concurrency (1–16 requests) where decode is memory-bandwidth-bound. The speedup tapers above ~64 concurrent requests as the workload becomes compute-bound.
+
+The primary value proposition is **footprint**: 3.6–4.1× smaller weights free VRAM for KV cache or allow deployment on much smaller GPUs. Multimodal correctness (text, vision, audio) tracks BF16 quality.
+
+```bash
+vllm serve google/gemma-4-E4B-it-qat-mobile-ct
+```
 
 ## Benchmarking
 

--- a/models/Google/gemma-4-12B-it.yaml
+++ b/models/Google/gemma-4-12B-it.yaml
@@ -64,6 +64,11 @@ variants:
     precision: bf16
     vram_minimum_gb: 29
     description: "Full BF16 — single 40 GB+ NVIDIA GPU"
+  w4a16:
+    model_id: "google/gemma-4-12B-it-qat-w4a16-ct"
+    precision: int4
+    vram_minimum_gb: 9
+    description: "W4A16 QAT (4-bit weights, 16-bit activations, group_size=32) via compressed-tensors — runs on any GPU"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -82,6 +82,11 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
+  w4a16:
+    model_id: "google/gemma-4-31B-it-qat-w4a16-ct"
+    precision: int4
+    vram_minimum_gb: 20
+    description: "W4A16 QAT (4-bit weights, 16-bit activations, group_size=32) via compressed-tensors — runs on any GPU"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Google/gemma-4-E2B-it.yaml
+++ b/models/Google/gemma-4-E2B-it.yaml
@@ -78,6 +78,11 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
+  w4a16:
+    model_id: "google/gemma-4-E2B-it-qat-w4a16-ct"
+    precision: int4
+    vram_minimum_gb: 8
+    description: "W4A16 QAT (4-bit weights, 16-bit activations, group_size=32) via compressed-tensors — runs on any GPU"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Google/gemma-4-E2B-it.yaml
+++ b/models/Google/gemma-4-E2B-it.yaml
@@ -83,6 +83,11 @@ variants:
     precision: int4
     vram_minimum_gb: 8
     description: "W4A16 QAT (4-bit weights, 16-bit activations, group_size=32) via compressed-tensors — runs on any GPU"
+  mobile:
+    model_id: "google/gemma-4-E2B-it-qat-mobile-ct"
+    precision: int2/4/8
+    vram_minimum_gb: 4
+    description: "Mobile QAT — mixed int2/4/8 compressed-tensors (int2 embeddings + lm_head + deep MLP, int4 attention + early MLP, int8 vision + gates). 3.6× weight compression vs BF16, up to 1.25× faster decode at low batch"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Google/gemma-4-E4B-it.yaml
+++ b/models/Google/gemma-4-E4B-it.yaml
@@ -83,6 +83,11 @@ variants:
     precision: int4
     vram_minimum_gb: 10
     description: "W4A16 QAT (4-bit weights, 16-bit activations, group_size=32) via compressed-tensors — runs on any GPU"
+  mobile:
+    model_id: "google/gemma-4-E4B-it-qat-mobile-ct"
+    precision: int2/4/8
+    vram_minimum_gb: 5
+    description: "Mobile QAT — mixed int2/4/8 compressed-tensors (int2 embeddings + lm_head + audio, int4 LLM attention + MLP, int8 vision + gates). 4.1× weight compression vs BF16, up to 1.5× faster decode at low batch"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Google/gemma-4-E4B-it.yaml
+++ b/models/Google/gemma-4-E4B-it.yaml
@@ -78,6 +78,11 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
+  w4a16:
+    model_id: "google/gemma-4-E4B-it-qat-w4a16-ct"
+    precision: int4
+    vram_minimum_gb: 10
+    description: "W4A16 QAT (4-bit weights, 16-bit activations, group_size=32) via compressed-tensors — runs on any GPU"
 
 compatible_strategies:
   - single_node_tp


### PR DESCRIPTION
## Summary

Add W4A16 quantized variant entries for the four Gemma 4 dense models, pointing to Google's official QAT (Quantization-Aware Training) checkpoints in `compressed-tensors` format.

### Changes

**Recipe YAMLs** — new `w4a16` variant added to:
- `models/Google/gemma-4-E2B-it.yaml` (`google/gemma-4-E2B-it-qat-w4a16-ct`)
- `models/Google/gemma-4-E4B-it.yaml` (`google/gemma-4-E4B-it-qat-w4a16-ct`)
- `models/Google/gemma-4-12B-it.yaml` ( `google/gemma-4-12B-it-qat-w4a16-ct`)
- `models/Google/gemma-4-31B-it.yaml` (`google/gemma-4-31B-it-qat-w4a16-ct`)

**Usage guide** (`Google/Gemma4.md`) — new "Quantized Models (QAT W4A16)" section with:
- Checkpoint table with memory savings per model size
- Serving example (no `--quantization` flag needed — vLLM auto-detects)
- Note on 26B-A4B MoE requiring `int8_per_channel_weight_only` instead of W4A16

### Checkpoint details

- **Quantization**: 4-bit integer weights, 16-bit activations, symmetric, group_size=32
- **Format**: `compressed-tensors` (pack-quantized) — vLLM loads via Marlin W4A16 kernel
- **Excluded layers**: vision tower/embedder, audio tower, router, embeddings, lm_head (kept in BF16)
- **No serving flags required**: `quantization_config` is embedded in the checkpoint's `config.json`

### Validation

Tested each checkpoint end-to-end with `vllm serve` on NVIDIA A100 80GB (TP=1).