### PR TITLE
Update Kimi-K2 AMD recipe YAML format

### DIFF
--- a/models/moonshotai/Kimi-K2-Instruct.yaml
+++ b/models/moonshotai/Kimi-K2-Instruct.yaml
@@ -64,8 +64,6 @@ compatible_strategies:
 
 hardware_overrides:
   amd:
-    extra_args:
-      - "--no-enable-prefix-caching"
     extra_env:
       SAFETENSORS_FAST_GPU: "1"
 
@@ -195,8 +193,9 @@ guide: |
   export SAFETENSORS_FAST_GPU=1
   vllm serve moonshotai/Kimi-K2-Instruct \
     --tensor-parallel-size 8 \
-    --no-enable-prefix-caching \
-    --trust-remote-code
+    --trust-remote-code \
+    --enable-auto-tool-choice \
+    --tool-call-parser kimi_k2
   ```
 
   Additional flags:

--- a/models/moonshotai/Kimi-K2-Instruct.yaml
+++ b/models/moonshotai/Kimi-K2-Instruct.yaml
@@ -13,6 +13,9 @@ meta:
     - "moonshotai/Kimi-K2.5"
   hardware:
     h200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "moonshotai/Kimi-K2-Instruct"
@@ -59,7 +62,12 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
-hardware_overrides: {}
+hardware_overrides:
+  amd:
+    extra_args:
+      - "--no-enable-prefix-caching"
+    extra_env:
+      SAFETENSORS_FAST_GPU: "1"
 
 strategy_overrides:
   # Kimi-K2 16xH800 reference command from the original recipe: TP8 inside each
@@ -103,6 +111,17 @@ guide: |
   uv venv
   source .venv/bin/activate
   uv pip install -U vllm --torch-backend auto
+  ```
+
+  ### AMD ROCm
+
+  The ROCm wheel requires Python 3.12, ROCm 7.0+, and glibc >= 2.35. Use the
+  ROCm Docker image when your host environment does not meet those requirements.
+
+  ```bash
+  uv venv --python 3.12
+  source .venv/bin/activate
+  uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
   ```
 
   ## Running Kimi-K2 with FP8 on 16xH800
@@ -168,6 +187,16 @@ guide: |
     --gpu-memory-utilization 0.85 \
     --enable-auto-tool-choice \
     --tool-call-parser kimi_k2
+  ```
+
+  ### ROCm on 8x MI300X / MI325X / MI355X
+
+  ```bash
+  export SAFETENSORS_FAST_GPU=1
+  vllm serve moonshotai/Kimi-K2-Instruct \
+    --tensor-parallel-size 8 \
+    --no-enable-prefix-caching \
+    --trust-remote-code
   ```
 
   Additional flags:


### PR DESCRIPTION
## Summary
- Replaces the legacy Markdown AMD update in #153 with the current YAML recipe format for Kimi-K2-Instruct.
- Encodes AMD hardware support, ROCm installation guidance, launch commands, and runtime overrides in `models/...yaml`.

## Test plan
- `node scripts/build-recipes-api.mjs`
- Parsed the updated YAML recipes and verified required top-level schema order against `.claude/skills/add-recipe/SKILL.md`.
- Verified DCO sign-off as `haic0`.

Replaces #153.
