### PR TITLE
PD cluster: render follower node commands, fix router endpoints, add per-pool TP/TEP/DEP selector

### DIFF
--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -506,11 +506,11 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     return { prefill: pick("prefill"), decode: pick("decode") };
   }, [recipe, strategies, pdModes]);
   const [pdPrefillPar, setPdPrefillPar] = useState(() => {
-    const p = searchParams.get("prefill_par");
+    const p = searchParams.get("prefill_mode");
     return p && pdModes.includes(p) ? p : pdDefaultPar.prefill;
   });
   const [pdDecodePar, setPdDecodePar] = useState(() => {
-    const p = searchParams.get("decode_par");
+    const p = searchParams.get("decode_mode");
     return p && pdModes.includes(p) ? p : pdDefaultPar.decode;
   });
   // Which DP rank's command to render for each DEP pool. User can bump this
@@ -894,11 +894,11 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     if (role === "prefill") {
       setPdPrefillPar(mode);
       setPdPrefillRank(0);
-      syncUrl({ prefill_par: mode === pdDefaultPar.prefill ? "" : mode, prefill_rank: "" });
+      syncUrl({ prefill_mode: mode === pdDefaultPar.prefill ? "" : mode, prefill_rank: "" });
     } else {
       setPdDecodePar(mode);
       setPdDecodeRank(0);
-      syncUrl({ decode_par: mode === pdDefaultPar.decode ? "" : mode, decode_rank: "" });
+      syncUrl({ decode_mode: mode === pdDefaultPar.decode ? "" : mode, decode_rank: "" });
     }
   };
 

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -1504,7 +1504,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
           {activeStrategy === "pd_cluster" ? (
             <ConfigRow
               label="Nodes"
-              hint="Each pool (prefill / decode) sizes independently. Total cluster = prefill_nodes + decode_nodes. For Kimi-K2.5 on GB200 the production pattern is prefill=1, decode=4."
+              hint="Each pool (prefill / decode) sizes independently. Total cluster = prefill_nodes + decode_nodes."
             >
               <div className="flex flex-wrap items-center gap-3 text-sm">
                 <PdNodeInput
@@ -2159,11 +2159,12 @@ function PdClusterBlock({ result, verifyCmd, benchCmd, statusHeader, onRankChang
           )}
         </div>
       )}
