### PR TITLE
Update DeepSeek-V3.2-Exp AMD recipe YAML format

### DIFF
--- a/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -73,7 +73,6 @@ hardware_overrides:
       - "1"
       - "--kv-cache-dtype"
       - "bfloat16"
-      - "--no-enable-prefix-caching"
       - "--max-num-batched-tokens"
       - "32768"
     extra_env:
@@ -88,24 +87,26 @@ guide: |
   ## Overview
 
   DeepSeek-V3.2-Exp is a sparse-attention MoE preview. Its main architecture is similar to
-  DeepSeek-V3.1, with a sparse attention mechanism. Only Hopper and Blackwell data center
-  GPUs are supported for now.
+  DeepSeek-V3.1, with a sparse attention mechanism. This guide covers deployment on NVIDIA
+  Hopper/Blackwell GPUs and AMD MI300X / MI325X / MI355X GPUs.
 
   ## Prerequisites
 
-  - **Hardware**: 8x H200 (or H20, or 8xB200) GPUs
-  - **AMD ROCm**: 8x MI300X / MI325X / MI355X GPUs
+  - **Hardware**: 8x H200/H20/B200 (CUDA) or 8x MI300X / MI325X / MI355X (ROCm)
   - **vLLM**: Current stable release
-  - **DeepGEMM**: Required for MQA logits computation (and optionally for MoE)
+  - **DeepGEMM** (CUDA only): Required for MQA logits computation (and optionally for MoE)
 
+  ### CUDA
   ```bash
   source .venv/bin/activate
   uv pip install -U vllm --torch-backend auto
   uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation
   ```
 
-  AMD ROCm wheel:
-
+  ### ROCm (MI300X, MI325X, MI355X)
+  Requires Python 3.12, ROCm 7.2.1, and glibc >= 2.35. If your environment does not
+  meet these requirements, use the Docker-based setup described in the
+  [documentation](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/#pre-built-images).
   ```bash
   uv venv --python 3.12
   source .venv/bin/activate
@@ -113,13 +114,13 @@ guide: |
   ```
 
   Note: DeepGEMM is used both for MoE and for MQA logits computation. It is required for
-  MQA logits. To disable the MoE path only, set `VLLM_USE_DEEP_GEMM=0`. Some users report
-  better performance with `VLLM_USE_DEEP_GEMM=0` (e.g. on H20), and this also skips the
-  long warmup.
+  MQA logits on CUDA. To disable the MoE path only, set `VLLM_USE_DEEP_GEMM=0`. Some users
+  report better performance with `VLLM_USE_DEEP_GEMM=0` (e.g. on H20), and this also skips
+  the long warmup.
 
   ## Launching DeepSeek-V3.2-Exp
 
-  ### Serving on 8xH200 (or H20) GPUs
+  ### 8xH200 / 8xH20 (CUDA)
 
   Using the recommended EP/DP mode:
   ```bash
@@ -131,7 +132,11 @@ guide: |
   vllm serve deepseek-ai/DeepSeek-V3.2-Exp -tp 8
   ```
 
-  ### AMD ROCm on 8x MI300X / MI325X / MI355X
+  ### 8xB200 (CUDA)
+
+  Same as 8xH200 / 8xH20.
+
+  ### 8xMI300X / MI325X / MI355X (ROCm)
 
   ```bash
   export SAFETENSORS_FAST_GPU=1
@@ -143,14 +148,9 @@ guide: |
     --tensor-parallel-size 8 \
     --max-num-batched-tokens 32768 \
     --trust-remote-code \
-    --no-enable-prefix-caching \
     --kv-cache-dtype bfloat16 \
     --block-size 1
   ```
-
-  ### Serving on 8xB200 GPUs
-
-  Same as the above.
 
   ## Accuracy Benchmarking
 

--- a/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -13,6 +13,9 @@ meta:
     - "deepseek-ai/DeepSeek-V3.2"
   hardware:
     h200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.2-Exp"
@@ -91,6 +94,7 @@ guide: |
   ## Prerequisites
 
   - **Hardware**: 8x H200 (or H20, or 8xB200) GPUs
+  - **AMD ROCm**: 8x MI300X / MI325X / MI355X GPUs
   - **vLLM**: Current stable release
   - **DeepGEMM**: Required for MQA logits computation (and optionally for MoE)
 
@@ -98,6 +102,14 @@ guide: |
   source .venv/bin/activate
   uv pip install -U vllm --torch-backend auto
   uv pip install git+https://github.com/deepseek-ai/DeepGEMM.git@v2.1.1.post3 --no-build-isolation
+  ```
+
+  AMD ROCm wheel:
+
+  ```bash
+  uv venv --python 3.12
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
   ```
 
   Note: DeepGEMM is used both for MoE and for MQA logits computation. It is required for
@@ -117,6 +129,23 @@ guide: |
   Using tensor parallel:
   ```bash
   vllm serve deepseek-ai/DeepSeek-V3.2-Exp -tp 8
+  ```
+
+  ### AMD ROCm on 8x MI300X / MI325X / MI355X
+
+  ```bash
+  export SAFETENSORS_FAST_GPU=1
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_USE_AITER_MOE=1
+  export VLLM_RPC_TIMEOUT=18000000
+
+  vllm serve deepseek-ai/DeepSeek-V3.2-Exp \
+    --tensor-parallel-size 8 \
+    --max-num-batched-tokens 32768 \
+    --trust-remote-code \
+    --no-enable-prefix-caching \
+    --kv-cache-dtype bfloat16 \
+    --block-size 1
   ```
 
   ### Serving on 8xB200 GPUs


### PR DESCRIPTION
## Summary
- Replaces the legacy Markdown AMD update in #279 with the current YAML recipe format for DeepSeek-V3.2-Exp.
- Encodes AMD hardware support, ROCm installation guidance, launch commands, and runtime overrides in `models/...yaml`.

## Test plan
- `node scripts/build-recipes-api.mjs`
- Parsed the updated YAML recipes and verified required top-level schema order against `.claude/skills/add-recipe/SKILL.md`.
- Verified DCO sign-off as `haic0`.

Replaces #279.
