### PR TITLE
Update GLM-5 family

### DIFF
--- a/models/zai-org/GLM-5.1.yaml
+++ b/models/zai-org/GLM-5.1.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "glm-5.1"
   provider: "GLM (Z-AI)"
   description: "GLM-5.1 refreshed version of GLM-5 — frontier-scale MoE language model (~744B total parameters) with MTP speculative decoding and thinking mode"
-  date_updated: 2026-05-21
+  date_updated: 2026-06-24
   difficulty: advanced
   tasks:
     - text
@@ -11,6 +11,8 @@ meta:
   related_recipes: []
   hardware:
     h200: verified
+    b300: verified
+    gb300: verified
 
 model:
   model_id: "zai-org/GLM-5.1"
@@ -39,10 +41,8 @@ features:
   spec_decoding:
     description: "Multi-Token Prediction speculative decoding (3 draft tokens)"
     args:
-      - "--speculative-config.method"
-      - "mtp"
-      - "--speculative-config.num_speculative_tokens"
-      - "3"
+      - "--speculative-config"
+      - '{"method": "mtp", "num_speculative_tokens": 3}'
 
 opt_in_features:
   - spec_decoding
@@ -62,11 +62,6 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 446
     description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
-    extra_args:
-      - "--kv-cache-dtype"
-      - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -77,7 +72,17 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
-hardware_overrides: {}
+hardware_overrides:
+  hopper:
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+  blackwell:
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8_e4m3"
+      - "--attention-config"
+      - '{"mla_prefill_backend": "TRTLLM_RAGGED", "use_prefill_query_quantization": true}'
 
 strategy_overrides: {}
 
@@ -112,7 +117,8 @@ guide: |
       --reasoning-parser glm45 \
       --enable-auto-tool-choice \
       --chat-template-content-format=string \
-      --served-model-name glm-5.1-fp8
+      --served-model-name glm-5.1-fp8 \
+      --kv-cache-dtype fp8
   ```
 
   Use `vllm/vllm-openai:latest-cu129` for CUDA 12.x.
@@ -133,8 +139,8 @@ guide: |
   ```bash
   vllm serve zai-org/GLM-5.1-FP8 \
        --tensor-parallel-size 8 \
-       --speculative-config.method mtp \
-       --speculative-config.num_speculative_tokens 3 \
+       --kv-cache-dtype fp8 \
+       --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}' \
        --tool-call-parser glm47 \
        --reasoning-parser glm45 \
        --enable-auto-tool-choice \

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "glm-5.2"
   provider: "GLM (Z-AI)"
   description: "GLM-5.2 — frontier-scale MoE language model (~743B total parameters, 39B active) with up to 5-token MTP speculative decoding and thinking mode"
-  date_updated: 2026-06-09
+  date_updated: 2026-06-24
   difficulty: advanced
   tasks:
     - text
@@ -14,6 +14,7 @@ meta:
   hardware:
     b300: verified
     b200: verified
+    gb300: verified
     mi300x: verified
     mi355x: verified
 
@@ -47,10 +48,8 @@ features:
   spec_decoding:
     description: "Multi-Token Prediction speculative decoding (up to 5 draft tokens)"
     args:
-      - "--speculative-config.method"
-      - "mtp"
-      - "--speculative-config.num_speculative_tokens"
-      - "5"
+      - "--speculative-config"
+      - '{"method": "mtp", "num_speculative_tokens": 5}'
 
 opt_in_features:
   - spec_decoding
@@ -82,6 +81,10 @@ hardware_overrides:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
+  blackwell:
+    extra_args:
+      - "--attention-config"
+      - '{"mla_prefill_backend": "TRTLLM_RAGGED", "use_prefill_query_quantization": true}'
   amd:
     extra_args:
       - "--linear-backend"
@@ -150,8 +153,7 @@ guide: |
   vllm serve zai-org/GLM-5.2-FP8 \
     --kv-cache-dtype fp8 \
     --tensor-parallel-size 8 \
-    --speculative-config.method mtp \
-    --speculative-config.num_speculative_tokens 5 \
+    --speculative-config '{"method": "mtp", "num_speculative_tokens": 5}' \
     --tool-call-parser glm47 \
     --reasoning-parser glm45 \
     --enable-auto-tool-choice \
@@ -172,8 +174,7 @@ guide: |
   vllm serve zai-org/GLM-5.2-FP8 \
     --kv-cache-dtype fp8_e4m3 \
     --tensor-parallel-size 8 \
-    --speculative-config.method mtp \
-    --speculative-config.num_speculative_tokens 5 \
+    --speculative-config '{"method": "mtp", "num_speculative_tokens": 5}' \
     --tool-call-parser glm47 \
     --enable-auto-tool-choice \
     --reasoning-parser glm45 \
@@ -190,8 +191,8 @@ guide: |
     start at 32 and tune it to your HBM (up on headroom, down on OOM).
   - **`--gpu-memory-utilization 0.80`** — leaves ROCm runtime headroom for MTP graph capture
     and inference; raise it only after a representative concurrent smoke test.
