### PR TITLE
chore: remove MiniMax fusion config

### DIFF
--- a/models/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.1.yaml
@@ -58,10 +58,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  nvidia:
-    extra_args:
-      - "--compilation-config"
-      - '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
   amd:
     extra_args:
       - "--tensor-parallel-size"
@@ -114,7 +110,6 @@ guide: |
         --tool-call-parser minimax_m2 \
         --reasoning-parser minimax_m2 \
         --enable-auto-tool-choice \
-        --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
         --trust-remote-code
   ```
 
@@ -127,7 +122,6 @@ guide: |
     --tensor-parallel-size 4 \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice \
     --trust-remote-code
   ```
@@ -142,7 +136,6 @@ guide: |
     --enable-expert-parallel \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice
   ```
 
@@ -174,7 +167,7 @@ guide: |
   ## Troubleshooting
 
   - See [MiniMax-M2](./MiniMax-M2.yaml) for shared troubleshooting notes
-    (`fuse_minimax_qk_norm`, nightly vs stable, DeepGEMM, AITER).
+    (latest vLLM fusion behavior, nightly vs stable, DeepGEMM, AITER).
 
   ## References
 

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -73,11 +73,11 @@ hardware_overrides:
   nvidia:
     extra_args:
       - "--compilation-config"
-      - '{"mode":3,"cudagraph_mode":"PIECEWISE","pass_config":{"fuse_minimax_qk_norm":true}}'
+      - '{"cudagraph_mode":"PIECEWISE"}'
   hopper:
     extra_args:
       - "--compilation-config"
-      - '{"mode":3,"cudagraph_mode":"PIECEWISE","pass_config":{"fuse_minimax_qk_norm":true}}'
+      - '{"cudagraph_mode":"PIECEWISE"}'
       - "--max-num-seqs"
       - "512"
       - "--max-num-batched-tokens"
@@ -156,7 +156,7 @@ guide: |
         --tool-call-parser minimax_m2 \
         --reasoning-parser minimax_m2 \
         --enable-auto-tool-choice \
-        --compilation-config '{"mode":3,"cudagraph_mode":"PIECEWISE","pass_config":{"fuse_minimax_qk_norm":true}}' \
+        --compilation-config '{"cudagraph_mode":"PIECEWISE"}' \
         --trust-remote-code
   ```
 
@@ -179,7 +179,7 @@ guide: |
     --enable-flashinfer-autotune \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"cudagraph_mode":"PIECEWISE","pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --compilation-config '{"cudagraph_mode":"PIECEWISE"}' \
     --enable-auto-tool-choice \
     --trust-remote-code
   ```
@@ -199,7 +199,7 @@ guide: |
     --enable-expert-parallel \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
+    --compilation-config '{"cudagraph_mode":"PIECEWISE"}' \
     --enable-auto-tool-choice
   ```
 
@@ -231,7 +231,7 @@ guide: |
   ## Troubleshooting
 
   - See [MiniMax-M2](./MiniMax-M2.yaml) for shared troubleshooting notes
-    (`fuse_minimax_qk_norm`, nightly vs stable, DeepGEMM, AITER).
+    (latest vLLM fusion behavior, nightly vs stable, DeepGEMM, AITER).
 
   ## References
 

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -70,10 +70,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  nvidia:
-    extra_args:
-      - "--compilation-config"
-      - '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
   amd:
     extra_args:
       - "--tensor-parallel-size"
@@ -132,7 +128,6 @@ guide: |
         --tool-call-parser minimax_m2 \
         --reasoning-parser minimax_m2 \
         --enable-auto-tool-choice \
-        --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
         --trust-remote-code
   ```
 
@@ -145,7 +140,6 @@ guide: |
     --tensor-parallel-size 4 \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice \
     --trust-remote-code
   ```
@@ -160,7 +154,6 @@ guide: |
     --enable-expert-parallel \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice
   ```
 
@@ -172,7 +165,6 @@ guide: |
     --enable-expert-parallel \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice
   ```
 