-      {!active.isRouter && active.meta?.parallelism === "dep" && active.meta.nodes > 1 && onRankChange && (
+      {!active.isRouter && active.meta?.nodes > 1 && onRankChange && (
         <div className="px-4 pt-2 pb-0 flex items-center gap-2 text-[11px] text-[var(--command-fg)]/70 flex-wrap">
           <span className="font-mono uppercase tracking-wider text-[var(--command-fg)]/50">node</span>
-          {/* Display node index is 1-based; emitted --data-parallel-start-rank
-              stays 0-based to match vLLM's rank convention. */}
+          {/* Display node index is 1-based; the emitted rank flag stays 0-based
+              to match vLLM's convention — --data-parallel-start-rank for DEP,
+              --node-rank for TP. */}
           <input
             type="number"
             min={1}
@@ -2175,10 +2176,23 @@ function PdClusterBlock({ result, verifyCmd, benchCmd, statusHeader, onRankChang
             }}
             className="w-14 px-2 py-0.5 text-xs font-mono tabular-nums rounded border border-[var(--command-fg)]/20 bg-transparent text-[var(--command-fg)] focus:outline-none focus:border-vllm-blue/60"
           />
-          <span className="text-[var(--command-fg)]/40">
-            of 1..{active.meta.nodes} · start_rank = {active.meta.startRank}
-          </span>
-          <span className="text-[var(--command-fg)]/40 ml-auto">vLLM spawns {active.meta.dpLocal} local DP ranks per node</span>
+          {active.meta.parallelism === "dep" ? (
+            <>
+              <span className="text-[var(--command-fg)]/40">
+                of 1..{active.meta.nodes} · start_rank = {active.meta.startRank}
+              </span>
+              <span className="text-[var(--command-fg)]/40 ml-auto">vLLM spawns {active.meta.dpLocal} local DP ranks per node</span>
+            </>
+          ) : (
+            <>
+              <span className="text-[var(--command-fg)]/40">
+                of 1..{active.meta.nodes} · --node-rank = {active.meta.currentNode ?? 0}
+              </span>
+              <span className="text-[var(--command-fg)]/40 ml-auto">
+                {(active.meta.currentNode ?? 0) === 0 ? "head node — serves HTTP + NIXL" : "follower — runs --headless"}
+              </span>
+            </>
+          )}
         </div>
       )}
       {prelude && (

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package, Info, Zap, Globe, Wrench, Brain } from "lucide-react";
-import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, fitsSingleNode, isHardwareScalable, variantRunsOnHardware, pickFittingVariant, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun, resolveOmniCommand } from "@/lib/command-synthesis";
+import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, fitsSingleNode, isHardwareScalable, variantRunsOnHardware, pickFittingVariant, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun, resolveOmniCommand, pdPoolModes } from "@/lib/command-synthesis";
 import { resolveOmniTasks } from "@/lib/omni-tasks";
 import { TooltipProvider, InfoTip } from "@/components/ui/tooltip";
 import { detectPlaceholdersAll, substitute, substituteEnv, loadEndpoints, saveEndpoint, clearEndpoints } from "@/lib/cluster-endpoints";
@@ -490,6 +490,29 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     if (!searchParams.get("decode_nodes")) setPdDecodeNodes(pdDefaults.decode);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pdDefaults]);
+  // PD-pool parallelism modes offered for this recipe, derived from
+  // compatible_strategies (TP / TEP / DEP). A single-mode list (e.g. dense
+  // models with only TP) hides the per-pool pills entirely.
+  const pdModes = useMemo(() => pdPoolModes(recipe), [recipe]);
+  // Default per-role parallelism: recipe strategy_overrides → strategy YAML →
+  // "tp", clamped to an offered mode.
+  const pdDefaultPar = useMemo(() => {
+    const so = recipe.strategy_overrides?.pd_cluster || {};
+    const st = strategies?.pd_cluster || {};
+    const pick = (role) => {
+      const d = so[role]?.parallelism || st[role]?.parallelism || "tp";
+      return pdModes.includes(d) ? d : pdModes[0];
+    };
+    return { prefill: pick("prefill"), decode: pick("decode") };
+  }, [recipe, strategies, pdModes]);
+  const [pdPrefillPar, setPdPrefillPar] = useState(() => {
+    const p = searchParams.get("prefill_par");
+    return p && pdModes.includes(p) ? p : pdDefaultPar.prefill;
+  });
+  const [pdDecodePar, setPdDecodePar] = useState(() => {
+    const p = searchParams.get("decode_par");
+    return p && pdModes.includes(p) ? p : pdDefaultPar.decode;
+  });
   // Which DP rank's command to render for each DEP pool. User can bump this
   // to see e.g. rank 7's command — illustrates that each rank differs only in
   // --data-parallel-rank, CUDA_VISIBLE_DEVICES, and the per-host ports.
@@ -682,13 +705,13 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       const advArgs = advanced.flatMap((id) => advancedById[id]?.args || []);
       const pdNodes = activeStrategy === "pd_cluster"
         ? {
-          prefill: { nodes: pdPrefillNodes, rank: pdPrefillRank },
-          decode: { nodes: pdDecodeNodes, rank: pdDecodeRank },
+          prefill: { nodes: pdPrefillNodes, rank: pdPrefillRank, parallelism: pdPrefillPar },
+          decode: { nodes: pdDecodeNodes, rank: pdDecodeRank, parallelism: pdDecodePar },
         }
         : null;
       return resolveCommand(recipe, variant, activeStrategy, hwId, features, strategies, taxonomy, advArgs, nodeCount, pdNodes);
     },
-    [recipe, variant, activeStrategy, hwId, features, advanced, advancedById, strategies, taxonomy, nodeCount, pdPrefillNodes, pdDecodeNodes, pdPrefillRank, pdDecodeRank]
+    [recipe, variant, activeStrategy, hwId, features, advanced, advancedById, strategies, taxonomy, nodeCount, pdPrefillNodes, pdDecodeNodes, pdPrefillRank, pdDecodeRank, pdPrefillPar, pdDecodePar]
   );
 
   // Visual feedback when any rendered command changes. Covers single-node
