### PR TITLE
[ROCm] Add MI300X and MI355X guidance for Moonshot Kimi

### DIFF
--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -22,7 +22,7 @@ model:
   min_vllm_version: "0.19.1"
   docker_image:
     nvidia: "vllm/vllm-openai:latest"
-    amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
+    amd: "vllm/vllm-openai-rocm:nightly"
   architecture: moe
   parameter_count: "1T"
   active_parameters: "32B"

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -20,6 +20,9 @@ meta:
 model:
   model_id: "moonshotai/Kimi-K2.5"
   min_vllm_version: "0.19.1"
+  docker_image:
+    nvidia: "vllm/vllm-openai:latest"
+    amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
   architecture: moe
   parameter_count: "1T"
   active_parameters: "32B"
@@ -96,12 +99,9 @@ hardware_overrides:
       - "--attention-config.use_trtllm_ragged_deepseek_prefill=True"
   amd:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
-    extra_args:
-      - "--block-size=1"
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
-      VLLM_ROCM_USE_AITER_RMSNORM: "0"
 
 strategy_overrides:
   single_node_dep:
@@ -173,6 +173,52 @@ guide: |
   ```bash
   docker pull vllm/vllm-openai:latest
   ```
+
+  ### AMD MI300X/MI325X
+
+  On 8x MI300X or MI325X (`gfx942`), use the standard W4A16 MoE path with AITER
+  and INT4 QuickReduce.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+  vllm serve moonshotai/Kimi-K2.5 \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --tool-call-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --reasoning-parser kimi_k2 \
+    --mm-encoder-tp-mode data
+  ```
+
+  ### AMD MI350X/MI355X
+
+  On 8x MI350X or MI355X (`gfx950`), add `--moe-backend flydsl` to use the
+  optimized FlyDSL W4A16 MoE kernel. Keep LoRA disabled for this path.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+  vllm serve moonshotai/Kimi-K2.5 \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --mm-encoder-tp-mode data \
+    --moe-backend flydsl \
+    --compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}'
+  ```
+
+  Notes:
+  - The FlyDSL INT4 MoE path does not support expert parallelism; do not add
+    `--enable-expert-parallel`.
+  - Keep `--compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}'`;
+    it is required for this FlyDSL path on MI350X / MI355X.
+  - vLLM has tuned MI350X/MI355X FlyDSL configs for this Kimi shape at TP=8 and TP=4.
+  - Keep vLLM's default block size unless you are tuning long-context
+    throughput; `--block-size 64` is safe to try.
 
   ## Client Usage
 

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -22,7 +22,7 @@ model:
   min_vllm_version: "0.19.1"
   docker_image:
     nvidia: "vllm/vllm-openai:latest"
-    amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
+    amd: "vllm/vllm-openai-rocm:nightly"
   architecture: moe
   parameter_count: "1T"
   active_parameters: "32B"

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -13,10 +13,16 @@ meta:
   hardware:
     h200: verified
     gb200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "moonshotai/Kimi-K2.6"
   min_vllm_version: "0.19.1"
+  docker_image:
+    nvidia: "vllm/vllm-openai:latest"
+    amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
   architecture: moe
   parameter_count: "1T"
   active_parameters: "32B"
@@ -93,12 +99,9 @@ hardware_overrides:
       - "--attention-config.use_trtllm_ragged_deepseek_prefill=True"
   amd:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
-    extra_args:
-      - "--block-size=1"
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
-      VLLM_ROCM_USE_AITER_RMSNORM: "0"
 
 strategy_overrides:
   single_node_dep:
@@ -149,6 +152,51 @@ guide: |
   - **Hardware (INT4):** 8x H200 GPUs (verified), or equivalent aggregate VRAM (~640 GB)
   - **AMD support:** 8x MI300X / MI325X / MI355X with ROCm 7.2.1 and Python 3.12
 
+  ### AMD MI300X/MI325X
+
+  On 8x MI300X or MI325X (`gfx942`), use the standard W4A16 MoE path with AITER
+  and INT4 QuickReduce.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+  vllm serve moonshotai/Kimi-K2.6 \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --tool-call-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --reasoning-parser kimi_k2 \
+    --mm-encoder-tp-mode data
+  ```
+
+  ### AMD MI350X/MI355X
+
+  On 8x MI350X or MI355X (`gfx950`), add `--moe-backend flydsl` to use the
+  optimized FlyDSL W4A16 MoE kernel. Keep LoRA disabled for this path.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+  vllm serve moonshotai/Kimi-K2.6 \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --mm-encoder-tp-mode data \
+    --moe-backend flydsl \
+    --compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}'
+  ```
+
+  Notes:
+  - The FlyDSL INT4 MoE path does not support expert parallelism; do not add
+    `--enable-expert-parallel`.
+  - Keep `--compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}'`;
+    it is required for this FlyDSL path on MI350X / MI355X.
+  - vLLM has tuned MI350X/MI355X FlyDSL configs for this Kimi shape at TP=8 and TP=4.
+  - Keep vLLM's default block size unless you are tuning long-context
+    throughput; `--block-size 64` is safe to try.
 
   ## Client Usage
 

