### PR TITLE
fix: add timeouts to build-time network requests

### DIFF
--- a/scripts/fetch-hf-dates.mjs
+++ b/scripts/fetch-hf-dates.mjs
@@ -28,23 +28,11 @@ function findYamlFiles(dir) {
   return out;
 }
 
-async function fetchWithTimeout(url, options = {}, timeout = 10000) {
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-  try {
-    const response = await fetch(url, { ...options, signal: controller.signal });
-    clearTimeout(id);
-    return response;
-  } catch (error) {
-    clearTimeout(id);
-    throw error;
-  }
-}
-
 async function fetchCreatedAt(modelId) {
   try {
-    const res = await fetchWithTimeout(`https://huggingface.co/api/models/${modelId}`, {
+    const res = await fetch(`https://huggingface.co/api/models/${modelId}`, {
       headers: { "User-Agent": "vllm-recipes-build/1.0" },
+      signal: AbortSignal.timeout(10000),
     });
     if (!res.ok) return null;
     const data = await res.json();

--- a/scripts/fetch-hf-dates.mjs
+++ b/scripts/fetch-hf-dates.mjs
@@ -28,9 +28,22 @@ function findYamlFiles(dir) {
   return out;
 }
 
+async function fetchWithTimeout(url, options = {}, timeout = 10000) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    clearTimeout(id);
+    return response;
+  } catch (error) {
+    clearTimeout(id);
+    throw error;
+  }
+}
+
 async function fetchCreatedAt(modelId) {
   try {
-    const res = await fetch(`https://huggingface.co/api/models/${modelId}`, {
+    const res = await fetchWithTimeout(`https://huggingface.co/api/models/${modelId}`, {
       headers: { "User-Agent": "vllm-recipes-build/1.0" },
     });
     if (!res.ok) return null;

--- a/scripts/fetch-provider-logos.mjs
+++ b/scripts/fetch-provider-logos.mjs
@@ -28,8 +28,21 @@ const HARDWARE_LOGOS = {
 const OUT = "public/providers";
 fs.mkdirSync(OUT, { recursive: true });
 
+async function fetchWithTimeout(url, options = {}, timeout = 10000) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    clearTimeout(id);
+    return response;
+  } catch (error) {
+    clearTimeout(id);
+    throw error;
+  }
+}
+
 async function fetchOrgAvatarUrl(org) {
-  const res = await fetch(`https://huggingface.co/${org}`, {
+  const res = await fetchWithTimeout(`https://huggingface.co/${org}`, {
     headers: { "User-Agent": "vllm-recipes-build/1.0" },
   });
   const html = await res.text();
@@ -58,7 +71,7 @@ for (const [org, meta] of Object.entries(targets)) {
       failed++;
       continue;
     }
-    const imgRes = await fetch(avatarUrl);
+    const imgRes = await fetchWithTimeout(avatarUrl);
     const buffer = Buffer.from(await imgRes.arrayBuffer());
     fs.writeFileSync(localPath, buffer);
     console.log(`✓ ${org} (${buffer.length}B)`);

--- a/scripts/fetch-provider-logos.mjs
+++ b/scripts/fetch-provider-logos.mjs
@@ -28,22 +28,10 @@ const HARDWARE_LOGOS = {
 const OUT = "public/providers";
 fs.mkdirSync(OUT, { recursive: true });
 
-async function fetchWithTimeout(url, options = {}, timeout = 10000) {
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-  try {
-    const response = await fetch(url, { ...options, signal: controller.signal });
-    clearTimeout(id);
-    return response;
-  } catch (error) {
-    clearTimeout(id);
-    throw error;
-  }
-}
-
 async function fetchOrgAvatarUrl(org) {
-  const res = await fetchWithTimeout(`https://huggingface.co/${org}`, {
+  const res = await fetch(`https://huggingface.co/${org}`, {
     headers: { "User-Agent": "vllm-recipes-build/1.0" },
+    signal: AbortSignal.timeout(10000),
   });
   const html = await res.text();
   const match = html.match(/cdn-avatars\.huggingface\.co\/[^"&]+/);
@@ -71,7 +59,9 @@ for (const [org, meta] of Object.entries(targets)) {
       failed++;
       continue;
     }
-    const imgRes = await fetchWithTimeout(avatarUrl);
+    const imgRes = await fetch(avatarUrl, {
+      signal: AbortSignal.timeout(10000),
+    });
     const buffer = Buffer.from(await imgRes.arrayBuffer());
     fs.writeFileSync(localPath, buffer);
     console.log(`✓ ${org} (${buffer.length}B)`);


### PR DESCRIPTION
The build-time scripts `fetch-hf-dates.mjs` and `fetch-provider-logos.mjs` performed network requests to the HuggingFace API and external resources without any timeout configurations. In scenarios of network instability or API latency, these scripts could stall indefinitely, blocking the entire `pnpm build` pipeline. I have implemented an `AbortController` with a 10-second timeout for all `fetch` requests within these scripts to ensure the build process remains robust and fails fast in the event of unreachable external services.