### PR TITLE
fix(google/gemma-4-26b-a4b-it): add --max-num-batched-tokens to single-GPU command

### DIFF
--- a/models/Google/gemma-4-26B-A4B-it.yaml
+++ b/models/Google/gemma-4-26B-A4B-it.yaml
@@ -176,6 +176,7 @@ guide: |
   vllm serve google/gemma-4-26B-A4B-it \
     --max-model-len 16384 \
     --gpu-memory-utilization 0.90 \
+    --max-num-batched-tokens 4096 \
     --enable-auto-tool-choice \
     --reasoning-parser gemma4 \
     --tool-call-parser gemma4 \
@@ -195,6 +196,7 @@ guide: |
       --model google/gemma-4-26B-A4B-it \
       --max-model-len 32768 \
       --gpu-memory-utilization 0.90 \
+      --max-num-batched-tokens 4096 \
       --host 0.0.0.0 --port 8000
   ```
   Swap `vllm/vllm-openai:gemma4-0505-cu129` for `vllm/vllm-openai:gemma4-0505-cu130` on Blackwell (B200/B300).

--- a/models/Google/gemma-4-26B-A4B-it.yaml
+++ b/models/Google/gemma-4-26B-A4B-it.yaml
@@ -166,7 +166,8 @@ guide: |
   ```bash
   vllm serve google/gemma-4-26B-A4B-it \
     --max-model-len 32768 \
-    --gpu-memory-utilization 0.90
+    --gpu-memory-utilization 0.90 \
+    --max-num-batched-tokens 4096
   ```
 
   ### Full-Featured Server Launch


### PR DESCRIPTION
## Summary

Fixes #441

The single-GPU BF16 command for `gemma-4-26B-A4B-it` was missing
`--max-num-batched-tokens`, causing this error on 1× A100/H100:

ValueError: Chunked MM input disabled but max_tokens_per_mm_item (2496)
is larger than max_num_batched_tokens (2048).
Please increase max_num_batched_tokens.

This happens because the model's multimodal token budget (2496) exceeds
vLLM's default `max_num_batched_tokens` of 2048. Added
`--max-num-batched-tokens 4096` to all single-GPU command blocks to clear
this threshold.

## Changes

- `models/Google/gemma-4-26B-A4B-it.yaml`: added `--max-num-batched-tokens 4096` to:
  - `### 26B MoE on 1x A100/H100 (BF16)` command block
  - `### Full-Featured Server Launch` command block
  - `### Docker (NVIDIA)` command block

Co-authored-by: @muhammadfawaz1