@@ -851,6 +874,21 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     } else {
       setPdDecodeRank(clamped);
       syncUrl({ decode_rank: clamped === 0 ? "" : String(clamped) });
+    }
+  };
+
+  // Switching a pool's parallelism changes what the rank/node index means
+  // (DEP start-rank vs TP node-rank), so reset that pool's rank to 0.
+  const setPdPar = (role, mode) => {
+    if (!pdModes.includes(mode)) return;
+    if (role === "prefill") {
+      setPdPrefillPar(mode);
+      setPdPrefillRank(0);
+      syncUrl({ prefill_par: mode === pdDefaultPar.prefill ? "" : mode, prefill_rank: "" });
+    } else {
+      setPdDecodePar(mode);
+      setPdDecodeRank(0);
+      syncUrl({ decode_par: mode === pdDefaultPar.decode ? "" : mode, decode_rank: "" });
     }
   };
 
@@ -1504,20 +1542,28 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
           {activeStrategy === "pd_cluster" ? (
             <ConfigRow
               label="Nodes"
-              hint="Each pool (prefill / decode) sizes independently. Total cluster = prefill_nodes + decode_nodes."
+              hint={pdModes.length > 1
+                ? "Each pool (prefill / decode) sizes and shards independently — pick its parallelism (TP / TEP / DEP) and node count. Total cluster = prefill_nodes + decode_nodes."
+                : "Each pool (prefill / decode) sizes independently. Total cluster = prefill_nodes + decode_nodes."}
             >
-              <div className="flex flex-wrap items-center gap-3 text-sm">
+              <div className="flex flex-col gap-2 text-sm">
                 <PdNodeInput
                   label="Prefill"
                   value={pdPrefillNodes}
                   gpuPerNode={hwProfile.gpu_count || 8}
                   onChange={(n) => setPdNodes("prefill", n)}
+                  modes={pdModes}
+                  parallelism={pdPrefillPar}
+                  onParChange={(m) => setPdPar("prefill", m)}
                 />
                 <PdNodeInput
                   label="Decode"
                   value={pdDecodeNodes}
                   gpuPerNode={hwProfile.gpu_count || 8}
                   onChange={(n) => setPdNodes("decode", n)}
+                  modes={pdModes}
+                  parallelism={pdDecodePar}
+                  onParChange={(m) => setPdPar("decode", m)}
                 />
                 <span className="text-xs text-muted-foreground tabular-nums">
                   total {(pdPrefillNodes + pdDecodeNodes) * (hwProfile.gpu_count || 8)} GPUs
@@ -1674,10 +1720,37 @@ function endpointHintFor(name) {
   return "value";
 }
 
-function PdNodeInput({ label, value, gpuPerNode, onChange }) {
+const PD_PAR_LABELS = { tp: "TP", tep: "TEP", dep: "DEP" };
+const PD_PAR_TIPS = {
+  tp: "Tensor parallel — one engine sharded across the pool's GPUs; only the head node serves HTTP.",
+  tep: "Tensor + expert parallel — TP layout plus --enable-expert-parallel (MoE models).",
+  dep: "Data + expert parallel — one vllm serve per node, DP across nodes with EP (MoE throughput).",
+};
+
+function PdNodeInput({ label, value, gpuPerNode, onChange, modes, parallelism, onParChange }) {
+  const showPills = Array.isArray(modes) && modes.length > 1 && typeof onParChange === "function";
   return (
-    <label className="inline-flex items-center gap-2">
-      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+    <div className="inline-flex flex-wrap items-center gap-2">
+      <span className="text-xs font-medium text-muted-foreground w-12 shrink-0">{label}</span>
+      {showPills && (
+        <span className="inline-flex gap-1">
+          {modes.map((m) => (
+            <InfoTip key={m} content={PD_PAR_TIPS[m]}>
+              <button
+                onClick={() => onParChange(m)}
+                aria-label={PD_PAR_TIPS[m]}
+                className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-[11px] font-mono transition-all ${
+                  parallelism === m
+                    ? "border-vllm-blue bg-vllm-blue/5 text-foreground ring-1 ring-vllm-blue/20"
+                    : "border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground/40 hover:bg-muted/30"
+                }`}
+              >
+                {PD_PAR_LABELS[m] || m.toUpperCase()}
+              </button>
+            </InfoTip>
+          ))}
+        </span>
+      )}
       <input
         type="number"
         min={1}
@@ -1689,7 +1762,7 @@ function PdNodeInput({ label, value, gpuPerNode, onChange }) {
       <span className="text-xs text-muted-foreground tabular-nums">
         × {gpuPerNode} = {value * gpuPerNode}
       </span>
-    </label>
+    </div>
   );
 }
 

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -757,16 +757,20 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
 
   const selectVariant = (key) => {
     setVariant(key);
-    syncUrl({ variant: key });
     // Only swap hardware when precision demands it (e.g. NVFP4 needs Blackwell).
     // VRAM is not a blocker because multi-node TP/DP can always supply more.
     const v = recipe.variants?.[key] || {};
     const currentProfile = taxonomy.hardware_profiles?.[hwId] || {};
+    const updates = { variant: key };
     if (!isPrecisionCompatible(currentProfile, v)) {
       const next = pickDefaultHardware(taxonomy.hardware_profiles, v, recipe);
       setHwId(next);
-      syncUrl({ hardware: next });
+      updates.hardware = next;
     }
+    // One syncUrl call — two sequential calls each read the same stale
+    // searchParams from this closure, so the second would clobber the first
+    // (dropping variant= when selecting a Blackwell-only variant off Hopper).
+    syncUrl(updates);
   };
 
   const selectHardware = (id) => {
@@ -789,11 +793,16 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     // variant. If the active variant doesn't fit the new box, fall to the
     // largest variant that does (e.g. BF16 → FP8 on DGX Station).
     let activeVariant = currentVariant;
+    // Folded into the single syncUrl below rather than synced here — a separate
+    // syncUrl call would read stale searchParams and get clobbered (same footgun
+    // as selectVariant). Left undefined when the variant is unchanged so the
+    // existing variant= param is preserved, not deleted.
+    let variantUpdate;
     if (!newScalable && !fitsSingleNode(newProfile, currentVariant)) {
       const fitting = pickFittingVariant(recipe, newProfile);
       if (fitting && fitting !== variant) {
         setVariant(fitting);
-        syncUrl({ variant: fitting });
+        variantUpdate = fitting;
         activeVariant = recipe.variants?.[fitting] || currentVariant;
       }
     }
@@ -819,6 +828,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       strategy: "",
       nodes: shouldBumpNodes ? "2" : shouldUnbumpNodes ? "" : undefined,
       features: featuresToUrl(next, id),
+      ...(variantUpdate ? { variant: variantUpdate } : {}),
     });
     savePreference("hardware", id);
     // Mirror the new state to per-recipe storage so a hardware switch

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -99,6 +99,31 @@ export function recommendStrategy(recipe, _hwProfile, nodeCount = 1) {
 }
 
 /**
+ * PD-cluster pool parallelism modes offered for a recipe, derived from its
+ * `compatible_strategies[]`. Each strategy id encodes a parallelism family in
+ * its suffix — `*_tp` / `*_tp_pp` → TP, `*_tep` → TEP, `*_dep` → DEP — and the
+ * pd_cluster pools reuse that same vocabulary. So a recipe listing
+ * single_node_tp + multi_node_tep + multi_node_dep offers TP / TEP / DEP per
+ * pool, while a dense model that only lists `*_tp` strategies offers TP alone.
+ *
+ * Returns an ordered subset of ["tp", "tep", "dep"]; never empty (falls back to
+ * ["tp"]). EP modes (tep/dep) are inherently MoE-only, which compatible_strategies
+ * already encodes — dense recipes don't list them.
+ */
+export function pdPoolModes(recipe) {
+  const compat = recipe?.compatible_strategies || [];
+  const modes = new Set();
+  for (const s of compat) {
+    if (s === "pd_cluster") continue;
+    if (/(?:^|_)dep$/.test(s)) modes.add("dep");
+    else if (/(?:^|_)tep$/.test(s)) modes.add("tep");
+    else if (/(?:^|_)tp(?:_pp)?$/.test(s)) modes.add("tp");
+  }
+  if (modes.size === 0) modes.add("tp");
+  return ["tp", "tep", "dep"].filter((m) => modes.has(m));
+}
+
+/**
  * Precision → allowed hardware constraint.
  * NVFP4 is NVIDIA Blackwell-only (sm_100+). FP4 generic is also Blackwell-only
  * in practice. AWQ/GPTQ/INT quants run on most NVIDIA+AMD hardware.
@@ -574,9 +599,11 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
       // PD splits inference across separate prefill and decode pools.
       //
       // New model (per-role nodes + parallelism):
-      //   pdNodes = { prefill: <int>, decode: <int> } — user-set node counts
+      //   pdNodes = { prefill: {nodes, rank, parallelism?}, decode: {…} }
+      //   parallelism precedence: pdNodes (UI pill) → strategy_overrides →
+      //     strategy YAML → "tp". Modes: "tp" | "tep" | "dep".
       //   role config (strategy_overrides.pd_cluster.<role>):
-      //     parallelism: "tp" | "dep"          (default: "tp")
+      //     parallelism: "tp" | "tep" | "dep"  (default: "tp")
       //     tp:          <int>                  (default: 1 for dep, poolGpus for tp)
       //     parallel_flag: "--…"                (last-resort override)
       //
@@ -599,7 +626,7 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
       const poolGpus = rolePoolNodes === 0
         ? Math.floor(gpuCount / 2)
         : rolePoolNodes * gpuCount;
-      const parallelism = soRoleCfg.parallelism || roleCfg.parallelism || "tp";
+      const parallelism = pdRole.parallelism || soRoleCfg.parallelism || roleCfg.parallelism || "tp";
 
       if (parallelism === "dep") {
         // Data-parallel + expert-parallel pool (Kimi-K2.5 GB200 pattern).
@@ -640,17 +667,23 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
         }
         args.push("--enable-expert-parallel");
       } else {
-        // TP pool. A single engine spanning the pool's nodes via vLLM's mp
-        // multi-node backend: every node runs the same command, varying only
+        // TP / TEP pool. A single engine spanning the pool's nodes via vLLM's
+        // mp multi-node backend: every node runs the same command, varying only
         // --node-rank; rank > 0 adds --headless (no HTTP server). The UI's node
         // selector picks which rank to render via pdRole.rank, mirroring the
-        // DEP pool's per-node command rendering.
+        // DEP pool's per-node command rendering. TEP = the same TP layout plus
+        // expert parallel (mirrors single_node_tep / multi_node_tep strategies).
         const roleParallelFlag =
           soRoleCfg.parallel_flag ||
           roleCfg.parallel_flag ||
           strategy.parallel_flag ||
           "--tensor-parallel-size";
         args.push(roleParallelFlag, String(Math.max(1, poolGpus)));
+        if (parallelism === "tep") {
+          args.push("--enable-expert-parallel");
+          // Cross-node TEP perf tweak from multi_node_tep; single-node TEP omits it.
+          if (rolePoolNodes > 1) args.push("-cc.pass_config.fuse_allreduce_rms=False");
+        }
         if (rolePoolNodes > 1) {
           const nodeIdx = Math.max(0, Math.min(rolePoolNodes - 1, pdRole.rank ?? 0));
           args.push("--nnodes", String(rolePoolNodes));
@@ -819,7 +852,7 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
       const rank = pdRoleObj.rank || 0;
       const rwSoRoleCfg = recipe.strategy_overrides?.[strategyName]?.[roleOverride] || {};
       const rwRoleCfg = strategy[roleOverride] || {};
-      const rwParallelism = rwSoRoleCfg.parallelism || rwRoleCfg.parallelism || "tp";
+      const rwParallelism = pdRoleObj.parallelism || rwSoRoleCfg.parallelism || rwRoleCfg.parallelism || "tp";
       if (rank > 0 && rwParallelism === "dep") {
         const oldVar = `$${roleOverride.toUpperCase()}_NODE_1`;
         const newVar = `$${roleOverride.toUpperCase()}_NODE_${rank + 1}`;
@@ -882,7 +915,7 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
         : (raw && typeof raw === "object") ? raw
         : {};
       const nodes = typeof pdRole.nodes === "number" ? pdRole.nodes : legacyNodes;
-      const parallelism = soRoleCfg.parallelism || roleCfg.parallelism || "tp";
+      const parallelism = pdRole.parallelism || soRoleCfg.parallelism || roleCfg.parallelism || "tp";
       const poolGpus = nodes === 0 ? Math.floor(gpuCount / 2) : nodes * gpuCount;
       const tp = parallelism === "dep"
         ? (soRoleCfg.tp || roleCfg.tp || 1)

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -640,7 +640,11 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
         }
         args.push("--enable-expert-parallel");
       } else {
-        // TP pool. With >1 node, layer on vLLM mp multi-node flags.
+        // TP pool. A single engine spanning the pool's nodes via vLLM's mp
+        // multi-node backend: every node runs the same command, varying only
+        // --node-rank; rank > 0 adds --headless (no HTTP server). The UI's node
+        // selector picks which rank to render via pdRole.rank, mirroring the
+        // DEP pool's per-node command rendering.
         const roleParallelFlag =
           soRoleCfg.parallel_flag ||
           roleCfg.parallel_flag ||
@@ -648,10 +652,13 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
           "--tensor-parallel-size";
         args.push(roleParallelFlag, String(Math.max(1, poolGpus)));
         if (rolePoolNodes > 1) {
+          const nodeIdx = Math.max(0, Math.min(rolePoolNodes - 1, pdRole.rank ?? 0));
           args.push("--nnodes", String(rolePoolNodes));
-          args.push("--node-rank", "0");
+          args.push("--node-rank", String(nodeIdx));
           // TP master = node 0 of pool = NODE_1 (same naming as router endpoints).
           args.push("--master-addr", `$${roleKey.toUpperCase()}_NODE_1`);
+          // Followers are GPU workers only — no API server / NIXL side channel.
+          if (nodeIdx > 0) args.push("--headless");
         }
       }
     } else {
@@ -799,10 +806,10 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
 
     // Per-rank node rewrite: strategy YAML carries `$PREFILL_NODE_1` /
     // `$DECODE_NODE_1` as the rank-0 default for per-node bind hosts (NIXL
-    // side channel etc). For DEP pools where the UI shows a non-zero rank's
-    // command, point those values at NODE_{rank+1} so the rendered command
-    // matches that physical node. TP pools always render the head node, so
-    // NODE_1 is already correct.
+    // side channel etc). Only DEP pools open a per-node side channel (one
+    // `vllm serve` per node), so for a non-zero DEP rank point those values at
+    // NODE_{rank+1} to match that physical node. TP followers run --headless
+    // with no side channel, so their host stays pinned to the head (NODE_1).
     if (strategy.deploy_type === "pd_cluster" && roleOverride) {
       const raw = pdNodes ? pdNodes[roleOverride] : undefined;
       const pdRoleObj =
@@ -810,7 +817,10 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
         : (raw && typeof raw === "object") ? raw
         : {};
       const rank = pdRoleObj.rank || 0;
-      if (rank > 0) {
+      const rwSoRoleCfg = recipe.strategy_overrides?.[strategyName]?.[roleOverride] || {};
+      const rwRoleCfg = strategy[roleOverride] || {};
+      const rwParallelism = rwSoRoleCfg.parallelism || rwRoleCfg.parallelism || "tp";
+      if (rank > 0 && rwParallelism === "dep") {
         const oldVar = `$${roleOverride.toUpperCase()}_NODE_1`;
         const newVar = `$${roleOverride.toUpperCase()}_NODE_${rank + 1}`;
         for (const k of Object.keys(env)) {
@@ -894,12 +904,18 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
     // Shell-variable form ($PREFILL_NODE_N / $DECODE_NODE_N) so the same name
     // the prefill/decode commands consume is also what the router lists —
     // user fills one set of values in the Endpoints panel, applied everywhere.
+    // Endpoint count per pool depends on the parallelism mode:
+    //   DEP → one `vllm serve` per node, each binds its own HTTP port, so list
+    //         one endpoint per node (NODE_1..NODE_n).
+    //   TP  → a single engine spanning n nodes; only the head node (NODE_1)
+    //         serves HTTP (followers are --headless), so list exactly one.
+    const epCount = (meta) => (meta.parallelism === "dep" ? Math.max(1, meta.nodes || 1) : 1);
     const prefillEndpoints = Array.from(
-      { length: Math.max(1, pMeta.nodes || 1) },
+      { length: epCount(pMeta) },
       (_, i) => `    --prefill http://$PREFILL_NODE_${i + 1}:8001 \\`,
     );
     const decodeEndpoints = Array.from(
-      { length: Math.max(1, dMeta.nodes || 1) },
+      { length: epCount(dMeta) },
       (_, i) => `    --decode http://$DECODE_NODE_${i + 1}:8002 \\`,
     );
     // intra-node-data-parallel-size = max dp_local across the two pools for


### PR DESCRIPTION
Two related improvements to `pd_cluster` deployments in the command builder.

## 1. Multi-node TP pool: follower command + router endpoints

For a PD pool spanning **multiple nodes in TP mode** (e.g. `?strategy=pd_cluster&prefill_nodes=5`), the builder only ever rendered the **rank-0 head** command:

- Follower nodes' `--node-rank i --headless` commands were never shown (DEP pools had a per-node selector; TP pools were gated out).
- The router listed one HTTP endpoint **per node** even for TP pools, but a multi-node TP pool is a single engine that serves HTTP only on its head node.

Fix:
- TP pool uses `pdRole.rank` for `--node-rank` and appends `--headless` for followers (mirrors the DEP path).
- Router emits a **single** endpoint for a TP/TEP pool; one-per-node only for DEP.
- NIXL side-channel host rewrite (`$ROLE_NODE_1` → `$ROLE_NODE_{rank+1}`) is now **DEP-only** — TP/TEP followers are headless and never open a side channel.
- UI per-node selector enabled for TP pools too, with TP-appropriate hint (`--node-rank`, head vs `--headless` follower).

## 2. Per-pool parallelism selector (TP / TEP / DEP)

Previously each pool's parallelism was locked to whatever the recipe's `strategy_overrides` declared (TP by default), with no way to change it from the page.

- New exported `pdPoolModes(recipe)` derives the offered modes from `compatible_strategies` (`*_tp` → TP, `*_tep` → TEP, `*_dep` → DEP). Dense/limited recipes collapse to fewer modes; EP modes stay MoE-only since that's already what `compatible_strategies` encodes.
- Per-pool parallelism now reads from the UI first (`pdNodes[role].parallelism`), then recipe/strategy YAML, then `"tp"`.
- Added **TEP** as a PD-pool mode: TP layout + `--enable-expert-parallel`, plus `-cc.pass_config.fuse_allreduce_rms=False` only when multi-node (mirrors `single_node_tep` / `multi_node_tep`).
- `CommandBuilder`: per-pool `TP / TEP / DEP` pills beside each Prefill/Decode node stepper (hidden when only one mode is available). Syncs to `prefill_mode` / `decode_mode` URL params; switching a pool's mode resets its node index.

## Verification

GLM-5.1, prefill pool, 3 nodes:
- **TP** → `--tensor-parallel-size 24 --nnodes 3 --node-rank 0` (follower: `--node-rank 2 --headless`)
- **TEP** → `... --enable-expert-parallel -cc.pass_config.fuse_allreduce_rms=False --nnodes 3 ...`
- **DEP** → `--data-parallel-size N --data-parallel-size-local 8 ... --enable-expert-parallel`
- Mixed (prefill TEP / decode DEP): router lists 1 prefill + N decode endpoints, `--intra-node-data-parallel-size` = max dp_local.

`pdPoolModes` checked across all 35 PD-capable recipes (dense → TP-only, most MoE → TP/TEP/DEP). `node scripts/build-recipes-api.mjs` passes (118 models); JSX syntax-checked clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 3. Variant/hardware URL sync (unrelated drive-by fix)

Selecting a Blackwell-only variant (e.g. NVFP4) while on Hopper hardware needed **two clicks** to land `variant=` in the URL — the first click switched hardware but dropped the variant param.

Root cause: `syncUrl` closes over `searchParams`, so two sequential `syncUrl` calls in one handler both read the same stale params and the second `router.replace` clobbers the first. `selectVariant` called it twice (variant, then hardware); `selectHardware` did the same on non-scalable hardware. Fix: each handler now issues a single `syncUrl` with all updates merged (conditional spread preserves an unchanged `variant=` rather than deleting it).