--- a/models/moonshotai/Kimi-K2.7-Code.yaml
+++ b/models/moonshotai/Kimi-K2.7-Code.yaml
@@ -23,7 +23,7 @@ model:
   min_vllm_version: "0.19.1"
   docker_image:
     nvidia: "vllm/vllm-openai:latest"
-    amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
+    amd: "vllm/vllm-openai-rocm:nightly"
   architecture: moe
   parameter_count: "1T"
   active_parameters: "32B"

--- a/models/moonshotai/Kimi-K2.7-Code.yaml
+++ b/models/moonshotai/Kimi-K2.7-Code.yaml
@@ -14,10 +14,16 @@ meta:
     - "moonshotai/Kimi-K2-Thinking"
   hardware:
     h200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "moonshotai/Kimi-K2.7-Code"
   min_vllm_version: "0.19.1"
+  docker_image:
+    nvidia: "vllm/vllm-openai:latest"
+    amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
   architecture: moe
   parameter_count: "1T"
   active_parameters: "32B"
@@ -74,6 +80,11 @@ hardware_overrides:
   blackwell:
     extra_args:
       - "--attention-config.use_trtllm_ragged_deepseek_prefill=True"
+  amd:
+    # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
 
 strategy_overrides: {}
 
@@ -124,6 +135,55 @@ guide: |
     correct reasoning processing.
   - `--mm-encoder-tp-mode data` — runs the small MoonViT encoder data-parallel to avoid TP
     communication overhead.
+
+  ### AMD MI300X/MI325X
+
+  On 8x MI300X or MI325X (`gfx942`), use the standard W4A16 MoE path with AITER
+  and INT4 QuickReduce.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+  vllm serve moonshotai/Kimi-K2.7-Code \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --tool-call-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --reasoning-parser kimi_k2 \
+    --mm-encoder-tp-mode data
+  ```
+
+  ### AMD MI350X/MI355X
+
+  On 8x MI350X or MI355X (`gfx950`), add `--moe-backend flydsl` to use the
+  optimized FlyDSL W4A16 MoE kernel. Keep LoRA disabled for this path.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+  vllm serve moonshotai/Kimi-K2.7-Code \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --mm-encoder-tp-mode data \
+    --moe-backend flydsl \
+    --tool-call-parser kimi_k2 \
+    --enable-auto-tool-choice \
+    --reasoning-parser kimi_k2 \
+    --compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}'
+  ```
+
+  Notes:
+  - The FlyDSL INT4 MoE path does not support expert parallelism; do not add
+    `--enable-expert-parallel`.
+  - Keep `--compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}'`;
+    it is required for this FlyDSL path on MI350X / MI355X.
+  - vLLM has tuned MI350X/MI355X FlyDSL configs for this Kimi shape at TP=8 and TP=4.
+  - Keep vLLM's default block size unless you are tuning long-context
+    throughput; `--block-size 64` is safe to try.
 
   ## Client Usage
 


### PR DESCRIPTION
## Summary

Add AMD ROCm guidance for the Moonshot Kimi K2.5, K2.6, and K2.7-Code recipes.

This updates the recipes with:

- AMD ROCm Docker image selection.
- AMD runtime environment variables:
  - `VLLM_ROCM_USE_AITER=1`
  - `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4`
- MI300X / MI325X guidance for the existing `gfx942` W4A16 MoE path.
- MI350X / MI355X guidance for the `gfx950` FlyDSL W4A16 MoE path.
- Notes that the FlyDSL path should not use expert parallelism.
- Notes that the MI350X / MI355X FlyDSL path requires:
  `--compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}'`

## Why

The MI350X / MI355X path depends on recent vLLM support from
[vllm-project/vllm#44400](https://github.com/vllm-project/vllm/pull/44400), which enabled the W4A16 FlyDSL MoE path for `gfx950`.

Because this support is recent, the AMD recipe pins the ROCm Docker image to:

```yaml
amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
```

The AMD paths are split by GPU generation:

- MI300X / MI325X report `gfx942`, so they use the existing W4A16 MoE implementation.
- MI350X / MI355X report `gfx950`, so they can use the new FlyDSL W4A16 MoE path with `--moe-backend flydsl`.

## Validation

Validated Kimi-K2.5, Kimi-K2.7-Code (Kimi-K2.6 should work)

Also benchmarked `--block-size 16` vs `--block-size 64` with an 8k input / 1k output serving workload. Results were effectively tied, so the recipes do not force a block-size override and instead leave it as an optional tuning knob.

| block size | successful | failed | duration | output tok/s | total tok/s | median TTFT | mean TPOT |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 16 | 32 | 0 | 123.75s | 264.79 | 2333.44 | 37.03s | 82.71ms |
| 64 | 32 | 0 | 123.74s | 264.81 | 2333.65 | 37.62s | 82.13ms |

We also tested `VLLM_ROCM_USE_AITER_RMSNORM=0`; it was slower than leaving the RMSNorm setting at the image default, so the recipes remove that override and only keep the required AITER / INT4 QuickReduce environment variables.