### PR TITLE
Add LiquidAI LFM2.5 recipes (dense, MoE, VL)

### DIFF
--- a/LiquidAI/LFM2.5.md
+++ b/LiquidAI/LFM2.5.md
@@ -1,0 +1,285 @@
+# LFM2.5 Usage Guide
+
+[LFM2.5](https://www.liquid.ai/) is [Liquid AI's](https://www.liquid.ai/) family of small,
+efficient open-weight models built on the **LFM2 hybrid backbone** — short-range gated
+convolution blocks interleaved with grouped-query attention. The hybrid design keeps the KV
+cache small and decode fast, so LFM2.5 models punch above their weight while remaining cheap to
+serve, down to edge / on-device GPUs. The family spans dense chat models (350M, 1.2B), a
+mixture-of-experts model (8B-A1B), reasoning and Japanese variants, base checkpoints, and
+vision-language models (VL 450M / 1.6B) — all served through vLLM's OpenAI-compatible API.
+
+All LFM2.5 language and vision-language models are supported **natively** by vLLM (the
+`Lfm2ForCausalLM`, `Lfm2MoeForCausalLM`, and `Lfm2VlForConditionalGeneration` architectures), so
+**no `--trust-remote-code` is required**. Tool calling is handled by the built-in `lfm2` tool
+parser, and `<think>` reasoning by the `qwen3` reasoning parser.
+
+> ℹ️ All commands below were verified end-to-end on **NVIDIA H100**. Other GPUs are expected to
+> work but are listed only where validated.
+
+## Supported Models
+
+### Dense Chat Models
+
+| Model | Parameters | Min NVIDIA GPU (BF16) | Context | Tools | HuggingFace |
+|-------|-----------|------------------------|---------|-------|-------------|
+| LFM2.5 350M | 350M | 1× (any) | 128K | ✓ | [LiquidAI/LFM2.5-350M](https://huggingface.co/LiquidAI/LFM2.5-350M) |
+| LFM2.5 1.2B Instruct | 1.2B | 1× (8 GB+) | 128K | ✓ | [LiquidAI/LFM2.5-1.2B-Instruct](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct) |
+| LFM2.5 1.2B Thinking | 1.2B | 1× (8 GB+) | 128K | ✓ (+reasoning) | [LiquidAI/LFM2.5-1.2B-Thinking](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking) |
+| LFM2.5 1.2B JP | 1.2B | 1× (8 GB+) | 128K | – | [LiquidAI/LFM2.5-1.2B-JP](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP) |
+| LFM2.5 1.2B JP (202606) | 1.2B | 1× (8 GB+) | 128K | ✓ | [LiquidAI/LFM2.5-1.2B-JP-202606](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-202606) |
+| LFM2.5 1.2B Base | 1.2B | 1× (8 GB+) | 128K | – (completions) | [LiquidAI/LFM2.5-1.2B-Base](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Base) |
+
+### Mixture-of-Experts (MoE) Model
+
+| Model | Total / Active Params | Min NVIDIA GPU (BF16) | Context | HuggingFace |
+|-------|----------------------|------------------------|---------|-------------|
+| LFM2.5 8B-A1B | 8B / ~1B active | 1× (24 GB+) | 128K | [LiquidAI/LFM2.5-8B-A1B](https://huggingface.co/LiquidAI/LFM2.5-8B-A1B) |
+
+The 8B-A1B keeps every expert resident in VRAM, so size the GPU for the full ~8B of weights even
+though only ~1B is active per token. It supports `<think>` reasoning and tool calling.
+
+### Vision-Language Models
+
+| Model | Parameters | Min NVIDIA GPU (BF16) | Context | HuggingFace |
+|-------|-----------|------------------------|---------|-------------|
+| LFM2.5 VL 450M | 450M | 1× (any) | 128K | [LiquidAI/LFM2.5-VL-450M](https://huggingface.co/LiquidAI/LFM2.5-VL-450M) |
+| LFM2.5 VL 1.6B | 1.6B | 1× (8 GB+) | 128K | [LiquidAI/LFM2.5-VL-1.6B](https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B) |
+
+The VL models pair the LFM2 hybrid language backbone with a SigLIP2 vision encoder
+(`Lfm2VlForConditionalGeneration`).
+
+## Installing vLLM
+
+LFM2.5 dense, MoE, and VL architectures all ship in vLLM **≥ 0.23.0** (stable).
+
+### pip (NVIDIA CUDA)
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -U vllm --torch-backend auto
+```
+
+### Docker
+
+```bash
+docker pull vllm/vllm-openai:latest        # CUDA 12.x
+docker pull vllm/vllm-openai:latest-cu130  # CUDA 13.0 (Blackwell)
+```
+
+## Running LFM2.5
+
+### Quick Start (Single GPU)
+
+```bash
+vllm serve LiquidAI/LFM2.5-1.2B-Instruct
+```
+
+Cap the context to fit a smaller GPU (models support up to 128K):
+
+```bash
+vllm serve LiquidAI/LFM2.5-1.2B-Instruct --max-model-len 32768
+```
+
+### 8B-A1B with Expert Parallelism (multi-GPU node)
+
+```bash
+vllm serve LiquidAI/LFM2.5-8B-A1B \
+  --tensor-parallel-size 2 \
+  --enable-expert-parallel
+```
+
+### Docker Deployment
+
+```bash
+docker run -itd --name lfm2.5 \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+        --model LiquidAI/LFM2.5-1.2B-Instruct \
+        --host 0.0.0.0 --port 8000
+```
+
+## Recommended Sampling
+
+LFM2.5 uses per-model sampling presets from the model cards. `top_k`, `min_p`, and
+`repetition_penalty` are vLLM extra sampling params — pass them via `extra_body` on the OpenAI
+client (or top-level in a raw `/v1/...` request).
+
+| Model | temperature | top_k | min_p | repetition_penalty |
+|-------|------------:|------:|------:|-------------------:|
+| LFM2.5 350M | 0.1 | 50 | – | 1.05 |
+| LFM2.5 1.2B Instruct | 0.1 | 50 | – | 1.05 |
+| LFM2.5 1.2B Thinking | 0.05 | 50 | – | 1.05 |
+| LFM2.5 1.2B JP | 0.3 | – | 0.15 | 1.05 |
+| LFM2.5 1.2B JP (202606) | 0.1 | 50 | – | 1.05 |
+| LFM2.5 1.2B Base | 0.3 | – | 0.15 | 1.05 |
+| LFM2.5 8B-A1B | 0.2 | 80 | – | 1.05 |
+| LFM2.5 VL 450M / 1.6B | 0.1 | – | 0.15 | 1.05 |
+
+> ⚠️ Do **not** bake these into `vllm serve` — they are per-request client defaults, not server
+> flags. Capping `max_tokens` too low truncates the reasoning models' chain-of-thought.
+
+## Text Generation
+
+### Online Serving (OpenAI SDK)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+response = client.chat.completions.create(
+    model="LiquidAI/LFM2.5-1.2B-Instruct",
+    messages=[{"role": "user", "content": "What is C. elegans? Answer in one sentence."}],
+    temperature=0.1,
+    extra_body={"top_k": 50, "repetition_penalty": 1.05},
+)
+print(response.choices[0].message.content)
+```
+
+### Base Model (completions)
+
+`LFM2.5-1.2B-Base` is not instruction-tuned and has no chat template — use the completions
+endpoint:
+
+```python
+resp = client.completions.create(
+    model="LiquidAI/LFM2.5-1.2B-Base",
+    prompt="The three laws of thermodynamics are:",
+    max_tokens=128,
+    temperature=0.3,
+    extra_body={"min_p": 0.15, "repetition_penalty": 1.05},
+)
+print(resp.choices[0].text)
+```
+
+## Reasoning Mode
+
+`LFM2.5-8B-A1B` and `LFM2.5-1.2B-Thinking` emit an explicit `<think>…</think>` chain-of-thought.
+Launch with the `qwen3` reasoning parser to split it into a separate `reasoning_content` field:
+
+```bash
+vllm serve LiquidAI/LFM2.5-1.2B-Thinking \
+  --reasoning-parser qwen3
+```
+
+```python
+response = client.chat.completions.create(
+    model="LiquidAI/LFM2.5-1.2B-Thinking",
+    messages=[{"role": "user", "content": "If a train travels 60 km in 45 minutes, what is its speed in km/h?"}],
+    temperature=0.05,
+    extra_body={"top_k": 50, "repetition_penalty": 1.05},
+)
+msg = response.choices[0].message
+print("reasoning:", msg.reasoning_content)
+print("answer:", msg.content)
+```
+
+> ℹ️ These models open the `<think>` channel for non-trivial problems; a trivial prompt may be
+> answered directly, in which case `reasoning_content` is empty. That's expected behavior.
+
+## Function Calling / Tool Use
+
+LFM2.5 emits Pythonic tool calls wrapped in `<|tool_call_start|>…<|tool_call_end|>`. The built-in
+`lfm2` tool parser converts these into standard OpenAI `tool_calls`:
+
+```bash
+vllm serve LiquidAI/LFM2.5-1.2B-Instruct \
+  --enable-auto-tool-choice \
+  --tool-call-parser lfm2
+```
+
+```python
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a location",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+        },
+    },
+}]
+
+response = client.chat.completions.create(
+    model="LiquidAI/LFM2.5-1.2B-Instruct",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=tools,
+    temperature=0.1,
+    extra_body={"top_k": 50, "repetition_penalty": 1.05},
+)
+print(response.choices[0].message.tool_calls)
+```
+
+Reasoning and tool calling can be combined for the reasoning models:
+
+```bash
+vllm serve LiquidAI/LFM2.5-8B-A1B \
+  --reasoning-parser qwen3 \
+  --enable-auto-tool-choice \
+  --tool-call-parser lfm2
+```
+
+## Image Understanding (VL)
+
+The VL models accept image + text turns through the standard chat API:
+
+```bash
+vllm serve LiquidAI/LFM2.5-VL-1.6B
+```
+
+```python
+response = client.chat.completions.create(
+    model="LiquidAI/LFM2.5-VL-1.6B",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg"}},
+            {"type": "text", "text": "What is in this image?"},
+        ],
+    }],
+    temperature=0.1,
+    extra_body={"min_p": 0.15, "repetition_penalty": 1.05},
+)
+print(response.choices[0].message.content)
+```
+
+Allow more than one image per request with `--limit-mm-per-prompt '{"image": 4}'`.
+
+## Benchmarking
+
+Disable prefix caching for consistent measurements:
+
+```bash
+vllm serve LiquidAI/LFM2.5-8B-A1B \
+  --no-enable-prefix-caching
+
+vllm bench serve \
+  --model LiquidAI/LFM2.5-8B-A1B \
+  --dataset-name random \
+  --random-input-len 1000 \
+  --random-output-len 1000 \
+  --request-rate 10000 \
+  --num-prompts 64 \
+  --ignore-eos
+```
+
+## Server Flags Reference
+
+| Flag | Description | When |
+|------|-------------|------|
+| `--reasoning-parser qwen3` | Split `<think>…</think>` into `reasoning_content` | 8B-A1B, 1.2B-Thinking |
+| `--tool-call-parser lfm2` | Surface Pythonic tool calls as `tool_calls` | tool-capable models |
+| `--enable-auto-tool-choice` | Auto-detect tool calls in output | with `--tool-call-parser` |
+| `--enable-expert-parallel` | Split MoE experts across GPUs | 8B-A1B multi-GPU |
+| `--max-model-len N` | Cap context (models support up to 128K) | small GPUs / fixed workload |
+| `--limit-mm-per-prompt '{"image": N}'` | Max images per request | VL models |
+
+## References
+
+- [Liquid AI](https://www.liquid.ai/)
+- [LiquidAI on HuggingFace](https://huggingface.co/LiquidAI)
+- [LFM2.5-1.2B-Instruct model card](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct)
+- [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/LiquidAI/LFM2.5.md
+++ b/LiquidAI/LFM2.5.md
@@ -277,6 +277,39 @@ vllm bench serve \
 | `--max-model-len N` | Cap context (models support up to 128K) | small GPUs / fixed workload |
 | `--limit-mm-per-prompt '{"image": N}'` | Max images per request | VL models |
 
+## Deploy on Modal
+
+[Modal](https://modal.com) runs this recipe on cloud GPUs with a single command — no
+infrastructure to manage. The deployment script is [`lfm25-modal.py`](lfm25-modal.py) in this
+directory: it serves an LFM2.5 model with vLLM behind an OpenAI-compatible endpoint, with the
+model and GPU selectable via environment variables.
+
+### Deploy
+
+```bash
+pip install modal
+modal setup                  # one-time: authenticate with Modal
+modal deploy lfm25-modal.py  # serves LiquidAI/LFM2.5-1.2B-Instruct on an L4 by default
+```
+
+### Test
+
+```bash
+modal run lfm25-modal.py
+```
+
+### Pick a model / GPU
+
+```bash
+MODEL=LiquidAI/LFM2.5-8B-A1B GPU=H100 modal run lfm25-modal.py
+```
+
+LFM2.5's small footprint means even a budget GPU is plenty. The 1.2B dense checkpoint was
+validated end-to-end on this script across NVIDIA **T4, L4, A10G, L40S, A100 (40/80 GB), H100,
+H200, and B200** (vLLM 0.23.0); the 8B-A1B MoE and the VL models were validated on **H100, H200,
+and B200**. Size up to a 24 GB+ GPU (L4 / A10G or larger) for the 8B-A1B MoE, which keeps all
+~8B of experts resident in VRAM.
+
 ## References
 
 - [Liquid AI](https://www.liquid.ai/)

--- a/LiquidAI/lfm25-modal.py
+++ b/LiquidAI/lfm25-modal.py
@@ -1,0 +1,121 @@
+import json
+import os
+from typing import Any
+
+import aiohttp
+import modal
+
+# LFM2.5 is a first-class vLLM architecture as of vLLM 0.23.0 (Lfm2ForCausalLM /
+# Lfm2MoeForCausalLM / Lfm2VlForConditionalGeneration) — no --trust-remote-code needed.
+vllm_image = (
+    modal.Image.from_registry("nvidia/cuda:12.9.0-devel-ubuntu22.04", add_python="3.12")
+    .entrypoint([])
+    .uv_pip_install("vllm==0.23.0")  # pins the version the recipe is validated against
+    .env({"HF_XET_HIGH_PERFORMANCE": "1"})  # faster model transfers
+)
+
+# Override via env to deploy a different LFM2.5 model or GPU, e.g.:
+#   MODEL=LiquidAI/LFM2.5-8B-A1B GPU=H100 modal run LiquidAI/lfm25-modal.py
+# LFM2.5 models are small, so a cheap GPU is plenty for the dense / VL checkpoints; size up to
+# an L4/A10G (24 GB) or larger for the 8B-A1B MoE (all ~8B of experts stay resident).
+MODEL_NAME = os.environ.get("MODEL", "LiquidAI/LFM2.5-1.2B-Instruct")
+GPU = os.environ.get("GPU", "L4")
+
+hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
+vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)
+
+FAST_BOOT = False
+
+app = modal.App("example-lfm2-5-vllm-inference")
+
+N_GPU = 1
+MINUTES = 60  # seconds
+VLLM_PORT = 8000
+
+
+@app.function(
+    image=vllm_image,
+    gpu=f"{GPU}:{N_GPU}",
+    scaledown_window=15 * MINUTES,  # how long should we stay up with no requests?
+    timeout=10 * MINUTES,  # how long should we wait for container start?
+    volumes={
+        "/root/.cache/huggingface": hf_cache_vol,
+        "/root/.cache/vllm": vllm_cache_vol,
+    },
+)
+@modal.concurrent(  # how many requests can one replica handle? tune carefully!
+    max_inputs=100,
+)
+@modal.web_server(port=VLLM_PORT, startup_timeout=10 * MINUTES)
+def serve():
+    import subprocess
+
+    cmd = [
+        "vllm",
+        "serve",
+        MODEL_NAME,
+        "--served-model-name",
+        "llm",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(VLLM_PORT),
+        "--uvicorn-log-level=info",
+        "--async-scheduling",
+        # LFM2.5 tool calling: surface Pythonic <|tool_call_start|>...<|tool_call_end|> as tool_calls
+        "--enable-auto-tool-choice",
+        "--tool-call-parser",
+        "lfm2",
+    ]
+
+    # enforce-eager disables both Torch compilation and CUDA graph capture; default keeps them on.
+    cmd += ["--enforce-eager" if FAST_BOOT else "--no-enforce-eager"]
+
+    # split large matmuls across GPUs (use >1 only for the 8B-A1B MoE on a multi-GPU node)
+    cmd += ["--tensor-parallel-size", str(N_GPU)]
+
+    print(*cmd)
+
+    subprocess.Popen(" ".join(cmd), shell=True)
+
+
+@app.local_entrypoint()
+async def test(test_timeout=10 * MINUTES, content=None):
+    url = await serve.get_web_url.aio()
+
+    if content is None:
+        content = "What is C. elegans? Answer in one sentence."
+    messages = [{"role": "user", "content": content}]  # OpenAI chat format
+
+    async with aiohttp.ClientSession(base_url=url) as session:
+        print(f"Running health check for server at {url}")
+        async with session.get("/health", timeout=test_timeout - 1 * MINUTES) as resp:
+            up = resp.status == 200
+        assert up, f"Failed health check for server at {url}"
+        print(f"Successful health check for server at {url}")
+
+        print(f"Sending a sample message to {url}", *messages, sep="\n\t")
+        await _send_request(session, "llm", messages)
+
+
+async def _send_request(session: aiohttp.ClientSession, model: str, messages: list) -> None:
+    # `stream=True` tells an OpenAI-compatible backend to stream chunks
+    payload: dict[str, Any] = {"messages": messages, "model": model, "stream": True}
+    headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
+
+    async with session.post("/v1/chat/completions", json=payload, headers=headers) as resp:
+        async for raw in resp.content:
+            resp.raise_for_status()
+            line = raw.decode().strip()
+            if not line or line == "data: [DONE]":
+                continue
+            if line.startswith("data: "):  # SSE prefix
+                line = line[len("data: ") :]
+
+            chunk = json.loads(line)
+            assert chunk["object"] == "chat.completion.chunk"  # or something went horribly wrong
+            delta = chunk["choices"][0]["delta"]
+            content = delta.get("content") or delta.get("reasoning_content")
+            if content:
+                print(content, end="")
+    print()

--- a/models/LiquidAI/LFM2.5-1.2B-Base.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Base.yaml
@@ -13,6 +13,8 @@ meta:
     - LiquidAI/LFM2.5-350M
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-1.2B-Base"

--- a/models/LiquidAI/LFM2.5-1.2B-Base.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Base.yaml
@@ -1,0 +1,130 @@
+meta:
+  title: "LFM2.5 1.2B Base"
+  slug: "lfm2.5-1.2b-base"
+  provider: "LiquidAI"
+  description: "Liquid AI's 1.2B pretrained base model on the LFM2 hybrid conv+attention backbone — a text-completion and fine-tuning foundation (no chat template)."
+  date_updated: 2026-06-24
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "1.2B pretrained base (no chat template) — completions endpoint, ideal as a fine-tuning base"
+  related_recipes:
+    - LiquidAI/LFM2.5-1.2B-Instruct
+    - LiquidAI/LFM2.5-350M
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-1.2B-Base"
+  min_vllm_version: "0.23.0"
+  architecture: dense
+  parameter_count: "1.2B"
+  active_parameters: "1.2B"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 3
+    description: "Full BF16 — single 8 GB+ NVIDIA GPU with room for KV cache"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-1.2B-Base](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Base) is the pretrained base
+  checkpoint behind [Liquid AI's](https://www.liquid.ai/) LFM2.5-1.2B instruct models, built on
+  the **LFM2 hybrid backbone** (short-range gated convolution blocks interleaved with grouped-query
+  attention). It is **not** instruction-tuned and has no chat template — use the
+  `/v1/completions` endpoint (raw text continuation), or fine-tune it for your own task.
+
+  ### Key Features
+  - **Pretrained base**: No chat template, no instruction tuning — a clean foundation for fine-tuning or raw completion.
+  - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
+  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+
+  ### Supported Variants
+
+  Dense:
+  - `LiquidAI/LFM2.5-350M` (350M)
+  - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
+  - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
+  - `LiquidAI/LFM2.5-1.2B-JP` / `LiquidAI/LFM2.5-1.2B-JP-202606` (Japanese)
+  - `LiquidAI/LFM2.5-1.2B-Base` (pretrained base)
+
+  MoE:
+  - `LiquidAI/LFM2.5-8B-A1B` (8B total / ~1B active)
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M`, `LiquidAI/LFM2.5-VL-1.6B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-Base
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-base \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-1.2B-Base \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Text Completion
+  This is a base model — use the **completions** endpoint, not chat. Recommended sampling:
+  temperature `0.3`, `min_p 0.15`, `repetition_penalty 1.05`.
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.completions.create(
+      model="LiquidAI/LFM2.5-1.2B-Base",
+      prompt="The three laws of thermodynamics are:",
+      max_tokens=128,
+      temperature=0.3,
+      extra_body={"min_p": 0.15, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].text)
+  ```
+
+  ## Configuration Tips
+  - Use `/v1/completions` (raw continuation) — there is no chat template on a base model.
+  - For fine-tuning, this checkpoint is the recommended starting point for custom LFM2.5-1.2B tasks.
+  - Set `--max-model-len` to match your workload (up to 128K).
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Base)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-1.2B-Instruct.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Instruct.yaml
@@ -14,6 +14,8 @@ meta:
     - LiquidAI/LFM2.5-8B-A1B
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-1.2B-Instruct"

--- a/models/LiquidAI/LFM2.5-1.2B-Instruct.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Instruct.yaml
@@ -1,0 +1,178 @@
+meta:
+  title: "LFM2.5 1.2B Instruct"
+  slug: "lfm2.5-1.2b-instruct"
+  provider: "LiquidAI"
+  description: "Liquid AI's 1.2B instruction-tuned model on the LFM2 hybrid conv+attention backbone, with tool calling and a 128K context window on a single small GPU."
+  date_updated: 2026-06-24
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "1.2B hybrid (gated conv + GQA) instruct model with tool calling — runs on a single 8 GB+ GPU"
+  related_recipes:
+    - LiquidAI/LFM2.5-350M
+    - LiquidAI/LFM2.5-1.2B-Thinking
+    - LiquidAI/LFM2.5-8B-A1B
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-1.2B-Instruct"
+  min_vllm_version: "0.23.0"
+  architecture: dense
+  parameter_count: "1.2B"
+  active_parameters: "1.2B"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Surface LFM2.5's Pythonic tool calls (wrapped in <|tool_call_start|>…<|tool_call_end|>) as OpenAI tool_calls via vLLM's native lfm2 parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "lfm2"
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 3
+    description: "Full BF16 — single 8 GB+ NVIDIA GPU with room for KV cache"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-1.2B-Instruct](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct) is a 1.2B
+  instruction-tuned model from [Liquid AI](https://www.liquid.ai/), built on the **LFM2 hybrid
+  backbone**: short-range gated convolution blocks interleaved with grouped-query attention.
+  The hybrid design keeps the KV cache small and decode fast, so the model serves comfortably on
+  a single small GPU while supporting a 128K context window and Pythonic tool calling — all
+  through vLLM's OpenAI-compatible API.
+
+  ### Key Features
+  - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
+  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **Tool calling**: Pythonic tool calls (`<|tool_call_start|>…<|tool_call_end|>`) surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+  - **Edge-ready family**: Day-one support across llama.cpp, MLX, ONNX, vLLM, and SGLang.
+
+  ### Supported Variants
+
+  Dense:
+  - `LiquidAI/LFM2.5-350M` (350M)
+  - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
+  - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
+  - `LiquidAI/LFM2.5-1.2B-JP` / `LiquidAI/LFM2.5-1.2B-JP-202606` (Japanese)
+  - `LiquidAI/LFM2.5-1.2B-Base` (pretrained base)
+
+  MoE:
+  - `LiquidAI/LFM2.5-8B-A1B` (8B total / ~1B active)
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M`, `LiquidAI/LFM2.5-VL-1.6B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU with ≥8 GB VRAM (e.g. L4, A10, RTX 4090, H100). Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-Instruct
+  ```
+  Cap the context to fit a smaller GPU (the model supports up to 128K):
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-Instruct --max-model-len 32768
+  ```
+
+  ### Full-Featured Server Launch
+  Enables tool calling:
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-Instruct \
+    --enable-auto-tool-choice \
+    --tool-call-parser lfm2 \
+    --host 0.0.0.0 --port 8000
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-1.2b \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-1.2B-Instruct \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Text Generation
+  The model card recommends temperature `0.1`, `top_k 50`, `repetition_penalty 1.05`. `top_k` and
+  `repetition_penalty` are vLLM extra sampling params — pass them via `extra_body`.
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-1.2B-Instruct",
+      messages=[{"role": "user", "content": "What is C. elegans? Answer in one sentence."}],
+      temperature=0.1,
+      extra_body={"top_k": 50, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### Tool Calling
+  Launch with `--enable-auto-tool-choice --tool-call-parser lfm2`, then pass `tools=[…]`. The
+  `lfm2` parser converts the model's Pythonic call into a standard `tool_calls` array.
+  ```python
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-1.2B-Instruct",
+      messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+      tools=[{
+          "type": "function",
+          "function": {
+              "name": "get_weather",
+              "description": "Get current weather for a location",
+              "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+          },
+      }],
+      temperature=0.1,
+      extra_body={"top_k": 50, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].message.tool_calls)
+  ```
+
+  ### Structured Outputs
+  vLLM's guided decoding constrains output to a JSON schema via `response_format`. The model does
+  not see the schema itself — put semantic instructions (units, formatting) in the system prompt.
+
+  ## Configuration Tips
+  - Set `--max-model-len` to match your workload (up to 128K); lowering it frees VRAM for KV cache.
+  - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
+  - FP8 KV cache (`--kv-cache-dtype fp8`) roughly halves KV memory.
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-1.2B-JP-202606.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-JP-202606.yaml
@@ -13,6 +13,8 @@ meta:
     - LiquidAI/LFM2.5-1.2B-Instruct
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-1.2B-JP-202606"

--- a/models/LiquidAI/LFM2.5-1.2B-JP-202606.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-JP-202606.yaml
@@ -1,0 +1,150 @@
+meta:
+  title: "LFM2.5 1.2B JP (202606)"
+  slug: "lfm2.5-1.2b-jp-202606"
+  provider: "LiquidAI"
+  description: "Liquid AI's updated (2026-06) 1.2B Japanese chat model on the LFM2 hybrid conv+attention backbone — adds tool calling, with a 128K context window."
+  date_updated: 2026-06-24
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "Updated Japanese-tuned 1.2B hybrid chat model with tool calling — single small GPU"
+  related_recipes:
+    - LiquidAI/LFM2.5-1.2B-JP
+    - LiquidAI/LFM2.5-1.2B-Instruct
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-1.2B-JP-202606"
+  min_vllm_version: "0.23.0"
+  architecture: dense
+  parameter_count: "1.2B"
+  active_parameters: "1.2B"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Surface LFM2.5's Pythonic tool calls (wrapped in <|tool_call_start|>…<|tool_call_end|>) as OpenAI tool_calls via vLLM's native lfm2 parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "lfm2"
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 3
+    description: "Full BF16 — single 8 GB+ NVIDIA GPU with room for KV cache"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-1.2B-JP-202606](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-202606) is the updated
+  (June 2026) Japanese-specialized 1.2B chat model from [Liquid AI](https://www.liquid.ai/),
+  adding tool calling on top of the **LFM2 hybrid backbone** (short-range gated convolution
+  blocks interleaved with grouped-query attention). It serves on a single small GPU through
+  vLLM's OpenAI-compatible API.
+
+  ### Key Features
+  - **Japanese-specialized**: Updated June 2026 checkpoint tuned for Japanese chat.
+  - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
+  - **Tool calling**: Pythonic tool calls (`<|tool_call_start|>…<|tool_call_end|>`) surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
+  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+
+  ### Supported Variants
+
+  Dense:
+  - `LiquidAI/LFM2.5-350M` (350M)
+  - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
+  - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
+  - `LiquidAI/LFM2.5-1.2B-JP` / `LiquidAI/LFM2.5-1.2B-JP-202606` (Japanese)
+  - `LiquidAI/LFM2.5-1.2B-Base` (pretrained base)
+
+  MoE:
+  - `LiquidAI/LFM2.5-8B-A1B` (8B total / ~1B active)
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M`, `LiquidAI/LFM2.5-VL-1.6B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-JP-202606
+  ```
+
+  ### Full-Featured Server Launch
+  Enables tool calling:
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-JP-202606 \
+    --enable-auto-tool-choice \
+    --tool-call-parser lfm2 \
+    --host 0.0.0.0 --port 8000
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-jp-202606 \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-1.2B-JP-202606 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Text Generation
+  The updated checkpoint uses temperature `0.1`, `top_k 50`, `repetition_penalty 1.05` (`top_k`
+  and `repetition_penalty` ride in `extra_body`).
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-1.2B-JP-202606",
+      messages=[{"role": "user", "content": "京都でおすすめの観光スポットを3つ教えてください。"}],
+      temperature=0.1,
+      extra_body={"top_k": 50, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### Tool Calling
+  Launch with `--enable-auto-tool-choice --tool-call-parser lfm2`, then pass `tools=[…]`; the
+  `lfm2` parser converts the model's Pythonic call into a standard `tool_calls` array.
+
+  ## Configuration Tips
+  - Set `--max-model-len` to match your workload (up to 128K); lowering it frees VRAM for KV cache.
+  - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-202606)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-1.2B-JP.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-JP.yaml
@@ -1,0 +1,129 @@
+meta:
+  title: "LFM2.5 1.2B JP"
+  slug: "lfm2.5-1.2b-jp"
+  provider: "LiquidAI"
+  description: "Liquid AI's 1.2B Japanese-specialized chat model on the LFM2 hybrid conv+attention backbone, with a 128K context window on a single small GPU."
+  date_updated: 2026-06-24
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "Japanese-tuned 1.2B hybrid chat model — single small GPU"
+  related_recipes:
+    - LiquidAI/LFM2.5-1.2B-JP-202606
+    - LiquidAI/LFM2.5-1.2B-Instruct
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-1.2B-JP"
+  min_vllm_version: "0.23.0"
+  architecture: dense
+  parameter_count: "1.2B"
+  active_parameters: "1.2B"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 3
+    description: "Full BF16 — single 8 GB+ NVIDIA GPU with room for KV cache"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-1.2B-JP](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP) is the Japanese-specialized
+  1.2B chat model from [Liquid AI](https://www.liquid.ai/), built on the **LFM2 hybrid backbone**
+  (short-range gated convolution blocks interleaved with grouped-query attention). It serves on a
+  single small GPU through vLLM's OpenAI-compatible API. For the latest Japanese checkpoint with
+  tool calling, see
+  [LFM2.5-1.2B-JP-202606](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-202606).
+
+  ### Key Features
+  - **Japanese-specialized**: Tuned for Japanese chat and instruction following.
+  - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
+  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+
+  ### Supported Variants
+
+  Dense:
+  - `LiquidAI/LFM2.5-350M` (350M)
+  - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
+  - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
+  - `LiquidAI/LFM2.5-1.2B-JP` / `LiquidAI/LFM2.5-1.2B-JP-202606` (Japanese)
+  - `LiquidAI/LFM2.5-1.2B-Base` (pretrained base)
+
+  MoE:
+  - `LiquidAI/LFM2.5-8B-A1B` (8B total / ~1B active)
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M`, `LiquidAI/LFM2.5-VL-1.6B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-JP
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-jp \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-1.2B-JP \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Text Generation
+  The card recommends temperature `0.3`, `min_p 0.15`, `repetition_penalty 1.05` for the JP
+  checkpoint (`min_p` and `repetition_penalty` ride in `extra_body`).
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-1.2B-JP",
+      messages=[{"role": "user", "content": "日本の四季について簡単に説明してください。"}],
+      temperature=0.3,
+      extra_body={"min_p": 0.15, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## Configuration Tips
+  - Set `--max-model-len` to match your workload (up to 128K); lowering it frees VRAM for KV cache.
+  - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-1.2B-JP.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-JP.yaml
@@ -13,6 +13,8 @@ meta:
     - LiquidAI/LFM2.5-1.2B-Instruct
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-1.2B-JP"

--- a/models/LiquidAI/LFM2.5-1.2B-Thinking.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Thinking.yaml
@@ -1,0 +1,173 @@
+meta:
+  title: "LFM2.5 1.2B Thinking"
+  slug: "lfm2.5-1.2b-thinking"
+  provider: "LiquidAI"
+  description: "Liquid AI's 1.2B reasoning model on the LFM2 hybrid conv+attention backbone — <think> chain-of-thought, tool calling, and 128K context on a single small GPU."
+  date_updated: 2026-06-24
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "1.2B hybrid reasoning model with <think> chain-of-thought and tool calling — single small GPU"
+  related_recipes:
+    - LiquidAI/LFM2.5-1.2B-Instruct
+    - LiquidAI/LFM2.5-8B-A1B
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-1.2B-Thinking"
+  min_vllm_version: "0.23.0"
+  architecture: dense
+  parameter_count: "1.2B"
+  active_parameters: "1.2B"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+features:
+  reasoning:
+    description: "Split the model's <think>…</think> chain-of-thought into a separate reasoning_content field via vLLM's qwen3 parser"
+    args:
+      - "--reasoning-parser"
+      - "qwen3"
+  tool_calling:
+    description: "Surface LFM2.5's Pythonic tool calls (wrapped in <|tool_call_start|>…<|tool_call_end|>) as OpenAI tool_calls via vLLM's native lfm2 parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "lfm2"
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 3
+    description: "Full BF16 — single 8 GB+ NVIDIA GPU with room for KV cache"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-1.2B-Thinking](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking) is the reasoning
+  variant of [Liquid AI's](https://www.liquid.ai/) 1.2B LFM2.5 model, built on the **LFM2 hybrid
+  backbone** (short-range gated convolution blocks interleaved with grouped-query attention). On
+  reasoning-heavy tasks it produces an explicit `<think>…</think>` chain-of-thought before its
+  final answer, so it reasons well above its weight class while still serving on a single small
+  GPU through vLLM's OpenAI-compatible API.
+
+  ### Key Features
+  - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
+  - **`<think>` reasoning**: Emits an explicit `<think>…</think>` chain-of-thought on non-trivial problems; vLLM's `qwen3` parser splits it into a separate `reasoning_content` field.
+  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **Tool calling**: Pythonic tool calls surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+
+  ### Supported Variants
+
+  Dense:
+  - `LiquidAI/LFM2.5-350M` (350M)
+  - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
+  - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
+  - `LiquidAI/LFM2.5-1.2B-JP` / `LiquidAI/LFM2.5-1.2B-JP-202606` (Japanese)
+  - `LiquidAI/LFM2.5-1.2B-Base` (pretrained base)
+
+  MoE:
+  - `LiquidAI/LFM2.5-8B-A1B` (8B total / ~1B active, also a reasoning model)
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M`, `LiquidAI/LFM2.5-VL-1.6B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  Enable the reasoning parser so the chain-of-thought is returned in `reasoning_content`:
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-Thinking \
+    --reasoning-parser qwen3
+  ```
+
+  ### Full-Featured Server Launch
+  Reasoning **and** tool calling:
+  ```bash
+  vllm serve LiquidAI/LFM2.5-1.2B-Thinking \
+    --reasoning-parser qwen3 \
+    --enable-auto-tool-choice \
+    --tool-call-parser lfm2 \
+    --host 0.0.0.0 --port 8000
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-thinking \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-1.2B-Thinking \
+      --reasoning-parser qwen3 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Reasoning Mode
+  The card recommends a low temperature for the reasoning model — temperature `0.05`, `top_k 50`,
+  `repetition_penalty 1.05`. Do **not** cap `max_tokens` too low: it can truncate the
+  chain-of-thought mid-stream.
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-1.2B-Thinking",
+      messages=[{"role": "user", "content": "A snail climbs 3 ft up a 20 ft well each day and slides 2 ft back each night. How many days to reach the top?"}],
+      temperature=0.05,
+      max_tokens=2048,
+      extra_body={"top_k": 50, "repetition_penalty": 1.05},
+  )
+  msg = response.choices[0].message
+  print("reasoning:", msg.reasoning_content)
+  print("answer:", msg.content)
+  ```
+
+  > **Note**: the model opens the `<think>` channel for non-trivial problems; a simple prompt may
+  > be answered directly, in which case `reasoning_content` is empty. That is expected behavior —
+  > the `qwen3` parser extracts the block whenever it is present.
+
+  ### Tool Calling
+  Add `--enable-auto-tool-choice --tool-call-parser lfm2` at launch, then pass `tools=[…]`; the
+  model can reason about which tool to call before emitting it.
+
+  ### Structured Outputs
+  vLLM's guided decoding constrains output to a JSON schema via `response_format`. The model does
+  not see the schema itself — put semantic instructions in the system prompt.
+
+  ## Configuration Tips
+  - Give reasoning room: keep `max_tokens` high enough for the `<think>` block plus the answer.
+  - Set `--max-model-len` to match your workload (up to 128K).
+  - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-1.2B-Thinking.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Thinking.yaml
@@ -13,6 +13,8 @@ meta:
     - LiquidAI/LFM2.5-8B-A1B
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-1.2B-Thinking"

--- a/models/LiquidAI/LFM2.5-350M.yaml
+++ b/models/LiquidAI/LFM2.5-350M.yaml
@@ -1,0 +1,173 @@
+meta:
+  title: "LFM2.5 350M"
+  slug: "lfm2.5-350m"
+  provider: "LiquidAI"
+  description: "Liquid AI's smallest LFM2.5 chat model (350M) on the LFM2 hybrid conv+attention backbone — tool calling and 128K context, light enough for edge GPUs."
+  date_updated: 2026-06-24
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "350M hybrid instruct model with tool calling — fits any GPU, ideal for edge / on-device serving"
+  related_recipes:
+    - LiquidAI/LFM2.5-1.2B-Instruct
+    - LiquidAI/LFM2.5-8B-A1B
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-350M"
+  min_vllm_version: "0.23.0"
+  architecture: dense
+  parameter_count: "350M"
+  active_parameters: "350M"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Surface LFM2.5's Pythonic tool calls (wrapped in <|tool_call_start|>…<|tool_call_end|>) as OpenAI tool_calls via vLLM's native lfm2 parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "lfm2"
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 1
+    description: "Full BF16 — fits essentially any GPU (~0.7 GB of weights)"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-350M](https://huggingface.co/LiquidAI/LFM2.5-350M) is the smallest chat model in
+  [Liquid AI's](https://www.liquid.ai/) LFM2.5 family, built on the **LFM2 hybrid backbone**:
+  short-range gated convolution blocks interleaved with grouped-query attention. It shares that
+  backbone with its larger siblings, which keeps memory and latency low enough for edge and
+  on-device deployment while still supporting tool calling and a 128K context window — all
+  through vLLM's OpenAI-compatible API.
+
+  ### Key Features
+  - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
+  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **Tool calling**: Pythonic tool calls (`<|tool_call_start|>…<|tool_call_end|>`) surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+  - **Edge-ready**: ~0.7 GB of BF16 weights — runs on commodity and on-device GPUs.
+
+  ### Supported Variants
+
+  Dense:
+  - `LiquidAI/LFM2.5-350M` (350M)
+  - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
+  - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
+  - `LiquidAI/LFM2.5-1.2B-JP` / `LiquidAI/LFM2.5-1.2B-JP-202606` (Japanese)
+  - `LiquidAI/LFM2.5-1.2B-Base` (pretrained base)
+
+  MoE:
+  - `LiquidAI/LFM2.5-8B-A1B` (8B total / ~1B active)
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M`, `LiquidAI/LFM2.5-VL-1.6B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU (~1 GB VRAM for weights; any modern GPU works). Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  ```bash
+  vllm serve LiquidAI/LFM2.5-350M
+  ```
+
+  ### Full-Featured Server Launch
+  Enables tool calling:
+  ```bash
+  vllm serve LiquidAI/LFM2.5-350M \
+    --enable-auto-tool-choice \
+    --tool-call-parser lfm2 \
+    --host 0.0.0.0 --port 8000
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-350m \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-350M \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Text Generation
+  The model card recommends temperature `0.1`, `top_k 50`, `repetition_penalty 1.05` (`top_k` and
+  `repetition_penalty` ride in `extra_body`).
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-350M",
+      messages=[{"role": "user", "content": "Give me three uses for baking soda."}],
+      temperature=0.1,
+      extra_body={"top_k": 50, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### Tool Calling
+  Launch with `--enable-auto-tool-choice --tool-call-parser lfm2`, then pass `tools=[…]`; the
+  `lfm2` parser converts the model's Pythonic call into a standard `tool_calls` array.
+  ```python
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-350M",
+      messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+      tools=[{
+          "type": "function",
+          "function": {
+              "name": "get_weather",
+              "description": "Get current weather for a location",
+              "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+          },
+      }],
+      temperature=0.1,
+      extra_body={"top_k": 50, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].message.tool_calls)
+  ```
+
+  ### Structured Outputs
+  vLLM's guided decoding constrains output to a JSON schema via `response_format`. The model does
+  not see the schema itself — put semantic instructions in the system prompt.
+
+  ## Configuration Tips
+  - At 350M the model fits any GPU; raise `--max-num-seqs` to push batch throughput.
+  - Set `--max-model-len` to match your workload (up to 128K).
+  - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-350M)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-350M.yaml
+++ b/models/LiquidAI/LFM2.5-350M.yaml
@@ -13,6 +13,8 @@ meta:
     - LiquidAI/LFM2.5-8B-A1B
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-350M"

--- a/models/LiquidAI/LFM2.5-8B-A1B.yaml
+++ b/models/LiquidAI/LFM2.5-8B-A1B.yaml
@@ -13,6 +13,8 @@ meta:
     - LiquidAI/LFM2.5-1.2B-Thinking
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-8B-A1B"

--- a/models/LiquidAI/LFM2.5-8B-A1B.yaml
+++ b/models/LiquidAI/LFM2.5-8B-A1B.yaml
@@ -1,0 +1,184 @@
+meta:
+  title: "LFM2.5 8B A1B"
+  slug: "lfm2.5-8b-a1b"
+  provider: "LiquidAI"
+  description: "Liquid AI's 8B mixture-of-experts model (~1B active) on the LFM2 hybrid conv+attention backbone, with <think> reasoning and tool calling at ~1B decode cost."
+  date_updated: 2026-06-24
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "8B-total / ~1B-active hybrid MoE with reasoning and tool calling — 8B quality at ~1B decode cost on a single GPU"
+  related_recipes:
+    - LiquidAI/LFM2.5-1.2B-Instruct
+    - LiquidAI/LFM2.5-1.2B-Thinking
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-8B-A1B"
+  min_vllm_version: "0.23.0"
+  architecture: moe
+  parameter_count: "8B"
+  active_parameters: "1B"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+features:
+  reasoning:
+    description: "Split the model's <think>…</think> chain-of-thought into a separate reasoning_content field via vLLM's qwen3 parser"
+    args:
+      - "--reasoning-parser"
+      - "qwen3"
+  tool_calling:
+    description: "Surface LFM2.5's Pythonic tool calls (wrapped in <|tool_call_start|>…<|tool_call_end|>) as OpenAI tool_calls via vLLM's native lfm2 parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "lfm2"
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 21
+    description: "Full BF16 — all 8B of experts live in VRAM; single 24 GB+ NVIDIA GPU"
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-8B-A1B](https://huggingface.co/LiquidAI/LFM2.5-8B-A1B) is [Liquid AI's](https://www.liquid.ai/)
+  mixture-of-experts model: ~8B total parameters with only ~1B activated per token. It pairs the
+  **LFM2 hybrid backbone** (short-range gated convolution blocks interleaved with grouped-query
+  attention) with sparse MoE feed-forward layers, so it reaches 8B-class quality at roughly 1B
+  decode cost. It supports explicit `<think>` reasoning and Pythonic tool calling through vLLM's
+  OpenAI-compatible API.
+
+  ### Key Features
+  - **Hybrid + MoE**: Gated short convolutions + grouped-query attention with sparse expert FFNs — ~1B active parameters per token out of ~8B total.
+  - **`<think>` reasoning**: Emits an explicit `<think>…</think>` chain-of-thought on non-trivial problems; vLLM's `qwen3` parser splits it into `reasoning_content`.
+  - **Tool calling**: Pythonic tool calls surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
+  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **Native vLLM support**: Served via the `Lfm2MoeForCausalLM` architecture — no `--trust-remote-code` required.
+
+  ### Supported Variants
+
+  Dense:
+  - `LiquidAI/LFM2.5-350M` (350M)
+  - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
+  - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
+  - `LiquidAI/LFM2.5-1.2B-JP` / `LiquidAI/LFM2.5-1.2B-JP-202606` (Japanese)
+  - `LiquidAI/LFM2.5-1.2B-Base` (pretrained base)
+
+  MoE:
+  - `LiquidAI/LFM2.5-8B-A1B` (8B total / ~1B active)
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M`, `LiquidAI/LFM2.5-VL-1.6B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  > **Sizing**: MoE keeps every expert resident in VRAM, so size the GPU for the full ~8B of
+  > weights (≈17 GB BF16 + KV cache) even though only ~1B is active per token.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU with ≥24 GB VRAM. Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the `Lfm2MoeForCausalLM` architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  ```bash
+  vllm serve LiquidAI/LFM2.5-8B-A1B
+  ```
+
+  ### Full-Featured Server Launch
+  Reasoning **and** tool calling:
+  ```bash
+  vllm serve LiquidAI/LFM2.5-8B-A1B \
+    --reasoning-parser qwen3 \
+    --enable-auto-tool-choice \
+    --tool-call-parser lfm2 \
+    --host 0.0.0.0 --port 8000
+  ```
+
+  ### Multi-GPU (Expert Parallelism)
+  Split the experts across GPUs on a multi-GPU node:
+  ```bash
+  vllm serve LiquidAI/LFM2.5-8B-A1B \
+    --tensor-parallel-size 2 \
+    --enable-expert-parallel
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-8b-a1b \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-8B-A1B \
+      --reasoning-parser qwen3 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Reasoning Mode
+  The model card recommends temperature `0.2`, `top_k 80`, `repetition_penalty 1.05`. Give the
+  `<think>` block room — don't cap `max_tokens` too low.
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-8B-A1B",
+      messages=[{"role": "user", "content": "A snail climbs 3 ft up a 20 ft well each day and slides 2 ft back each night. How many days to reach the top?"}],
+      temperature=0.2,
+      max_tokens=2048,
+      extra_body={"top_k": 80, "repetition_penalty": 1.05},
+  )
+  msg = response.choices[0].message
+  print("reasoning:", msg.reasoning_content)
+  print("answer:", msg.content)
+  ```
+
+  > **Note**: the model opens the `<think>` channel for non-trivial problems; a simple prompt may
+  > be answered directly, in which case `reasoning_content` is empty. That is expected behavior —
+  > the `qwen3` parser extracts the block whenever it is present.
+
+  ### Tool Calling
+  Add `--enable-auto-tool-choice --tool-call-parser lfm2` at launch, then pass `tools=[…]`; the
+  `lfm2` parser converts the model's Pythonic call into a standard `tool_calls` array.
+
+  ### Structured Outputs
+  vLLM's guided decoding constrains output to a JSON schema via `response_format`. The model does
+  not see the schema itself — put semantic instructions in the system prompt.
+
+  ## Configuration Tips
+  - Size the GPU for the full ~8B of weights — all experts are resident even though ~1B is active.
+  - For multi-GPU nodes, `--enable-expert-parallel` distributes experts across ranks.
+  - Set `--max-model-len` to match your workload (up to 128K).
+  - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-8B-A1B)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-VL-1.6B.yaml
+++ b/models/LiquidAI/LFM2.5-VL-1.6B.yaml
@@ -1,0 +1,141 @@
+meta:
+  title: "LFM2.5 VL 1.6B"
+  slug: "lfm2.5-vl-1.6b"
+  provider: "LiquidAI"
+  description: "Liquid AI's 1.6B vision-language model — LFM2 hybrid LM backbone plus a SigLIP2 vision tower for image+text chat on a single small GPU."
+  date_updated: 2026-06-24
+  difficulty: beginner
+  tasks:
+    - multimodal
+  performance_headline: "1.6B vision-language model (hybrid LM + SigLIP2 vision) — image understanding on a single small GPU"
+  related_recipes:
+    - LiquidAI/LFM2.5-VL-450M
+    - LiquidAI/LFM2.5-1.2B-Instruct
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-VL-1.6B"
+  min_vllm_version: "0.23.0"
+  architecture: dense
+  parameter_count: "1.6B"
+  active_parameters: "1.6B"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 4
+    description: "Full BF16 (LM + vision encoder) — single 8 GB+ NVIDIA GPU"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-VL-1.6B](https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B) is the larger vision-language
+  model in [Liquid AI's](https://www.liquid.ai/) LFM2.5-VL family. It pairs the **LFM2 hybrid
+  language backbone** (short-range gated convolution blocks interleaved with grouped-query
+  attention) with a SigLIP2 vision encoder for image understanding, while remaining small enough
+  to serve on a single commodity GPU through vLLM's OpenAI-compatible API.
+
+  ### Key Features
+  - **Vision-language**: SigLIP2 vision encoder on top of the LFM2 hybrid language backbone — single- and multi-image prompts.
+  - **Hybrid LM backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
+  - **128K context**: Long-context support (`text_config.max_position_embeddings = 128000`).
+  - **Native vLLM support**: Served via the `Lfm2VlForConditionalGeneration` architecture — no `--trust-remote-code` required.
+
+  ### Supported Variants
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M` (450M)
+  - `LiquidAI/LFM2.5-VL-1.6B` (1.6B)
+
+  Text (same LFM2 family):
+  - Dense: `LiquidAI/LFM2.5-350M`, `LiquidAI/LFM2.5-1.2B-Instruct`, `LiquidAI/LFM2.5-1.2B-Thinking`, `LiquidAI/LFM2.5-1.2B-JP`, `LiquidAI/LFM2.5-1.2B-JP-202606`, `LiquidAI/LFM2.5-1.2B-Base`
+  - MoE: `LiquidAI/LFM2.5-8B-A1B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the `Lfm2VlForConditionalGeneration` architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  ```bash
+  vllm serve LiquidAI/LFM2.5-VL-1.6B
+  ```
+
+  ### Multiple Images per Request
+  ```bash
+  vllm serve LiquidAI/LFM2.5-VL-1.6B \
+    --limit-mm-per-prompt '{"image": 4}' \
+    --host 0.0.0.0 --port 8000
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-vl-1.6b \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-VL-1.6B \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Image Understanding
+  Send an image + text turn via the OpenAI chat API. The card recommends temperature `0.1`,
+  `min_p 0.15`, `repetition_penalty 1.05` (`min_p` and `repetition_penalty` ride in `extra_body`).
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-VL-1.6B",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg"}},
+              {"type": "text", "text": "What is in this image?"},
+          ],
+      }],
+      temperature=0.1,
+      extra_body={"min_p": 0.15, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### Multiple Images
+  Launch with `--limit-mm-per-prompt '{"image": N}'`, then include several `image_url` blocks in
+  one message to compare or reason across images.
+
+  ## Configuration Tips
+  - `--limit-mm-per-prompt '{"image": N}'` caps images per request (default 1).
+  - Set `--max-model-len` to match your workload (up to 128K).
+  - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-VL-1.6B.yaml
+++ b/models/LiquidAI/LFM2.5-VL-1.6B.yaml
@@ -13,6 +13,8 @@ meta:
     - LiquidAI/LFM2.5-1.2B-Instruct
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-VL-1.6B"

--- a/models/LiquidAI/LFM2.5-VL-450M.yaml
+++ b/models/LiquidAI/LFM2.5-VL-450M.yaml
@@ -1,0 +1,142 @@
+meta:
+  title: "LFM2.5 VL 450M"
+  slug: "lfm2.5-vl-450m"
+  provider: "LiquidAI"
+  description: "Liquid AI's smallest vision-language model (450M) — LFM2 hybrid LM backbone plus a SigLIP2 vision tower for image+text chat, light enough for edge GPUs."
+  date_updated: 2026-06-24
+  difficulty: beginner
+  tasks:
+    - multimodal
+  performance_headline: "450M vision-language model (hybrid LM + SigLIP2 vision) — image understanding light enough for edge / on-device serving"
+  related_recipes:
+    - LiquidAI/LFM2.5-VL-1.6B
+    - LiquidAI/LFM2.5-350M
+  hardware:
+    h100: verified
+
+model:
+  model_id: "LiquidAI/LFM2.5-VL-450M"
+  min_vllm_version: "0.23.0"
+  architecture: dense
+  parameter_count: "450M"
+  active_parameters: "450M"
+  context_length: 128000
+  base_args: []
+  base_env: {}
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 2
+    description: "Full BF16 (LM + vision encoder) — fits essentially any GPU"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  [LFM2.5-VL-450M](https://huggingface.co/LiquidAI/LFM2.5-VL-450M) is the smallest vision-language
+  model in [Liquid AI's](https://www.liquid.ai/) LFM2.5-VL family — a SigLIP2 vision encoder on
+  top of the **LFM2 hybrid language backbone** (short-range gated convolution blocks interleaved
+  with grouped-query attention). It is light enough for edge and on-device image understanding,
+  served through vLLM's OpenAI-compatible API.
+
+  ### Key Features
+  - **Vision-language**: SigLIP2 vision encoder on top of the LFM2 hybrid language backbone — single- and multi-image prompts.
+  - **Edge-ready**: ~1 GB of BF16 weights — runs on commodity and on-device GPUs.
+  - **Hybrid LM backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
+  - **128K context**: Long-context support (`text_config.max_position_embeddings = 128000`).
+  - **Native vLLM support**: Served via the `Lfm2VlForConditionalGeneration` architecture — no `--trust-remote-code` required.
+
+  ### Supported Variants
+
+  Vision-Language:
+  - `LiquidAI/LFM2.5-VL-450M` (450M)
+  - `LiquidAI/LFM2.5-VL-1.6B` (1.6B)
+
+  Text (same LFM2 family):
+  - Dense: `LiquidAI/LFM2.5-350M`, `LiquidAI/LFM2.5-1.2B-Instruct`, `LiquidAI/LFM2.5-1.2B-Thinking`, `LiquidAI/LFM2.5-1.2B-JP`, `LiquidAI/LFM2.5-1.2B-JP-202606`, `LiquidAI/LFM2.5-1.2B-Base`
+  - MoE: `LiquidAI/LFM2.5-8B-A1B`
+
+  See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
+
+  ## Prerequisites
+
+  - **Hardware**: 1× GPU (~1–2 GB VRAM for weights; any modern GPU works). Verified on H100.
+  - **vLLM**: ≥ 0.23.0 — the `Lfm2VlForConditionalGeneration` architecture ships in the 0.23.0 stable release.
+
+  ### pip (NVIDIA CUDA)
+  ```bash
+  uv venv
+  source .venv/bin/activate
+  uv pip install -U vllm --torch-backend auto
+  ```
+
+  ## Deployment Configurations
+
+  ### Quick Start (Single GPU, BF16)
+  ```bash
+  vllm serve LiquidAI/LFM2.5-VL-450M
+  ```
+
+  ### Multiple Images per Request
+  ```bash
+  vllm serve LiquidAI/LFM2.5-VL-450M \
+    --limit-mm-per-prompt '{"image": 4}' \
+    --host 0.0.0.0 --port 8000
+  ```
+
+  ### Docker (NVIDIA)
+  ```bash
+  docker run -itd --name lfm2.5-vl-450m \
+    --ipc=host --network host --shm-size 16G --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:latest \
+      --model LiquidAI/LFM2.5-VL-450M \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  ## Client Usage
+
+  ### Image Understanding
+  Send an image + text turn via the OpenAI chat API. The card recommends temperature `0.1`,
+  `min_p 0.15`, `repetition_penalty 1.05` (`min_p` and `repetition_penalty` ride in `extra_body`).
+  ```python
+  from openai import OpenAI
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="LiquidAI/LFM2.5-VL-450M",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg"}},
+              {"type": "text", "text": "What is in this image?"},
+          ],
+      }],
+      temperature=0.1,
+      extra_body={"min_p": 0.15, "repetition_penalty": 1.05},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### Multiple Images
+  Launch with `--limit-mm-per-prompt '{"image": N}'`, then include several `image_url` blocks in
+  one message to compare or reason across images.
+
+  ## Configuration Tips
+  - At 450M the model fits any GPU; ideal for edge / on-device image understanding.
+  - `--limit-mm-per-prompt '{"image": N}'` caps images per request (default 1).
+  - Set `--max-model-len` to match your workload (up to 128K).
+  - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
+
+  ## References
+  - [Model card](https://huggingface.co/LiquidAI/LFM2.5-VL-450M)
+  - [LFM2.5 usage guide](../../LiquidAI/LFM2.5)
+  - [Liquid AI](https://www.liquid.ai/)
+  - [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/models/LiquidAI/LFM2.5-VL-450M.yaml
+++ b/models/LiquidAI/LFM2.5-VL-450M.yaml
@@ -13,6 +13,8 @@ meta:
     - LiquidAI/LFM2.5-350M
   hardware:
     h100: verified
+    h200: verified
+    b200: verified
 
 model:
   model_id: "LiquidAI/LFM2.5-VL-450M"

--- a/src/lib/providers.js
+++ b/src/lib/providers.js
@@ -42,6 +42,7 @@ export const PROVIDERS = {
   "poolside":        { display_name: "Poolside",                 logo: "/providers/poolside.png" },
   "JetBrains":       { display_name: "JetBrains",                 logo: "/providers/JetBrains.png" },
   "openbmb":         { display_name: "MiniCPM (OpenBMB)",          logo: "/providers/openbmb.png" },
+  "LiquidAI":        { display_name: "Liquid AI",                  logo: "/providers/LiquidAI.png" },
 };
 
 export function getProviderLogo(hfOrg) {


### PR DESCRIPTION
Adds the first **LiquidAI** provider entry, covering the LFM2.5 language and
vision-language model family. All recipes serve via vLLM's native LFM2
architectures — no `--trust-remote-code` needed.

### Recipes added (`models/LiquidAI/`)

| Recipe | Arch | Params | Features |
|--------|------|--------|----------|
| LFM2.5-350M | dense (`Lfm2ForCausalLM`) | 350M | tools |
| LFM2.5-1.2B-Instruct | dense | 1.2B | tools |
| LFM2.5-1.2B-Thinking | dense | 1.2B | reasoning + tools |
| LFM2.5-1.2B-JP | dense | 1.2B | — |
| LFM2.5-1.2B-JP-202606 | dense | 1.2B | tools |
| LFM2.5-1.2B-Base | dense | 1.2B | completions (base) |
| LFM2.5-8B-A1B | MoE (`Lfm2MoeForCausalLM`) | 8B / ~1B active | reasoning + tools |
| LFM2.5-VL-450M | VL (`Lfm2VlForConditionalGeneration`) | 450M | image+text |
| LFM2.5-VL-1.6B | VL | 1.6B | image+text |

Plus a `LiquidAI/LFM2.5.md` provider guide (install, supported-models table,
serve commands, reasoning/tools/vision usage, per-card recommended sampling)
and a `LiquidAI` entry in `src/lib/providers.js`.

### Notes

- **vLLM ≥ 0.23.0** — all three architectures (dense / MoE / VL) and the
  `lfm2` tool parser ship in the 0.23.0 stable release.
- **Tool calling**: `--enable-auto-tool-choice --tool-call-parser lfm2`
  (vLLM's native `Lfm2ToolParser` for LFM2/LFM2.5 Pythonic tool calls).
- **Reasoning** (8B-A1B, 1.2B-Thinking): `--reasoning-parser qwen3` — the
  correct parser for LFM2.5's `<think>…</think>` format. The models open the
  `<think>` channel for harder reasoning turns (a simple prompt may be answered
  inline), and the parser separates it into `reasoning_content` when present.
- **Sampling** is documented per model card in the guides (not baked into the
  serve command).

### Validation

Every recipe's exact generated serve command was run on **NVIDIA H100** with
`vllm/vllm-openai:v0.23.0` (one container per model): all 9 reach `/health`,
chat returns coherent output, the 6 tool-capable models return `tool_calls`
(`lfm2` parser), and both VL models answer an image+text turn. The reasoning
models serve with `--reasoning-parser qwen3` and emit/extract `<think>` on
reasoning-heavy turns. `meta.hardware` lists only `h100: verified` accordingly.

`node scripts/build-recipes-api.mjs` passes (no errors); the MkDocs `--strict`
build passes with the new guide.