### PR TITLE
Use match-sorter for search: multi-word, separator-insensitive, ranked

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clsx": "^2.1.1",
     "js-yaml": "^4.1.1",
     "lucide-react": "^0.483.0",
+    "match-sorter": "^8.3.0",
     "next": "^15.5.9",
     "next-mdx-remote": "^6.0.0",
     "react": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       lucide-react:
         specifier: ^0.483.0
         version: 0.483.0(react@19.2.5)
+      match-sorter:
+        specifier: ^8.3.0
+        version: 8.3.0
       next:
         specifier: ^15.5.9
         version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -91,6 +94,10 @@ packages:
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.10.0':
@@ -1869,6 +1876,9 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  match-sorter@8.3.0:
+    resolution: {integrity: sha512-8Py1GbZi5zsclYSFcPAH4H5xfTbeD0bOREA7qP/t8bW4MbOSlPl8sbqHOedEV7O+Bxyvxm6xs/v6BXJGe+JDNA==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2291,6 +2301,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  remove-accents@0.5.0:
+    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2614,6 +2627,8 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -4530,6 +4545,11 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  match-sorter@8.3.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      remove-accents: 0.5.0
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
@@ -5325,6 +5345,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  remove-accents@0.5.0: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -72,6 +72,9 @@ export default async function RootLayout({ children }) {
       architecture: r.model.architecture,
       parameter_count: r.model.parameter_count,
     },
+    precisions: [...new Set(
+      Object.values(r.variants || {}).map((v) => v?.precision).filter(Boolean)
+    )],
   }));
 
   return (

--- a/src/components/recipes/BrowseList.jsx
+++ b/src/components/recipes/BrowseList.jsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Layers, Cpu, X, ArrowDownUp, Type, Eye, Sparkles, Hash, SlidersHorizontal, ChevronDown } from "lucide-react";
 import { getProviderLogo, getProviderLogoClass, getProviderDisplayName } from "@/lib/providers";
+import { searchRecipes } from "@/lib/search";
 
 // Per-row decorations: icon (tasks/arch) or colored dot (precision/hardware).
 // Color is family-grouped — precision tiers, GPU brands — so the eye can
@@ -142,41 +143,14 @@ export function BrowseList({ recipes }) {
     };
   }, [searchParams]);
 
