### PR TITLE
Fix `--max-num-seqs 512` for `Qwen/Qwen3.6-27B-FP8`

### DIFF
--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -66,7 +66,7 @@ variants:
     description: "Qwen official FP8 checkpoint — single 40 GB GPU"
     extra_args:
       - "--max-num-seqs"
-      - "865"
+      - "512"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -64,6 +64,9 @@ variants:
     precision: fp8
     vram_minimum_gb: 33
     description: "Qwen official FP8 checkpoint — single 40 GB GPU"
+    extra_args:
+      - "--max-num-seqs"
+      - "865"
 
 compatible_strategies:
   - single_node_tp


### PR DESCRIPTION
## Description

This PR lowers the default value for `--max-num-seqs` from 1024 to 512, as otherwise `Qwen/Qwen3.6-27B-FP8` won't fit on a single H100 instance, and it will fail with:

```
ValueError: max_num_seqs (1024) exceeds available Mamba cache blocks (856). Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed. Please lower max_num_seqs to at most 856 or increase gpu_memory_utilization.
```

To verify that it also affects earlier vLLM versions since v0.17.0, as that's the version suggested to be the minimum version for `Qwen/Qwen3.6-27B` and `Qwen/Qwen3.6-27B-FP8`, so here's the summary / breakdown of the errors it raises without the lowered `--max-num-seqs`, all with the command `python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3.6-27B-FP8 --gpu-memory-utilization 0.95 --tool-call-parser qwen3_coder --reasoning-parser qwen3 --enable-auto-tool-choice`.

- **v0.17.0** failed with "Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  88%|████████▊ | 45/51 [00:04<00:00,  9.30it/s]CUDA error: device kernel image is invalid"

- **v0.18.0** failed with "Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  88%|████████▊ | 45/51 [00:04<00:00,  9.07it/s]CUDA error: device kernel image is invalid"

- **v0.19.0** failed with "Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  88%|████████▊ | 45/51 [00:04<00:00,  8.63it/s]CUDA error: device kernel image is invalid"

- **v0.20.0** failed with "ValueError: max_num_seqs (1024) exceeds available Mamba cache blocks (853). Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed. Please lower max_num_seqs to at most 853 or increase gpu_memory_utilization."

- **v0.21.0** failed with "ValueError: max_num_seqs (1024) exceeds available Mamba cache blocks (871). Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed. Please lower max_num_seqs to at most 871 or increase gpu_memory_utilization."

- **v0.22.0** failed with "ValueError: max_num_seqs (1024) exceeds available Mamba cache blocks (856). Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed. Please lower max_num_seqs to at most 856 or increase gpu_memory_utilization."

- **v0.23.0** (just released) failed with "ValueError: max_num_seqs (1024) exceeds available Mamba cache blocks (871). Each decode sequence requires one Mamba cache block, so CUDA graph capture cannot proceed. Please lower max_num_seqs to at most 871 or increase gpu_memory_utilization."

> [!NOTE]
> By submitting this PR, I disclose that all the code in this PR was written entirely by me, @alvarobartt, without the use of any coding assistants or third-party agentic tools.