### PR TITLE
LFM2.5: fix context_length to 32K (per model cards) + Blackwell oink + copy cleanup

### DIFF
--- a/LiquidAI/LFM2.5.md
+++ b/LiquidAI/LFM2.5.md
@@ -4,17 +4,14 @@
 efficient open-weight models built on the **LFM2 hybrid backbone** — short-range gated
 convolution blocks interleaved with grouped-query attention. The hybrid design keeps the KV
 cache small and decode fast, so LFM2.5 models punch above their weight while remaining cheap to
-serve, down to edge / on-device GPUs. The family spans dense chat models (350M, 1.2B), a
+serve, down to edge / on-device GPUs. The family spans dense chat models (230M, 350M, 1.2B), a
 mixture-of-experts model (8B-A1B), reasoning and Japanese variants, base checkpoints, and
 vision-language models (VL 450M / 1.6B) — all served through vLLM's OpenAI-compatible API.
 
 All LFM2.5 language and vision-language models are supported **natively** by vLLM (the
-`Lfm2ForCausalLM`, `Lfm2MoeForCausalLM`, and `Lfm2VlForConditionalGeneration` architectures), so
-**no `--trust-remote-code` is required**. Tool calling is handled by the built-in `lfm2` tool
-parser, and `<think>` reasoning by the `qwen3` reasoning parser.
-
-> ℹ️ All commands below were verified end-to-end on **NVIDIA H100**. Other GPUs are expected to
-> work but are listed only where validated.
+`Lfm2ForCausalLM`, `Lfm2MoeForCausalLM`, and `Lfm2VlForConditionalGeneration` architectures). Tool
+calling is handled by the built-in `lfm2` tool parser, and `<think>` reasoning by the `qwen3`
+reasoning parser.
 
 ## Supported Models
 
@@ -22,12 +19,13 @@ parser, and `<think>` reasoning by the `qwen3` reasoning parser.
 
 | Model | Parameters | Min NVIDIA GPU (BF16) | Context | Tools | HuggingFace |
 |-------|-----------|------------------------|---------|-------|-------------|