-  // Free-text match used for the `?q=...` query — same field set as the
-  // top-bar SearchBox so handing off from search to browse stays predictable.
-  // Verified hardware ids enter the haystack so "h100" / "mi300x" / "b200"
-  // find recipes by GPU compatibility; "tpu" is added as a synonym when any
-  // TPU profile is verified, since the ids (trillium/ironwood) don't carry it.
+  const qMatchIds = useMemo(() => {
+    if (!q) return null;
+    return new Set(searchRecipes(recipes, q).map((r) => r.hf_id));
+  }, [q, recipes]);
+
   const matchesQ = useCallback(
-    (r) => {
-      if (!q) return true;
-      const hwKeys = Object.entries(r.meta?.hardware || {})
-        .filter(([, s]) => s === "verified")
-        .map(([h]) => h);
-      const hwExtra = [
-	      (hwKeys.some((k) => k === "trillium" || k === "ironwood") ? ["tpu"] : []),
-	      (hwKeys.some((k) => k === "xeon6" || k === "xeon5") ? ["intel", "xeon", "cpu", "x86"] : []),
-      ];	    
-      const hay = [
-        r.hf_repo,
-        r.hf_org,
-        r.meta?.title,
-        r.meta?.provider,
-        r.meta?.description,
-        ...(r.meta?.tasks || []),
-        r.model?.architecture,
-        r.model?.parameter_count,
-        r.variant?.precision,
-        ...(r.precisions || []),
-        ...hwKeys,
-        ...hwExtra,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return hay.includes(q);
-    },
-    [q]
+    (r) => !qMatchIds || qMatchIds.has(r.hf_id),
+    [qMatchIds],
   );
 
   const update = useCallback(

--- a/src/components/recipes/SearchBox.jsx
+++ b/src/components/recipes/SearchBox.jsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Search, ArrowRight, Building2, SlidersHorizontal } from "lucide-react";
 import { recipeHref } from "@/lib/recipe-utils";
 import { getProviderLogo, getProviderLogoClass, getProviderDisplayName, PROVIDERS } from "@/lib/providers";
+import { searchRecipes, searchProviders } from "@/lib/search";
 
 export function SearchBox({ recipes }) {
   const [query, setQuery] = useState("");
@@ -16,20 +17,14 @@ export function SearchBox({ recipes }) {
   // Build a unified results list: first matching providers, then matching recipes
   const results = useMemo(() => {
     if (!query.trim()) return [];
-    const q = query.toLowerCase();
 
     // Count recipes per org (for display on provider entry)
     const orgCount = {};
     for (const r of recipes) orgCount[r.hf_org] = (orgCount[r.hf_org] || 0) + 1;
 
     // Find matching providers (by hf_org or display_name)
-    const providerMatches = Object.entries(PROVIDERS)
-      .filter(([org, meta]) => {
-        if (!orgCount[org]) return false; // only providers that have recipes
-        const hay = `${org} ${meta.display_name}`.toLowerCase();
-        return hay.includes(q);
-      })
-      // Dedupe case variants (e.g. "google" and "Google" both match)
+    const providerList = Object.entries(PROVIDERS).filter(([org]) => orgCount[org]);
+    const providerMatches = searchProviders(providerList, query)
       .filter((entry, i, arr) => arr.findIndex((e) => e[1].display_name === entry[1].display_name) === i)
       .slice(0, 3)
       .map(([org, meta]) => ({
@@ -40,38 +35,7 @@ export function SearchBox({ recipes }) {
         href: `/${org}`,
       }));
 
-    // Find matching recipes — compute total match count first, then slice
-    // for display. The total drives the "Browse N matching recipes" footer
-    // so users have an exit when there are more matches than fit.
-    const allRecipeMatches = recipes.filter((r) => {
-      // Verified hardware ids land in the haystack so "h100", "mi300x",
-      // "b200" etc. find recipes by GPU compatibility. "tpu" is added as
-      // a synonym whenever any TPU profile is verified, since the ids
-      // (trillium / ironwood) don't contain that string.
-      const hwKeys = Object.entries(r.meta?.hardware || {})
-        .filter(([, s]) => s === "verified")
-        .map(([h]) => h);
-      const hwExtra = [
-	      (hwKeys.some((k) => k === "trillium" || k === "ironwood") ? ["tpu"] : []),
-	      (hwKeys.some((k) => k === "xeon6" || k === "xeon5") ? ["intel", "xeon", "cpu", "x86"] : []),
-      ];	    
-      const hay = [
-        r.meta.title,
-        r.hf_repo,
-        r.hf_org,
-        r.meta.provider,
-        r.meta.description,
-        ...(r.meta.tasks || []),
-        r.model.architecture,
-        r.model.parameter_count,
-        ...hwKeys,
-        ...hwExtra,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return hay.includes(q);
-    });
+    const allRecipeMatches = searchRecipes(recipes, query);
     const recipeMatches = allRecipeMatches
       .slice(0, 6)
       .map((r) => ({ type: "recipe", recipe: r, href: recipeHref(r) }));

--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -1,6 +1,6 @@
 import { matchSorter } from "match-sorter";
 
-const strip = (s) => (s || "").replace(/[-_.]/g, "");
+const strip = (s) => String(s || "").replace(/[-_.]/g, "");
 
 const RECIPE_KEYS = [
   { key: (r) => strip(r.hf_repo) },
@@ -12,7 +12,7 @@ const RECIPE_KEYS = [
   { key: (r) => strip(r.model?.architecture) },
   { key: (r) => strip(r.model?.parameter_count) },
   { key: (r) => strip(r.variant?.precision) },
-  { key: (r) => (r.precisions || []).join(" ") },
+  { key: (r) => (r.precisions || []).map(strip).join(" ") },
   {
     key: (r) => {
       const hw = r.meta?.hardware || {};
@@ -23,7 +23,7 @@ const RECIPE_KEYS = [
         ...(verified.some((k) => k === "trillium" || k === "ironwood") ? ["tpu"] : []),
         ...(verified.some((k) => k === "xeon6" || k === "xeon5") ? ["intel", "xeon", "cpu", "x86"] : []),
       ];
-      return [...verified, ...synonyms].join(" ");
+      return [...verified, ...synonyms].map(strip).join(" ");
     },
   },
 ];
@@ -46,7 +46,7 @@ export function searchProviders(providerEntries, query) {
   if (!q) return [];
   const keys = [
     { key: (entry) => strip(entry[0]) },
-    { key: (entry) => strip(entry[1].display_name) },
+    { key: (entry) => strip(entry[1]?.display_name) },
   ];
   return q.split(/\s+/).reduceRight(
     (items, word) =>

--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -1,0 +1,59 @@
+import { matchSorter } from "match-sorter";
+
+const strip = (s) => (s || "").replace(/[-_.]/g, "");
+
+const RECIPE_KEYS = [
+  { key: (r) => strip(r.hf_repo) },
+  { key: (r) => strip(r.hf_org) },
+  { key: (r) => strip(r.meta?.title) },
+  { key: (r) => strip(r.meta?.provider) },
+  { key: (r) => strip(r.meta?.description) },
+  { key: (r) => (r.meta?.tasks || []).map(strip).join(" ") },
+  { key: (r) => strip(r.model?.architecture) },
+  { key: (r) => strip(r.model?.parameter_count) },
+  { key: (r) => strip(r.variant?.precision) },
+  { key: (r) => (r.precisions || []).join(" ") },
+  {
+    key: (r) => {
+      const hw = r.meta?.hardware || {};
+      const verified = Object.entries(hw)
+        .filter(([, s]) => s === "verified")
+        .map(([h]) => h);
+      const synonyms = [
+        ...(verified.some((k) => k === "trillium" || k === "ironwood") ? ["tpu"] : []),
+        ...(verified.some((k) => k === "xeon6" || k === "xeon5") ? ["intel", "xeon", "cpu", "x86"] : []),
+      ];
+      return [...verified, ...synonyms].join(" ");
+    },
+  },
+];
+
+export function searchRecipes(recipes, query) {
+  const q = query.trim();
+  if (!q) return [];
+  return q.split(/\s+/).reduceRight(
+    (items, word) =>
+      matchSorter(items, strip(word), {
+        keys: RECIPE_KEYS,
+        threshold: matchSorter.rankings.CONTAINS,
+      }),
+    recipes,
+  );
+}
+
+export function searchProviders(providerEntries, query) {
+  const q = query.trim();
+  if (!q) return [];
+  const keys = [
+    { key: (entry) => strip(entry[0]) },
+    { key: (entry) => strip(entry[1].display_name) },
+  ];
+  return q.split(/\s+/).reduceRight(
+    (items, word) =>
+      matchSorter(items, strip(word), {
+        keys,
+        threshold: matchSorter.rankings.CONTAINS,
+      }),
+    providerEntries,
+  );
+}


### PR DESCRIPTION
## Summary

- Add `match-sorter` (~2.5 KB gzip) to replace hand-rolled `.includes()` substring matching
- Extract shared search logic into `src/lib/search.js`, simplifying both `SearchBox` and `BrowseList`
- "gemma4" now matches "gemma-4", "e2b gemma" matches "gemma-4-E2B-it", and results are ranked by match quality

## What changed

**`src/lib/search.js` (new)** — `searchRecipes()` and `searchProviders()` strip separators (`-`, `_`, `.`) from both query and values, split on whitespace for multi-word AND matching, and use match-sorter's ranking tiers (starts-with > word-starts-with > contains). Hardware synonyms (tpu, intel/xeon/cpu/x86) are preserved.

**`SearchBox.jsx`** — replaced ~30 lines of haystack construction + `.includes()` with `searchRecipes()` / `searchProviders()` calls.

**`BrowseList.jsx`** — replaced per-recipe haystack callback with a precomputed `Set` of matching IDs from `searchRecipes()`. All categorical filters, counts, and sorting are unchanged.

## Test plan

- [ ] Search "gemma4" → matches gemma-4 models
- [ ] Search "e2b gemma" → matches gemma-4-E2B-it
- [ ] Search "gemma" → still matches all gemma models
- [ ] Search "h100" / "tpu" → hardware synonym matches work
- [ ] Click "Browse N matching" → browse page shows same results
- [ ] Browse page `?q=gemma4` → correct filtered results
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)