@@ -184,7 +176,6 @@ guide: |
     --enable-expert-parallel \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice
   ```
 
@@ -215,9 +206,9 @@ guide: |
 
   ## Troubleshooting
 
-  - **`fuse_minimax_qk_norm` not recognized:** This fusion was introduced in
-    [vLLM PR #37045](https://github.com/vllm-project/vllm/pull/37045); ensure your
-    vLLM build includes it.
+  - **MiniMax QK norm fusion:** Latest vLLM applies the fusion automatically at
+    runtime when the fused CUDA op is available; older vLLM builds used an
+    explicit `fuse_minimax_qk_norm` compile pass.
   - **Corrupted output on stable release:** Upgrade to a nightly after commit
     `cf3eacfe58fa9e745c2854782ada884a9f992cf7`.
   - **Verified accuracy:** Use the pinned commit
@@ -231,4 +222,4 @@ guide: |
 
   - [Model card](https://huggingface.co/MiniMaxAI/MiniMax-M2.7)
   - [MiniMax](https://www.minimax.io/)
-  - [vLLM PR #37045 (fuse_minimax_qk_norm)](https://github.com/vllm-project/vllm/pull/37045)
+  - [vLLM PR #43410 (automatic MiniMax QK norm fusion)](https://github.com/vllm-project/vllm/pull/43410)

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -74,10 +74,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  nvidia:
-    extra_args:
-      - "--compilation-config"
-      - '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}'
   amd:
     # First launch JIT-compiles AITER kernels (CK FP8 MoE, RMSNorm, activation);
     # expect a slow cold start on MI300X/MI325X/MI350X/MI355X.
@@ -152,7 +148,6 @@ guide: |
         --tool-call-parser minimax_m2 \
         --reasoning-parser minimax_m2 \
         --enable-auto-tool-choice \
-        --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
         --trust-remote-code
   ```
 
@@ -165,7 +160,6 @@ guide: |
     --tensor-parallel-size 4 \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice \
     --trust-remote-code
   ```
@@ -180,7 +174,6 @@ guide: |
     --enable-expert-parallel \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice
   ```
 
@@ -192,7 +185,6 @@ guide: |
     --enable-expert-parallel \
     --tool-call-parser minimax_m2 \
     --reasoning-parser minimax_m2 \
-    --compilation-config '{"mode":3,"pass_config":{"fuse_minimax_qk_norm":true}}' \
     --enable-auto-tool-choice
   ```
 
@@ -223,9 +215,9 @@ guide: |
 
   ## Troubleshooting
 
-  - **`fuse_minimax_qk_norm` not recognized:** This fusion was introduced in
-    [vLLM PR #37045](https://github.com/vllm-project/vllm/pull/37045); ensure your
-    vLLM build includes it.
+  - **MiniMax QK norm fusion:** Latest vLLM applies the fusion automatically at
+    runtime when the fused CUDA op is available; older vLLM builds used an
+    explicit `fuse_minimax_qk_norm` compile pass.
   - **Corrupted output on stable release:** Upgrade to a nightly after commit
     `cf3eacfe58fa9e745c2854782ada884a9f992cf7`.
   - **DeepGEMM:** vLLM uses DeepGEMM by default; install via
@@ -246,4 +238,4 @@ guide: |
   - [Model card](https://huggingface.co/MiniMaxAI/MiniMax-M2)
   - [NVFP4 variant](https://huggingface.co/RedHatAI/MiniMax-M2-NVFP4)
   - [MiniMax](https://www.minimax.io/)
-  - [vLLM PR #37045 (fuse_minimax_qk_norm)](https://github.com/vllm-project/vllm/pull/37045)
+  - [vLLM PR #43410 (automatic MiniMax QK norm fusion)](https://github.com/vllm-project/vllm/pull/43410)


### PR DESCRIPTION
Removing the fusion flag since it is enabled in engine by default. 

Part of https://github.com/vllm-project/recipes/issues/366

Successful on B200
```
vllm serve MiniMaxAI/MiniMax-M2.7 \
  --trust-remote-code \
  --tensor-parallel-size 4 \
  --tool-call-parser minimax_m2 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m2

(EngineCore pid=1355662) INFO 06-10 10:29:12 [core.py:112] Initializing a V1 LLM engine (v0.22.1) with config: model='MiniMaxAI/MiniMax-M2.7', speculative_config=None, tokenizer='MiniMaxAI/MiniMax-M2.7', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=204800, download_dir=None, load_format=auto, tensor_parallel_size=4, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=fp8, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='minimax_m2', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=MiniMaxAI/MiniMax-M2.7, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['+quant_fp8', 'none', '+quant_fp8'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [5461, 8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': True, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')



(APIServer pid=1354921) INFO:     Started server process [1354921]
(APIServer pid=1354921) INFO:     Waiting for application startup.
(APIServer pid=1354921) INFO:     Application startup complete.


```