### PR TITLE
Update DeepSeek-V3.1 AMD recipe YAML format

### DIFF
--- a/models/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.1.yaml
@@ -13,6 +13,9 @@ meta:
     - "deepseek-ai/DeepSeek-V3.2-Exp"
   hardware:
     h200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.1"
@@ -91,12 +94,21 @@ guide: |
   ## Prerequisites
 
   - **Hardware**: 8x H200 (or H20) GPUs (141 GB per GPU)
+  - **AMD ROCm**: 8x MI300X / MI325X / MI355X GPUs
   - **vLLM**: Current stable release
 
   ```bash
   uv venv
   source .venv/bin/activate
   uv pip install -U vllm --torch-backend auto
+  ```
+
+  AMD ROCm wheel:
+
+  ```bash
+  uv venv --python 3.12
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
   ```
 
   ## Launching DeepSeek-V3.1
@@ -108,6 +120,19 @@ guide: |
     --enable-expert-parallel \
     --tensor-parallel-size 8 \
     --served-model-name ds31
+  ```
+
+  ### AMD ROCm on 8x MI300X / MI325X / MI355X
+
+  ```bash
+  export SAFETENSORS_FAST_GPU=1
+  export VLLM_USE_TRITON_FLASH_ATTN=0
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_USE_AITER_MOE=1
+
+  vllm serve deepseek-ai/DeepSeek-V3.1 \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel
   ```
 
   ### Function calling

--- a/models/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.1.yaml
@@ -75,7 +75,6 @@ compatible_strategies:
 
 hardware_overrides:
   amd:
-    # AITER attention wins over Triton FA for DeepSeek MoE on MI300X/MI325X/MI355X.
     extra_args: []
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
@@ -93,18 +92,18 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: 8x H200 (or H20) GPUs (141 GB per GPU)
-  - **AMD ROCm**: 8x MI300X / MI325X / MI355X GPUs
+  - **Hardware**: 8x H200/H20 (CUDA) or 8x MI300X / MI325X / MI355X (ROCm)
   - **vLLM**: Current stable release
 
+  ### CUDA
   ```bash
   uv venv
   source .venv/bin/activate
   uv pip install -U vllm --torch-backend auto
   ```
 
-  AMD ROCm wheel:
-
+  ### ROCm (MI300X, MI325X, MI355X)
+  Requires Python 3.12, ROCm 7.2.1, and glibc >= 2.35.
   ```bash
   uv venv --python 3.12
   source .venv/bin/activate
@@ -113,7 +112,7 @@ guide: |
 
   ## Launching DeepSeek-V3.1
 
-  ### Serving on 8xH200 (or H20) GPUs
+  ### 8xH200 / 8xH20 (CUDA)
 
   ```bash
   vllm serve deepseek-ai/DeepSeek-V3.1 \
@@ -122,11 +121,10 @@ guide: |
     --served-model-name ds31
   ```
 
-  ### AMD ROCm on 8x MI300X / MI325X / MI355X
+  ### 8xMI300X / MI325X / MI355X (ROCm)
 
   ```bash
   export SAFETENSORS_FAST_GPU=1
-  export VLLM_USE_TRITON_FLASH_ATTN=0
   export VLLM_ROCM_USE_AITER=1
   export VLLM_ROCM_USE_AITER_MOE=1
 


### PR DESCRIPTION
## Summary
- Replaces the legacy Markdown AMD update in #277 with the current YAML recipe format for DeepSeek-V3.1.
- Encodes AMD hardware support, ROCm installation guidance, launch commands, and runtime overrides in `models/...yaml`.

## Test plan
- `node scripts/build-recipes-api.mjs`
- Parsed the updated YAML recipes and verified required top-level schema order against `.claude/skills/add-recipe/SKILL.md`.
- Verified DCO sign-off as `haic0`.

Replaces #277.