-| LFM2.5 350M | 350M | 1× (any) | 128K | ✓ | [LiquidAI/LFM2.5-350M](https://huggingface.co/LiquidAI/LFM2.5-350M) |
-| LFM2.5 1.2B Instruct | 1.2B | 1× (8 GB+) | 128K | ✓ | [LiquidAI/LFM2.5-1.2B-Instruct](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct) |
-| LFM2.5 1.2B Thinking | 1.2B | 1× (8 GB+) | 128K | ✓ (+reasoning) | [LiquidAI/LFM2.5-1.2B-Thinking](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking) |
-| LFM2.5 1.2B JP | 1.2B | 1× (8 GB+) | 128K | – | [LiquidAI/LFM2.5-1.2B-JP](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP) |
-| LFM2.5 1.2B JP (202606) | 1.2B | 1× (8 GB+) | 128K | ✓ | [LiquidAI/LFM2.5-1.2B-JP-202606](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-202606) |
-| LFM2.5 1.2B Base | 1.2B | 1× (8 GB+) | 128K | – (completions) | [LiquidAI/LFM2.5-1.2B-Base](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Base) |
+| LFM2.5 230M | 230M | 1× (any) | 32K | ✓ | [LiquidAI/LFM2.5-230M](https://huggingface.co/LiquidAI/LFM2.5-230M) |
+| LFM2.5 350M | 350M | 1× (any) | 32K | ✓ | [LiquidAI/LFM2.5-350M](https://huggingface.co/LiquidAI/LFM2.5-350M) |
+| LFM2.5 1.2B Instruct | 1.2B | 1× (8 GB+) | 32K | ✓ | [LiquidAI/LFM2.5-1.2B-Instruct](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct) |
+| LFM2.5 1.2B Thinking | 1.2B | 1× (8 GB+) | 32K | ✓ (+reasoning) | [LiquidAI/LFM2.5-1.2B-Thinking](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking) |
+| LFM2.5 1.2B JP | 1.2B | 1× (8 GB+) | 32K | – | [LiquidAI/LFM2.5-1.2B-JP](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP) |
+| LFM2.5 1.2B JP (202606) | 1.2B | 1× (8 GB+) | 32K | ✓ | [LiquidAI/LFM2.5-1.2B-JP-202606](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP-202606) |
+| LFM2.5 1.2B Base | 1.2B | 1× (8 GB+) | 32K | – (completions) | [LiquidAI/LFM2.5-1.2B-Base](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Base) |
 
 ### Mixture-of-Experts (MoE) Model
 
@@ -42,15 +40,16 @@ though only ~1B is active per token. It supports `<think>` reasoning and tool ca
 
 | Model | Parameters | Min NVIDIA GPU (BF16) | Context | HuggingFace |
 |-------|-----------|------------------------|---------|-------------|
-| LFM2.5 VL 450M | 450M | 1× (any) | 128K | [LiquidAI/LFM2.5-VL-450M](https://huggingface.co/LiquidAI/LFM2.5-VL-450M) |
-| LFM2.5 VL 1.6B | 1.6B | 1× (8 GB+) | 128K | [LiquidAI/LFM2.5-VL-1.6B](https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B) |
+| LFM2.5 VL 450M | 450M | 1× (any) | 32K | [LiquidAI/LFM2.5-VL-450M](https://huggingface.co/LiquidAI/LFM2.5-VL-450M) |
+| LFM2.5 VL 1.6B | 1.6B | 1× (8 GB+) | 32K | [LiquidAI/LFM2.5-VL-1.6B](https://huggingface.co/LiquidAI/LFM2.5-VL-1.6B) |
 
 The VL models pair the LFM2 hybrid language backbone with a SigLIP2 vision encoder
 (`Lfm2VlForConditionalGeneration`).
 
 ## Installing vLLM
 
-LFM2.5 dense, MoE, and VL architectures all ship in vLLM **≥ 0.23.0** (stable).
+LFM2.5's dense, MoE, and VL architectures (`Lfm2ForCausalLM`, `Lfm2MoeForCausalLM`,
+`Lfm2VlForConditionalGeneration`) run on **vLLM 0.23.0**, which `min_vllm_version` pins.
 
 ### pip (NVIDIA CUDA)
 
@@ -75,18 +74,20 @@ docker pull vllm/vllm-openai:latest-cu130  # CUDA 13.0 (Blackwell)
 vllm serve LiquidAI/LFM2.5-1.2B-Instruct
 ```
 
-Cap the context to fit a smaller GPU (models support up to 128K):
+Cap the context to fit a smaller GPU (models support up to 32K; 128K on 8B-A1B):
 
 ```bash
 vllm serve LiquidAI/LFM2.5-1.2B-Instruct --max-model-len 32768
 ```
 
-### 8B-A1B with Expert Parallelism (multi-GPU node)
+### Multi-GPU
+
+Every LFM2.5 model fits on a single GPU (the 8B-A1B MoE on a 24 GB+ GPU), so tensor parallelism
+gives no meaningful speedup on basically any GPU — there's nothing to split that helps. You can
+still try it on a multi-GPU node, but expect no throughput gain:
 
 ```bash
-vllm serve LiquidAI/LFM2.5-8B-A1B \
-  --tensor-parallel-size 2 \
-  --enable-expert-parallel
+vllm serve LiquidAI/LFM2.5-8B-A1B --tensor-parallel-size 2
 ```
 
 ### Docker Deployment
@@ -108,6 +109,7 @@ client (or top-level in a raw `/v1/...` request).
 
 | Model | temperature | top_k | min_p | repetition_penalty |
 |-------|------------:|------:|------:|-------------------:|
+| LFM2.5 230M | 0.1 | 50 | – | 1.05 |
 | LFM2.5 350M | 0.1 | 50 | – | 1.05 |
 | LFM2.5 1.2B Instruct | 0.1 | 50 | – | 1.05 |
 | LFM2.5 1.2B Thinking | 0.05 | 50 | – | 1.05 |
@@ -118,7 +120,7 @@ client (or top-level in a raw `/v1/...` request).
 | LFM2.5 VL 450M / 1.6B | 0.1 | – | 0.15 | 1.05 |
 
 > ⚠️ Do **not** bake these into `vllm serve` — they are per-request client defaults, not server
-> flags. Capping `max_tokens` too low truncates the reasoning models' chain-of-thought.
+> flags. Leave `max_tokens` unset — capping it truncates the reasoning models' chain-of-thought.
 
 ## Text Generation
 
@@ -146,7 +148,6 @@ endpoint:
 resp = client.completions.create(
     model="LiquidAI/LFM2.5-1.2B-Base",
     prompt="The three laws of thermodynamics are:",
-    max_tokens=128,
     temperature=0.3,
     extra_body={"min_p": 0.15, "repetition_penalty": 1.05},
 )
@@ -236,7 +237,7 @@ response = client.chat.completions.create(
     messages=[{
         "role": "user",
         "content": [
-            {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg"}},
+            {"type": "image_url", "image_url": {"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"}},
             {"type": "text", "text": "What is in this image?"},
         ],
     }],
@@ -266,6 +267,34 @@ vllm bench serve \
   --ignore-eos
 ```
 
+## Speed-of-Light Tuning
+
+The defaults are already strong for LFM2.5 — the model fits a single GPU (so tensor parallelism
+gives no speedup) and the standard serve path is well optimized. A few flags give a small extra
+gain:
+
+| Flag | Effect | Notes |
+|------|--------|-------|
+| `VLLM_USE_OINK_OPS=1` | **~+2.6%** on **B200** | Routes RMSNorm to the Blackwell `oink` kernels (bundled in the `vllm-openai` image); output identical. **Auto-enabled on Blackwell** by these recipes; inert (native fallback) elsewhere. |
+| `--optimization-level 3` | **~+2%** (all GPUs) | More aggressive compilation. Trades a longer one-time startup/compile for steady-state throughput — opt-in. |
+| `VLLM_USE_FASTOKENS=1` | lower **TTFT** on tokenization-bound loads | Swaps the HF fast-tokenizer Rust BPE backend for the [`fastokens`](https://github.com/crusoecloud/fastokens) shim (`pip install fastokens`). Helps high-QPS / long-prompt workloads; the gain is in tokenization latency, so it doesn't show up in steady-state decode throughput. |
+
+```bash
+# -O3 (opt-in); on Blackwell, VLLM_USE_OINK_OPS=1 is applied for you by the recipe
+vllm serve LiquidAI/LFM2.5-1.2B-Instruct --optimization-level 3
+
+# tokenization-bound serving (after `pip install fastokens`)
+VLLM_USE_FASTOKENS=1 vllm serve LiquidAI/LFM2.5-1.2B-Instruct
+```
+
+These knobs make little difference for single-GPU LFM2.5, but experiment if you like:
+`VLLM_SSM_CONV_STATE_LAYOUT` (SD vs DS), `--mamba-backend` (triton vs flashinfer),
+`--mamba-cache-mode` (none vs all), `--mm-processor-cache-type` (lru vs shm).
+
+> **Coming:** the Lfm2VL encoder CUDA graph
+> ([vllm-project/vllm#44930](https://github.com/vllm-project/vllm/pull/44930), ~10–20% lower e2e
+> latency at low batch) is not in 0.23.0 — it will be added once it ships in a stable release.
+
 ## Server Flags Reference
 
 | Flag | Description | When |
@@ -273,8 +302,7 @@ vllm bench serve \
 | `--reasoning-parser qwen3` | Split `<think>…</think>` into `reasoning_content` | 8B-A1B, 1.2B-Thinking |
 | `--tool-call-parser lfm2` | Surface Pythonic tool calls as `tool_calls` | tool-capable models |
 | `--enable-auto-tool-choice` | Auto-detect tool calls in output | with `--tool-call-parser` |
-| `--enable-expert-parallel` | Split MoE experts across GPUs | 8B-A1B multi-GPU |
-| `--max-model-len N` | Cap context (models support up to 128K) | small GPUs / fixed workload |
+| `--max-model-len N` | Cap context (up to 32K; 128K on 8B-A1B) | small GPUs / fixed workload |
 | `--limit-mm-per-prompt '{"image": N}'` | Max images per request | VL models |
 
 ## Deploy on Modal
@@ -304,11 +332,10 @@ modal run lfm25-modal.py
 MODEL=LiquidAI/LFM2.5-8B-A1B GPU=H100 modal run lfm25-modal.py
 ```
 
-LFM2.5's small footprint means even a budget GPU is plenty. The 1.2B dense checkpoint was
-validated end-to-end on this script across NVIDIA **T4, L4, A10G, L40S, A100 (40/80 GB), H100,
-H200, and B200** (vLLM 0.23.0); the 8B-A1B MoE and the VL models were validated on **H100, H200,
-and B200**. Size up to a 24 GB+ GPU (L4 / A10G or larger) for the 8B-A1B MoE, which keeps all
-~8B of experts resident in VRAM.
+LFM2.5's small footprint means even a budget GPU is plenty — the 1.2B dense checkpoint runs across
+NVIDIA **T4, L4, A10G, L40S, A100 (40/80 GB), H100, H200, and B200**; the 8B-A1B MoE and the VL
+models run on **H100, H200, and B200**. Size up to a 24 GB+ GPU (L4 / A10G or larger) for the
+8B-A1B MoE, which keeps all ~8B of experts resident in VRAM.
 
 ## References
 

--- a/LiquidAI/lfm25-modal.py
+++ b/LiquidAI/lfm25-modal.py
@@ -61,7 +61,6 @@ def serve():
         "--port",
         str(VLLM_PORT),
         "--uvicorn-log-level=info",
-        "--async-scheduling",
         # LFM2.5 tool calling: surface Pythonic <|tool_call_start|>...<|tool_call_end|> as tool_calls
         "--enable-auto-tool-choice",
         "--tool-call-parser",
@@ -71,7 +70,8 @@ def serve():
     # enforce-eager disables both Torch compilation and CUDA graph capture; default keeps them on.
     cmd += ["--enforce-eager" if FAST_BOOT else "--no-enforce-eager"]
 
-    # split large matmuls across GPUs (use >1 only for the 8B-A1B MoE on a multi-GPU node)
+    # LFM2.5 models fit on a single GPU, so tensor parallelism gives no real speedup — keep
+    # N_GPU=1 unless you specifically want to experiment with a multi-GPU node.
     cmd += ["--tensor-parallel-size", str(N_GPU)]
 
     print(*cmd)

--- a/models/LiquidAI/LFM2.5-1.2B-Base.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Base.yaml
@@ -22,7 +22,7 @@ model:
   architecture: dense
   parameter_count: "1.2B"
   active_parameters: "1.2B"
-  context_length: 128000
+  context_length: 32768
   base_args: []
   base_env: {}
 
@@ -35,7 +35,12 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -52,12 +57,13 @@ guide: |
   ### Key Features
   - **Pretrained base**: No chat template, no instruction tuning — a clean foundation for fine-tuning or raw completion.
   - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
-  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
-  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+  - **32K context**: 32,768-token context window.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture.
 
   ### Supported Variants
 
   Dense:
+  - `LiquidAI/LFM2.5-230M` (230M)
   - `LiquidAI/LFM2.5-350M` (350M)
   - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
   - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
@@ -74,8 +80,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU with ≥8 GB VRAM.
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -112,7 +118,6 @@ guide: |
   response = client.completions.create(
       model="LiquidAI/LFM2.5-1.2B-Base",
       prompt="The three laws of thermodynamics are:",
-      max_tokens=128,
       temperature=0.3,
       extra_body={"min_p": 0.15, "repetition_penalty": 1.05},
   )
@@ -122,7 +127,7 @@ guide: |
   ## Configuration Tips
   - Use `/v1/completions` (raw continuation) — there is no chat template on a base model.
   - For fine-tuning, this checkpoint is the recommended starting point for custom LFM2.5-1.2B tasks.
-  - Set `--max-model-len` to match your workload (up to 128K).
+  - Set `--max-model-len` to match your workload (up to 32K).
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
 
   ## References

--- a/models/LiquidAI/LFM2.5-1.2B-Instruct.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Instruct.yaml
@@ -2,7 +2,7 @@ meta:
   title: "LFM2.5 1.2B Instruct"
   slug: "lfm2.5-1.2b-instruct"
   provider: "LiquidAI"
-  description: "Liquid AI's 1.2B instruction-tuned model on the LFM2 hybrid conv+attention backbone, with tool calling and a 128K context window on a single small GPU."
+  description: "Liquid AI's 1.2B instruction-tuned model on the LFM2 hybrid conv+attention backbone, with tool calling and a 32K context window on a single small GPU."
   date_updated: 2026-06-24
   difficulty: beginner
   tasks:
@@ -23,7 +23,7 @@ model:
   architecture: dense
   parameter_count: "1.2B"
   active_parameters: "1.2B"
-  context_length: 128000
+  context_length: 32768
   base_args: []
   base_env: {}
 
@@ -44,7 +44,12 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -56,19 +61,20 @@ guide: |
   instruction-tuned model from [Liquid AI](https://www.liquid.ai/), built on the **LFM2 hybrid
   backbone**: short-range gated convolution blocks interleaved with grouped-query attention.
   The hybrid design keeps the KV cache small and decode fast, so the model serves comfortably on
-  a single small GPU while supporting a 128K context window and Pythonic tool calling — all
+  a single small GPU while supporting a 32K context window and Pythonic tool calling — all
   through vLLM's OpenAI-compatible API.
 
   ### Key Features
   - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
-  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **32K context**: 32,768-token context window.
   - **Tool calling**: Pythonic tool calls (`<|tool_call_start|>…<|tool_call_end|>`) surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
-  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture.
   - **Edge-ready family**: Day-one support across llama.cpp, MLX, ONNX, vLLM, and SGLang.
 
   ### Supported Variants
 
   Dense:
+  - `LiquidAI/LFM2.5-230M` (230M)
   - `LiquidAI/LFM2.5-350M` (350M)
   - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
   - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
@@ -85,8 +91,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU with ≥8 GB VRAM (e.g. L4, A10, RTX 4090, H100). Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU with ≥8 GB VRAM (e.g. L4, A10, RTX 4090, H100).
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -101,7 +107,7 @@ guide: |
   ```bash
   vllm serve LiquidAI/LFM2.5-1.2B-Instruct
   ```
-  Cap the context to fit a smaller GPU (the model supports up to 128K):
+  Cap the context to fit a smaller GPU (the model supports up to 32K):
   ```bash
   vllm serve LiquidAI/LFM2.5-1.2B-Instruct --max-model-len 32768
   ```
@@ -168,7 +174,7 @@ guide: |
   not see the schema itself — put semantic instructions (units, formatting) in the system prompt.
 
   ## Configuration Tips
-  - Set `--max-model-len` to match your workload (up to 128K); lowering it frees VRAM for KV cache.
+  - Set `--max-model-len` to match your workload (up to 32K); lowering it frees VRAM for KV cache.
   - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
   - FP8 KV cache (`--kv-cache-dtype fp8`) roughly halves KV memory.
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.

--- a/models/LiquidAI/LFM2.5-1.2B-JP-202606.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-JP-202606.yaml
@@ -2,7 +2,7 @@ meta:
   title: "LFM2.5 1.2B JP (202606)"
   slug: "lfm2.5-1.2b-jp-202606"
   provider: "LiquidAI"
-  description: "Liquid AI's updated (2026-06) 1.2B Japanese chat model on the LFM2 hybrid conv+attention backbone — adds tool calling, with a 128K context window."
+  description: "Liquid AI's updated (2026-06) 1.2B Japanese chat model on the LFM2 hybrid conv+attention backbone — adds tool calling, with a 32K context window."
   date_updated: 2026-06-24
   difficulty: beginner
   tasks:
@@ -22,7 +22,7 @@ model:
   architecture: dense
   parameter_count: "1.2B"
   active_parameters: "1.2B"
-  context_length: 128000
+  context_length: 32768
   base_args: []
   base_env: {}
 
@@ -43,7 +43,12 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -61,12 +66,13 @@ guide: |
   - **Japanese-specialized**: Updated June 2026 checkpoint tuned for Japanese chat.
   - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
   - **Tool calling**: Pythonic tool calls (`<|tool_call_start|>…<|tool_call_end|>`) surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
-  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
-  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+  - **32K context**: 32,768-token context window.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture.
 
   ### Supported Variants
 
   Dense:
+  - `LiquidAI/LFM2.5-230M` (230M)
   - `LiquidAI/LFM2.5-350M` (350M)
   - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
   - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
@@ -83,8 +89,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU with ≥8 GB VRAM.
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -141,7 +147,7 @@ guide: |
   `lfm2` parser converts the model's Pythonic call into a standard `tool_calls` array.
 
   ## Configuration Tips
-  - Set `--max-model-len` to match your workload (up to 128K); lowering it frees VRAM for KV cache.
+  - Set `--max-model-len` to match your workload (up to 32K); lowering it frees VRAM for KV cache.
   - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
 

--- a/models/LiquidAI/LFM2.5-1.2B-JP.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-JP.yaml
@@ -2,7 +2,7 @@ meta:
   title: "LFM2.5 1.2B JP"
   slug: "lfm2.5-1.2b-jp"
   provider: "LiquidAI"
-  description: "Liquid AI's 1.2B Japanese-specialized chat model on the LFM2 hybrid conv+attention backbone, with a 128K context window on a single small GPU."
+  description: "Liquid AI's 1.2B Japanese-specialized chat model on the LFM2 hybrid conv+attention backbone, with a 32K context window on a single small GPU."
   date_updated: 2026-06-24
   difficulty: beginner
   tasks:
@@ -22,7 +22,7 @@ model:
   architecture: dense
   parameter_count: "1.2B"
   active_parameters: "1.2B"
-  context_length: 128000
+  context_length: 32768
   base_args: []
   base_env: {}
 
@@ -35,7 +35,12 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -53,12 +58,13 @@ guide: |
   ### Key Features
   - **Japanese-specialized**: Tuned for Japanese chat and instruction following.
   - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
-  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
-  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+  - **32K context**: 32,768-token context window.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture.
 
   ### Supported Variants
 
   Dense:
+  - `LiquidAI/LFM2.5-230M` (230M)
   - `LiquidAI/LFM2.5-350M` (350M)
   - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
   - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
@@ -75,8 +81,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU with ≥8 GB VRAM.
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -120,7 +126,7 @@ guide: |
   ```
 
   ## Configuration Tips
-  - Set `--max-model-len` to match your workload (up to 128K); lowering it frees VRAM for KV cache.
+  - Set `--max-model-len` to match your workload (up to 32K); lowering it frees VRAM for KV cache.
   - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
 

--- a/models/LiquidAI/LFM2.5-1.2B-Thinking.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Thinking.yaml
@@ -2,7 +2,7 @@ meta:
   title: "LFM2.5 1.2B Thinking"
   slug: "lfm2.5-1.2b-thinking"
   provider: "LiquidAI"
-  description: "Liquid AI's 1.2B reasoning model on the LFM2 hybrid conv+attention backbone — <think> chain-of-thought, tool calling, and 128K context on a single small GPU."
+  description: "Liquid AI's 1.2B reasoning model on the LFM2 hybrid conv+attention backbone — <think> chain-of-thought, tool calling, and 32K context on a single small GPU."
   date_updated: 2026-06-24
   difficulty: beginner
   tasks:
@@ -22,7 +22,7 @@ model:
   architecture: dense
   parameter_count: "1.2B"
   active_parameters: "1.2B"
-  context_length: 128000
+  context_length: 32768
   base_args: []
   base_env: {}
 
@@ -48,7 +48,12 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -66,13 +71,14 @@ guide: |
   ### Key Features
   - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
   - **`<think>` reasoning**: Emits an explicit `<think>…</think>` chain-of-thought on non-trivial problems; vLLM's `qwen3` parser splits it into a separate `reasoning_content` field.
-  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **32K context**: 32,768-token context window.
   - **Tool calling**: Pythonic tool calls surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
-  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture.
 
   ### Supported Variants
 
   Dense:
+  - `LiquidAI/LFM2.5-230M` (230M)
   - `LiquidAI/LFM2.5-350M` (350M)
   - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
   - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
@@ -89,8 +95,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU with ≥8 GB VRAM.
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -133,7 +139,7 @@ guide: |
 
   ### Reasoning Mode
   The card recommends a low temperature for the reasoning model — temperature `0.05`, `top_k 50`,
-  `repetition_penalty 1.05`. Do **not** cap `max_tokens` too low: it can truncate the
+  `repetition_penalty 1.05`. Do **not** set `max_tokens` — capping it can truncate the
   chain-of-thought mid-stream.
   ```python
   from openai import OpenAI
@@ -142,7 +148,6 @@ guide: |
       model="LiquidAI/LFM2.5-1.2B-Thinking",
       messages=[{"role": "user", "content": "A snail climbs 3 ft up a 20 ft well each day and slides 2 ft back each night. How many days to reach the top?"}],
       temperature=0.05,
-      max_tokens=2048,
       extra_body={"top_k": 50, "repetition_penalty": 1.05},
   )
   msg = response.choices[0].message
@@ -163,8 +168,8 @@ guide: |
   not see the schema itself — put semantic instructions in the system prompt.
 
   ## Configuration Tips
-  - Give reasoning room: keep `max_tokens` high enough for the `<think>` block plus the answer.
-  - Set `--max-model-len` to match your workload (up to 128K).
+  - Give reasoning room: leave `max_tokens` unset so the `<think>` block and answer aren't truncated.
+  - Set `--max-model-len` to match your workload (up to 32K).
   - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
 

--- a/models/LiquidAI/LFM2.5-350M.yaml
+++ b/models/LiquidAI/LFM2.5-350M.yaml
@@ -2,7 +2,7 @@ meta:
   title: "LFM2.5 350M"
   slug: "lfm2.5-350m"
   provider: "LiquidAI"
-  description: "Liquid AI's smallest LFM2.5 chat model (350M) on the LFM2 hybrid conv+attention backbone — tool calling and 128K context, light enough for edge GPUs."
+  description: "Liquid AI's smallest LFM2.5 chat model (350M) on the LFM2 hybrid conv+attention backbone — tool calling and 32K context, light enough for edge GPUs."
   date_updated: 2026-06-24
   difficulty: beginner
   tasks:
@@ -22,7 +22,7 @@ model:
   architecture: dense
   parameter_count: "350M"
   active_parameters: "350M"
-  context_length: 128000
+  context_length: 32768
   base_args: []
   base_env: {}
 
@@ -43,7 +43,12 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -55,19 +60,20 @@ guide: |
   [Liquid AI's](https://www.liquid.ai/) LFM2.5 family, built on the **LFM2 hybrid backbone**:
   short-range gated convolution blocks interleaved with grouped-query attention. It shares that
   backbone with its larger siblings, which keeps memory and latency low enough for edge and
-  on-device deployment while still supporting tool calling and a 128K context window — all
+  on-device deployment while still supporting tool calling and a 32K context window — all
   through vLLM's OpenAI-compatible API.
 
   ### Key Features
   - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
-  - **128K context**: Long-context support (`max_position_embeddings = 128000`).
+  - **32K context**: 32,768-token context window.
   - **Tool calling**: Pythonic tool calls (`<|tool_call_start|>…<|tool_call_end|>`) surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
-  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture — no `--trust-remote-code` required.
+  - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture.
   - **Edge-ready**: ~0.7 GB of BF16 weights — runs on commodity and on-device GPUs.
 
   ### Supported Variants
 
   Dense:
+  - `LiquidAI/LFM2.5-230M` (230M)
   - `LiquidAI/LFM2.5-350M` (350M)
   - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
   - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
@@ -84,8 +90,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU (~1 GB VRAM for weights; any modern GPU works). Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the LFM2 architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU (~1 GB VRAM for weights; any modern GPU works).
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -164,7 +170,7 @@ guide: |
 
   ## Configuration Tips
   - At 350M the model fits any GPU; raise `--max-num-seqs` to push batch throughput.
-  - Set `--max-model-len` to match your workload (up to 128K).
+  - Set `--max-model-len` to match your workload (up to 32K).
   - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
 

--- a/models/LiquidAI/LFM2.5-8B-A1B.yaml
+++ b/models/LiquidAI/LFM2.5-8B-A1B.yaml
@@ -47,10 +47,13 @@ variants:
 
 compatible_strategies:
   - single_node_tp
-  - single_node_tep
-  - single_node_dep
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -70,11 +73,12 @@ guide: |
   - **`<think>` reasoning**: Emits an explicit `<think>…</think>` chain-of-thought on non-trivial problems; vLLM's `qwen3` parser splits it into `reasoning_content`.
   - **Tool calling**: Pythonic tool calls surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
   - **128K context**: Long-context support (`max_position_embeddings = 128000`).
-  - **Native vLLM support**: Served via the `Lfm2MoeForCausalLM` architecture — no `--trust-remote-code` required.
+  - **Native vLLM support**: Served via the `Lfm2MoeForCausalLM` architecture.
 
   ### Supported Variants
 
   Dense:
+  - `LiquidAI/LFM2.5-230M` (230M)
   - `LiquidAI/LFM2.5-350M` (350M)
   - `LiquidAI/LFM2.5-1.2B-Instruct` (1.2B)
   - `LiquidAI/LFM2.5-1.2B-Thinking` (1.2B, reasoning)
@@ -94,8 +98,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU with ≥24 GB VRAM. Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the `Lfm2MoeForCausalLM` architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU with ≥24 GB VRAM.
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -121,12 +125,12 @@ guide: |
     --host 0.0.0.0 --port 8000
   ```
 
-  ### Multi-GPU (Expert Parallelism)
-  Split the experts across GPUs on a multi-GPU node:
+  ### Multi-GPU
+  This model fits on a single 24 GB+ GPU, so tensor parallelism gives no meaningful speedup on
+  basically any GPU — there's nothing to split that helps. You can still try it on a multi-GPU
+  node if you want, but expect no throughput gain:
   ```bash
-  vllm serve LiquidAI/LFM2.5-8B-A1B \
-    --tensor-parallel-size 2 \
-    --enable-expert-parallel
+  vllm serve LiquidAI/LFM2.5-8B-A1B --tensor-parallel-size 2
   ```
 
   ### Docker (NVIDIA)
@@ -143,8 +147,8 @@ guide: |
   ## Client Usage
 
   ### Reasoning Mode
-  The model card recommends temperature `0.2`, `top_k 80`, `repetition_penalty 1.05`. Give the
-  `<think>` block room — don't cap `max_tokens` too low.
+  The model card recommends temperature `0.2`, `top_k 80`, `repetition_penalty 1.05`. Leave
+  `max_tokens` unset so the `<think>` block and answer aren't truncated mid-stream.
   ```python
   from openai import OpenAI
   client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
@@ -152,7 +156,6 @@ guide: |
       model="LiquidAI/LFM2.5-8B-A1B",
       messages=[{"role": "user", "content": "A snail climbs 3 ft up a 20 ft well each day and slides 2 ft back each night. How many days to reach the top?"}],
       temperature=0.2,
-      max_tokens=2048,
       extra_body={"top_k": 80, "repetition_penalty": 1.05},
   )
   msg = response.choices[0].message
@@ -174,7 +177,7 @@ guide: |
 
   ## Configuration Tips
   - Size the GPU for the full ~8B of weights — all experts are resident even though ~1B is active.
-  - For multi-GPU nodes, `--enable-expert-parallel` distributes experts across ranks.
+  - It fits on one GPU; tensor parallelism gives no real speedup on basically any GPU (you can still try `--tensor-parallel-size N`).
   - Set `--max-model-len` to match your workload (up to 128K).
   - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.

--- a/models/LiquidAI/LFM2.5-VL-1.6B.yaml
+++ b/models/LiquidAI/LFM2.5-VL-1.6B.yaml
@@ -22,9 +22,12 @@ model:
   architecture: dense
   parameter_count: "1.6B"
   active_parameters: "1.6B"
-  context_length: 128000
+  context_length: 32768
   base_args: []
   base_env: {}
+  # TODO(vincentzed): the Lfm2VL encoder CUDA graph (vllm-project/vllm#44930, ~10-20% lower e2e
+  # latency at low batch) is NOT in 0.23.0 — add the encoder-CG compilation flag here once it
+  # ships in a stable release (>0.23.0).
 
 variants:
   default:
@@ -35,7 +38,12 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -52,8 +60,8 @@ guide: |
   ### Key Features
   - **Vision-language**: SigLIP2 vision encoder on top of the LFM2 hybrid language backbone — single- and multi-image prompts.
   - **Hybrid LM backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
-  - **128K context**: Long-context support (`text_config.max_position_embeddings = 128000`).
-  - **Native vLLM support**: Served via the `Lfm2VlForConditionalGeneration` architecture — no `--trust-remote-code` required.
+  - **32K context**: 32,768-token context window.
+  - **Native vLLM support**: Served via the `Lfm2VlForConditionalGeneration` architecture.
 
   ### Supported Variants
 
@@ -62,15 +70,15 @@ guide: |
   - `LiquidAI/LFM2.5-VL-1.6B` (1.6B)
 
   Text (same LFM2 family):
-  - Dense: `LiquidAI/LFM2.5-350M`, `LiquidAI/LFM2.5-1.2B-Instruct`, `LiquidAI/LFM2.5-1.2B-Thinking`, `LiquidAI/LFM2.5-1.2B-JP`, `LiquidAI/LFM2.5-1.2B-JP-202606`, `LiquidAI/LFM2.5-1.2B-Base`
+  - Dense: `LiquidAI/LFM2.5-230M`, `LiquidAI/LFM2.5-350M`, `LiquidAI/LFM2.5-1.2B-Instruct`, `LiquidAI/LFM2.5-1.2B-Thinking`, `LiquidAI/LFM2.5-1.2B-JP`, `LiquidAI/LFM2.5-1.2B-JP-202606`, `LiquidAI/LFM2.5-1.2B-Base`
   - MoE: `LiquidAI/LFM2.5-8B-A1B`
 
   See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU with ≥8 GB VRAM. Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the `Lfm2VlForConditionalGeneration` architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU with ≥8 GB VRAM.
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -116,7 +124,7 @@ guide: |
       messages=[{
           "role": "user",
           "content": [
-              {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg"}},
+              {"type": "image_url", "image_url": {"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"}},
               {"type": "text", "text": "What is in this image?"},
           ],
       }],
@@ -130,9 +138,13 @@ guide: |
   Launch with `--limit-mm-per-prompt '{"image": N}'`, then include several `image_url` blocks in
   one message to compare or reason across images.
 
+  ## Performance
+
+  Tensor parallelism gives no speedup — the model fits on a single GPU.
+
   ## Configuration Tips
   - `--limit-mm-per-prompt '{"image": N}'` caps images per request (default 1).
-  - Set `--max-model-len` to match your workload (up to 128K).
+  - Set `--max-model-len` to match your workload (up to 32K).
   - `--gpu-memory-utilization 0.90–0.95` maximizes KV cache capacity.
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
 

--- a/models/LiquidAI/LFM2.5-VL-450M.yaml
+++ b/models/LiquidAI/LFM2.5-VL-450M.yaml
@@ -22,7 +22,7 @@ model:
   architecture: dense
   parameter_count: "450M"
   active_parameters: "450M"
-  context_length: 128000
+  context_length: 32768
   base_args: []
   base_env: {}
 
@@ -35,7 +35,12 @@ variants:
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  # Blackwell (B200) only: route RMSNorm to the bundled oink kernels (measured ~+2.6% on B200,
+  # output identical). Inert (falls back to native) on non-Blackwell GPUs.
+  blackwell:
+    extra_env:
+      VLLM_USE_OINK_OPS: "1"
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -53,8 +58,8 @@ guide: |
   - **Vision-language**: SigLIP2 vision encoder on top of the LFM2 hybrid language backbone — single- and multi-image prompts.
   - **Edge-ready**: ~1 GB of BF16 weights — runs on commodity and on-device GPUs.
   - **Hybrid LM backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
-  - **128K context**: Long-context support (`text_config.max_position_embeddings = 128000`).
-  - **Native vLLM support**: Served via the `Lfm2VlForConditionalGeneration` architecture — no `--trust-remote-code` required.
+  - **32K context**: 32,768-token context window.
+  - **Native vLLM support**: Served via the `Lfm2VlForConditionalGeneration` architecture.
 
   ### Supported Variants
 
@@ -63,15 +68,15 @@ guide: |
   - `LiquidAI/LFM2.5-VL-1.6B` (1.6B)
 
   Text (same LFM2 family):
-  - Dense: `LiquidAI/LFM2.5-350M`, `LiquidAI/LFM2.5-1.2B-Instruct`, `LiquidAI/LFM2.5-1.2B-Thinking`, `LiquidAI/LFM2.5-1.2B-JP`, `LiquidAI/LFM2.5-1.2B-JP-202606`, `LiquidAI/LFM2.5-1.2B-Base`
+  - Dense: `LiquidAI/LFM2.5-230M`, `LiquidAI/LFM2.5-350M`, `LiquidAI/LFM2.5-1.2B-Instruct`, `LiquidAI/LFM2.5-1.2B-Thinking`, `LiquidAI/LFM2.5-1.2B-JP`, `LiquidAI/LFM2.5-1.2B-JP-202606`, `LiquidAI/LFM2.5-1.2B-Base`
   - MoE: `LiquidAI/LFM2.5-8B-A1B`
 
   See the [LFM2.5 usage guide](../../LiquidAI/LFM2.5) for the full family.
 
   ## Prerequisites
 
-  - **Hardware**: 1× GPU (~1–2 GB VRAM for weights; any modern GPU works). Verified on H100.
-  - **vLLM**: ≥ 0.23.0 — the `Lfm2VlForConditionalGeneration` architecture ships in the 0.23.0 stable release.
+  - **Hardware**: 1× GPU (~1–2 GB VRAM for weights; any modern GPU works).
+  - **vLLM**: ≥ 0.23.0.
 
   ### pip (NVIDIA CUDA)
   ```bash
@@ -117,7 +122,7 @@ guide: |
       messages=[{
           "role": "user",
           "content": [
-              {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg"}},
+              {"type": "image_url", "image_url": {"url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"}},
               {"type": "text", "text": "What is in this image?"},
           ],
       }],
@@ -134,7 +139,7 @@ guide: |
   ## Configuration Tips
   - At 450M the model fits any GPU; ideal for edge / on-device image understanding.
   - `--limit-mm-per-prompt '{"image": N}'` caps images per request (default 1).
-  - Set `--max-model-len` to match your workload (up to 128K).
+  - Set `--max-model-len` to match your workload (up to 32K).
   - Sampling presets are per-request client defaults — don't bake them into `vllm serve`.
 
   ## References


### PR DESCRIPTION
Follow-up to #575 (LFM2.5 recipes) — a context-length correction, a measured perf flag, and copy cleanup.

### Fix `context_length` to 32K (per the model cards)

#575 set `context_length: 128000` on every recipe (config.json's `max_position_embeddings`, which
is inherited RoPE config), but the model cards document **32,768** for the whole family **except
8B-A1B (128K)**. This corrects the field and the "128K" copy on the 8 affected recipes and the
guide's tables. (8B-A1B stays 128K; `LiquidAI/LFM2.5-230M` was added separately in #576 with the
correct 32K and is left untouched here.)

### Performance: oink on Blackwell

`VLLM_USE_OINK_OPS=1` routes RMSNorm to the `oink` kernels bundled in the `vllm-openai` image on
Blackwell. **~+2.6%** output throughput on **B200** (1.2B-Instruct, vLLM 0.23.0), output identical.
Applied automatically via `hardware_overrides.blackwell` (native fallback elsewhere).

### Speed-of-Light Tuning section + copy cleanup

- Adds a `LiquidAI/LFM2.5.md` section: `-O3` (~+2%, opt-in, trades startup), `VLLM_USE_FASTOKENS=1` (TTFT win on tokenization-bound loads); other knobs make little difference (measured with `vllm bench serve`).
- Drops self-referential boilerplate: "no `--trust-remote-code` required", "Verified on H100", "validated end-to-end".

`node scripts/build-recipes-api.mjs` passes; MkDocs `--strict` passes.
