### PR TITLE
fix(deepseek-v4-pro): cap multi_node_tep TP to 8 for FP8 weights

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -146,7 +146,7 @@ strategy_overrides:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
   multi_node_tep:
-    # moe_intermediate_size=3072 / TP must divide evenly into FP8 block_n=128.
+    # moe_intermediate_size=3072 / TP must be a multiple of FP8 block_n=128.
     # TP=16 (2 × 8-GPU nodes) gives 3072/16=192, which is not a multiple of 128
     # and breaks FP8 block-quantized GEMMs (vllm-project/vllm#40955). Lock TP=8
     # until vllm-project/vllm#41312 ships in a stable release; revert this then.

--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -146,7 +146,13 @@ strategy_overrides:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
   multi_node_tep:
+    # moe_intermediate_size=3072 / TP must divide evenly into FP8 block_n=128.
+    # TP=16 (2 × 8-GPU nodes) gives 3072/16=192, which is not a multiple of 128
+    # and breaks FP8 block-quantized GEMMs (vllm-project/vllm#40955). Lock TP=8
+    # until vllm-project/vllm#41312 ships in a stable release; revert this then.
     extra_args:
+      - "--tensor-parallel-size"
+      - "8"
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
   single_node_dep:


### PR DESCRIPTION
## Problem
The DeepSeek-V4-Pro recipe renders `--tensor-parallel-size 16` for a 
2-node H200 `multi_node_tep` deployment. For FP8 weights, 
`moe_intermediate_size = 3072` and `3072 / 16 = 192`, which is not a 
multiple of the FP8 block size (128), breaking block-quantized GEMMs 
at runtime.

## Fix
Added `--tensor-parallel-size 8` to `strategy_overrides.multi_node_tep.extra_args`.
Via `dedupeArgs` last-wins logic in `command-synthesis.js`, this overrides 
the auto-computed TP=16.

## Test Plan
- YAML validated: `python3 -c "import yaml; yaml.safe_load(open('models/deepseek-ai/DeepSeek-V4-Pro.yaml')); print('YAML parses OK')"` → YAML parses OK
- Logic verified: `--tensor-parallel-size 8` in `extra_args` (step 4) 
  overrides auto-computed TP=16 (step 3) via `dedupeArgs` last-wins in `command-synthesis.js`
- Math: `3072 / 8 = 384` ✓ multiple of FP8 block size (128)

## Note
NVFP4 on `multi_node_tep` also gets TP=8 — valid though suboptimal. 
Per-variant strategy overrides would require changes to `command-synthesis.js`, 
out of scope here.

## Revert condition
Remove this override once `vllm-project/vllm#41312` ships in a stable release.

Fixes #497
Ref: vllm-project/vllm#40955
Ref: vllm-project/vllm#41312