-  - **`--speculative-config.num_speculative_tokens 5`** — enables GLM-5.2's 5-token MTP
-    path; reduce it if your workload shows low acceptance or higher latency.
+  - **`num_speculative_tokens: 5`** (inside `--speculative-config`) — enables GLM-5.2's 5-token
+    MTP path; reduce it if your workload shows low acceptance or higher latency.
   - **`VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`** — enables the shared-expert fused
     MoE path. `VLLM_ROCM_USE_AITER_LINEAR` and `VLLM_ROCM_USE_AITER_MOE` default to enabled
     when `VLLM_ROCM_USE_AITER=1`.
@@ -209,8 +210,8 @@ guide: |
   VLLM_DEEP_GEMM_WARMUP=skip vllm serve zai-org/GLM-5.2-FP8 \
     --kv-cache-dtype fp8_e4m3 \
     --tensor-parallel-size 8 \
-    --speculative-config.method mtp \
-    --speculative-config.num_speculative_tokens 5 \
+    --attention-config '{"mla_prefill_backend": "TRTLLM_RAGGED", "use_prefill_query_quantization": true}' \
+    --speculative-config '{"method": "mtp", "num_speculative_tokens": 5}' \
     --max-num-seqs 32 \
     --tool-call-parser glm47 \
     --reasoning-parser glm45 \

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "glm-5"
   provider: "GLM (Z-AI)"
   description: "GLM-5 frontier-scale MoE language model (~744B total parameters, 28.5T training tokens) with asynchronous RL infrastructure for reasoning, coding, and agentic tasks"
-  date_updated: 2026-04-17
+  date_updated: 2026-06-24
   difficulty: advanced
   tasks:
     - text
@@ -11,6 +11,8 @@ meta:
   related_recipes: []
   hardware:
     h200: verified
+    b300: verified
+    gb300: verified
 
 model:
   model_id: "zai-org/GLM-5"
@@ -23,15 +25,6 @@ model:
     - "--trust-remote-code"
     - "--chat-template-content-format=string"
   base_env: {}
-
-dependencies:
-  - note: "Pin vllm==0.19.0 (avoid nightly)"
-    command: 'uv pip install "vllm==0.19.0" --torch-backend=auto'
-  - note: "GLM-5 requires transformers >= 5.4.0"
-    command: 'uv pip install "transformers>=5.4.0"'
-  - note: "Optional: DeepGEMM for FP8 MoE kernels (FP8 variant only)"
-    command: "bash install_deepgemm.sh"
-    optional: true
 
 features:
   tool_calling:
@@ -48,10 +41,8 @@ features:
   spec_decoding:
     description: "Multi-Token Prediction speculative decoding (3 draft tokens)"
     args:
-      - "--speculative-config.method"
-      - "mtp"
-      - "--speculative-config.num_speculative_tokens"
-      - "3"
+      - "--speculative-config"
+      - '{"method": "mtp", "num_speculative_tokens": 3}'
 
 opt_in_features:
   - spec_decoding
@@ -71,11 +62,6 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 446
     description: "NVIDIA NVFP4 quantized weights for Blackwell GPUs"
-    extra_args:
-      - "--kv-cache-dtype"
-      - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -86,7 +72,17 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
-hardware_overrides: {}
+hardware_overrides:
+  hopper:
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+  blackwell:
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8_e4m3"
+      - "--attention-config"
+      - '{"mla_prefill_backend": "TRTLLM_RAGGED", "use_prefill_query_quantization": true}'
 
 strategy_overrides: {}
 
@@ -119,7 +115,8 @@ guide: |
       --tool-call-parser glm47 \
       --reasoning-parser glm45 \
       --enable-auto-tool-choice \
-      --chat-template-content-format=string
+      --chat-template-content-format=string \
+      --kv-cache-dtype fp8
   ```
 
   Use `vllm/vllm-openai:latest-cu129` for CUDA 12.x.
@@ -142,8 +139,8 @@ guide: |
   ```bash
   vllm serve zai-org/GLM-5-FP8 \
        --tensor-parallel-size 8 \
-       --speculative-config.method mtp \
-       --speculative-config.num_speculative_tokens 3 \
+       --kv-cache-dtype fp8 \
+       --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}' \
        --tool-call-parser glm47 \
        --reasoning-parser glm45 \
        --enable-auto-tool-choice \


### PR DESCRIPTION
## Summary

- Per-generation KV cache dtype overrides, with `fp8` on Hopper and `fp8_e4m3` on Blackwell
- Add `--attention-config` on Blackwell, with `mla_prefill_backend=TRTLLM_RAGGED` and `use_prefill_query_quantization=true`
- Convert `--speculative-config` to the JSON-object form
- Remove the `dependencies` install block from GLM-5
- Remove the deprecated `VLLM_USE_FLASHINFER_MOE_FP4` env from the NVFP4 variants
- Mark B300/GB300 verified on GLM-5 / 5.1 and mark GB300 verified on GLM-5.2