### PR TITLE
Add NVFP4 variant for DeepSeek-V4-Pro and DeepSeek-V4-Flash

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -75,6 +75,11 @@ variants:
     precision: fp8
     vram_minimum_gb: 170
     description: "Native FP4+FP8 mixed checkpoint (MoE experts FP4, remaining params FP8)"
+  nvfp4:
+    model_id: "nvidia/DeepSeek-V4-Flash-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 170
+    description: "NVIDIA modelopt NVFP4 checkpoint (MoE experts NVFP4; attention, shared experts, router head, and MTP stay FP8) for Blackwell GPUs."
 
 compatible_strategies:
   - single_node_tp
@@ -184,6 +189,12 @@ guide: |
 
   Checkpoint is **FP4+FP8 mixed**: MoE expert weights are stored in FP4 while the
   remaining (attention / norm / router) params stay in FP8.
+
+  An **NVFP4 variant** (`nvidia/DeepSeek-V4-Flash-NVFP4`) is also available — NVIDIA
+  modelopt re-quantizes the MoE experts to standard NVFP4 while attention, shared
+  experts, router head, and MTP stay FP8. Pick it from the **Variant** row; it runs on
+  Blackwell GPUs and inherits the same FP4 MoE backend (`deep_gemm_mega_moe` + FP4
+  indexer cache) as the native checkpoint.
 
   ## Reasoning modes
 

--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -69,6 +69,11 @@ variants:
     precision: fp8
     vram_minimum_gb: 960
     description: "Native FP4+FP8 mixed checkpoint (MoE experts FP4, remaining params FP8)"
+  nvfp4:
+    model_id: "nvidia/DeepSeek-V4-Pro-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 960
+    description: "NVIDIA modelopt NVFP4 checkpoint (MoE experts NVFP4; attention, shared experts, router head, and MTP stay FP8) for Blackwell GPUs."
 
 compatible_strategies:
   - single_node_tp
@@ -203,6 +208,12 @@ guide: |
 
   Checkpoint is **FP4+FP8 mixed**: MoE expert weights are stored in FP4 while the
   remaining (attention / norm / router) params stay in FP8.
+
+  An **NVFP4 variant** (`nvidia/DeepSeek-V4-Pro-NVFP4`) is also available — NVIDIA
+  modelopt re-quantizes the MoE experts to standard NVFP4 while attention, shared
+  experts, router head, and MTP stay FP8. Pick it from the **Variant** row; it runs on
+  Blackwell GPUs and inherits the same FP4 MoE backend (`deep_gemm_mega_moe` + FP4
+  indexer cache) as the native checkpoint.
 
   ## Reasoning modes
 


### PR DESCRIPTION
## What

Adds an `nvfp4` variant to both DeepSeek V4 recipes, pointing at the NVIDIA modelopt checkpoints:

- `models/deepseek-ai/DeepSeek-V4-Pro.yaml` → `nvidia/DeepSeek-V4-Pro-NVFP4`
- `models/deepseek-ai/DeepSeek-V4-Flash.yaml` → `nvidia/DeepSeek-V4-Flash-NVFP4`

## Details

Both NVFP4 checkpoints' `config.json` report `quant_algo: MIXED_PRECISION` with `moe_quant_algo: NVFP4` — the MoE experts are quantized to standard NVFP4 while attention, shared experts, router head, and MTP stay FP8. That's the same precision split as the native FP4+FP8 default, so `vram_minimum_gb` is left unchanged (960 GB / 170 GB).

`precision: nvfp4` auto-restricts the variant to Blackwell GPUs, so it inherits the existing recipe-level `blackwell` override (`--moe-backend deep_gemm_mega_moe` + `--attention_config.use_fp4_indexer_cache=True`). No redundant flags were added — `--kv-cache-dtype fp8` is already in `base_args`. Each guide gets a short note describing the variant.

## Validation

- `node scripts/build-recipes-api.mjs` passes (118 models).
- Ran `resolveCommand` for `nvfp4 @ b200`, confirming the synthesized command serves `nvidia/DeepSeek-V4-{Pro,Flash}-NVFP4` with the inherited `deep_gemm_mega_moe` backend and FP4 indexer cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)