### PR TITLE
MiniMax-M3: set VLLM_USE_BREAKABLE_CUDAGRAPH=0 on AMD MI300X/MI325X/MI355X

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -129,6 +129,10 @@ hardware_overrides:
     extra_args:
       - "--attention-backend"
       - "TRITON_ATTN"
+    extra_env:
+      # Run MiniMax-M3 with CUDA graphs on AMD MI3xx; avoids the decode
+      # breakable-cudagraph path that otherwise forces eager (per @hongxiayang).
+      VLLM_USE_BREAKABLE_CUDAGRAPH: "0"
 
 guide: |
   ## Overview
@@ -222,6 +226,14 @@ guide: |
   ```
 
   ### AMD ROCm (MI350X/MI355X (gfx950), MI300X/MI325X (gfx942))
+
+  On AMD MI300X / MI325X / MI355X, run with CUDA graphs and set the following
+  before any of the serve commands below. It avoids the MiniMax-M3 decode breakable-cudagraph path that would
+  otherwise force eager execution (per @hongxiayang):
+
+  ```bash
+  export VLLM_USE_BREAKABLE_CUDAGRAPH=0
+  ```
 
   For gfx950: Prefer using the MXFP8 variant `MiniMaxAI/MiniMax-M3-MXFP8` for TP=4 and a smaller
   footprint. Use TP=8 for lower latency or long context length, or the default bf16 model.


### PR DESCRIPTION
## Summary

On AMD MI300X / MI325X / MI355X, running MiniMax-M3 with CUDA graphs needs `VLLM_USE_BREAKABLE_CUDAGRAPH=0` to avoid the MiniMax-M3 decode breakable-cudagraph path that otherwise forces eager execution. This adds a short note + the `export` to the AMD ROCm section of the MiniMax-M3 recipe so MI3xx users get cudagraph performance out of the box.

Per @hongxiayang's suggestion.

Validated on MI300X and MI355X (8-GPU, MXFP8): with `VLLM_USE_BREAKABLE_CUDAGRAPH=0` the server starts and serves cleanly with CUDA graphs across the TP8 / TP8+EP / TP4 layouts.

Docs-only change to `models/MiniMaxAI/MiniMax-M3.yaml` (+9 lines).