### PR TITLE
Add MiniMax-M3 MXFP4 (AMD) variant

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "minimax-m3"
   provider: "MiniMax"
   description: "MiniMax M3 vision-language MoE (427B total / 26B active) for frontier coding, agent toolchains, and 1M-token reasoning via MSA sparse attention — native multimodal (image + video + computer use); BF16 checkpoint with an MXFP8 variant from NVIDIA. Runs on NVIDIA (Hopper/Blackwell) and on AMD CDNA4 (MI350X/MI355X) and CDNA3 (MI300X/MI325X)."
-  date_updated: 2026-06-12
+  date_updated: 2026-06-25
   difficulty: advanced
   tasks:
     - text
@@ -109,6 +109,23 @@ variants:
     # comfortably, ~4 GPUs for weights alone on Blackwell (B200/B300) or AMD MI350X/MI355X (gfx950)).
     vram_minimum_gb: 513
     description: "NVIDIA-quantized MXFP8 weights — Blackwell (B200/B300) for native MX tensor cores, and AMD CDNA4 (MI350X/MI355X, gfx950) for native MXFP8 Matrix Cores."
+  mxfp4:
+    model_id: "amd/MiniMax-M3-MXFP4"
+    precision: mxfp4
+    # 427B × 0.5 byte (MXFP4) + F32 norms, × 1.2 ≈ 257 GB → fits a single
+    # 8x MI355X (288 GB/GPU) node from TP=4.
+    vram_minimum_gb: 257
+    # AMD-quantized MXFP4 checkpoint. Served through the AITER MoE backend on
+    # CDNA4. This checkpoint ships no calibrated KV scales, so prefer the
+    # default KV cache dtype — fp8 KV still runs but falls back to an
+    # uncalibrated scale of 1.0 (accuracy risk; see the guide).
+    extra_args:
+      - "--moe-backend"
+      - "aiter"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MOE: "1"
+    description: "AMD-quantized MXFP4 weights for CDNA4 (MI350X/MI355X, gfx950) via the AITER MoE backend — half the VRAM of MXFP8, fits a single node from TP=4. AMD-only."
 
 compatible_strategies:
   - single_node_tp
@@ -424,6 +441,44 @@ guide: |
   For best MXFP8 throughput, prefer Blackwell (B200/B300) for native MX tensor cores,
   or AMD CDNA4 (MI350X/MI355X, gfx950) for native MXFP8 matrix cores.
 
+  ## Quantized Variant (MXFP4, AMD)
+
+  [`amd/MiniMax-M3-MXFP4`](https://huggingface.co/amd/MiniMax-M3-MXFP4) is an
+  AMD-quantized MXFP4 checkpoint for CDNA4 (MI350X/MI355X, gfx950) — roughly
+  half the VRAM of MXFP8, so M3 fits a single 8x MI355X node from **TP=4**. It
+  runs through the **AITER MoE backend** and the same Triton MSA attention path
+  as the other AMD variants. Select the **mxfp4** variant above, or run it
+  directly:
+
+  ```bash
+  export VLLM_USE_BREAKABLE_CUDAGRAPH=0
+  VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1 \
+    vllm serve amd/MiniMax-M3-MXFP4 \
+    --tensor-parallel-size 4 \
+    --block-size 128 \
+    --moe-backend aiter \
+    --attention-backend TRITON_ATTN \
+    --language-model-only \
+    --no-enable-prefix-caching \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    --enable-auto-tool-choice
+  ```
+
+  > **KV cache dtype on the MXFP4 variant.** Unlike the BF16 and MXFP8
+  > checkpoints, `amd/MiniMax-M3-MXFP4` ships no calibrated KV scales. Adding
+  > `--kv-cache-dtype fp8` still starts and serves, but vLLM falls back to an
+  > uncalibrated KV scale of 1.0 and logs `Using uncalibrated q_scale 1.0 ...
+  > This may cause accuracy issues`. Leave the KV cache at its default dtype
+  > unless you have validated accuracy for your workload.
+
+  This variant is AMD-only; it is not applicable to NVIDIA hardware (use the
+  **mxfp8** variant on Blackwell for native MX matrix cores).
+
+  Validated on 8x MI355X (gfx950), TP=4, with the `rocm/vllm-dev` ROCm image
+  (vLLM 0.23.1): the model serves and the `minimax_m3` reasoning/tool parsers
+  split `reasoning` from `content` correctly.
+
   ## Troubleshooting
 
   - **`--block-size` mismatch.** MSA's sparse block size is 128; the vLLM KV
@@ -447,6 +502,7 @@ guide: |
 
   - [Model card](https://huggingface.co/MiniMaxAI/MiniMax-M3)
   - [MXFP8 variant](https://huggingface.co/MiniMaxAI/MiniMax-M3-MXFP8)
+  - [MXFP4 variant (AMD)](https://huggingface.co/amd/MiniMax-M3-MXFP4)
   - [MiniMax](https://www.minimax.io/)
   - [MiniMax Agent](https://agent.minimax.io/)
   - [MiniMax Platform](https://platform.minimax.io/)

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -112,9 +112,19 @@ variants:
   mxfp4:
     model_id: "amd/MiniMax-M3-MXFP4"
     precision: mxfp4
+    # AMD MXFP4 is a CDNA4-only checkpoint: the AITER MXFP4 MoE kernels are
+    # gfx950 (MI350X/MI355X). It does NOT run on CDNA3 (gfx942, MI300X/MI325X)
+    # or NVIDIA — gate the hardware pills to gfx950 so the page can't claim
+    # otherwise. (Distinct from gpt-oss MXFP4, which also runs on NVIDIA.)
+    requires_arch: gfx950
     # 427B × 0.5 byte (MXFP4) + F32 norms, × 1.2 ≈ 257 GB → fits a single
     # 8x MI355X (288 GB/GPU) node from TP=4.
     vram_minimum_gb: 257
+    # AITER MXFP4 MoE on gfx950 needs aiter >= 0.1.16.post2 (vllm#46692) plus
+    # the MoE enablement (vllm#46419), not yet in a published rocm image — so
+    # pin the ROCm dev image that carries the path instead of the generic one.
+    docker_image:
+      amd: "rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625"
     # AMD-quantized MXFP4 checkpoint. Served through the AITER MoE backend on
     # CDNA4. This checkpoint ships no calibrated KV scales, so prefer the
     # default KV cache dtype — fp8 KV still runs but falls back to an
@@ -122,10 +132,11 @@ variants:
     extra_args:
       - "--moe-backend"
       - "aiter"
+    # VLLM_ROCM_USE_AITER=1 is the umbrella switch; the MoE sub-flag defaults on
+    # under it, so it's not set explicitly here (per @hongxiayang).
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
-      VLLM_ROCM_USE_AITER_MOE: "1"
-    description: "AMD-quantized MXFP4 weights for CDNA4 (MI350X/MI355X, gfx950) via the AITER MoE backend — half the VRAM of MXFP8, fits a single node from TP=4. AMD-only."
+    description: "AMD-quantized MXFP4 weights for CDNA4 (MI355X, gfx950) via the AITER MoE backend — half the VRAM of MXFP8, fits a single node from TP=4. AMD CDNA4-only."
 
 compatible_strategies:
   - single_node_tp
@@ -452,19 +463,24 @@ guide: |
 
   ### MoE backend: `aiter` (performance) vs `emulation` (works today)
 
-  > **Image requirement for the AITER path.** MXFP4 MoE on the high-performance
-  > **AITER** backend needs aiter `>= 0.1.16.post2`
+  > **Image requirement for the AITER path — a plain upstream nightly will
+  > crash.** MXFP4 MoE on the high-performance **AITER** backend needs aiter
+  > `>= 0.1.16.post2`
   > ([vllm#46692](https://github.com/vllm-project/vllm/pull/46692)) **and** the
-  > MoE enablement [vllm#46419](https://github.com/vllm-project/vllm/pull/46419).
-  > Until #46419 ships in a published `vllm/vllm-openai-rocm` image, a plain
-  > nightly will **not** bring up MXFP4 on `--moe-backend aiter` — build from
-  > source (or use the `emulation` backend below, which runs on current images).
+  > MoE enablement [vllm#46419](https://github.com/vllm-project/vllm/pull/46419),
+  > which has **not** landed in a published `vllm/vllm-openai-rocm` nightly. On a
+  > plain nightly, `--moe-backend aiter` fails to bring up MXFP4 (AITER MXFP4 MoE
+  > kernel missing). Use the ROCm dev image that carries the path —
+  > `rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625` — or build from source.
+  > (The `emulation` backend below runs on current images.)
 
-  **AITER MoE (recommended for serving once available):**
+  **AITER MoE (recommended for serving — CDNA4 / MI355X gfx950 only):**
 
   ```bash
+  docker pull rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625
+
   export VLLM_USE_BREAKABLE_CUDAGRAPH=0
-  VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1 \
+  VLLM_ROCM_USE_AITER=1 \
     vllm serve amd/MiniMax-M3-MXFP4 \
     --tensor-parallel-size 4 \
     --block-size 128 \
@@ -506,10 +522,14 @@ guide: |
   > This may cause accuracy issues`. Leave the KV cache at its default dtype
   > unless you have validated accuracy for your workload.
 
-  Serving validated on 8x MI355X (gfx950), TP=4, `--moe-backend aiter`, with a
-  ROCm `vllm-dev` image carrying the AITER MXFP4 MoE path (vLLM 0.23.1): the
-  model serves and the `minimax_m3` reasoning/tool parsers split `reasoning`
-  from `content` correctly.
+  Serving validated on 8x MI355X (gfx950), TP=4, `--moe-backend aiter`, using
+  the ROCm dev image `rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625`. That
+  image ships vLLM 0.23.1 plus the pre-release AITER MXFP4 MoE path
+  ([vllm#46419](https://github.com/vllm-project/vllm/pull/46419)); the
+  `min_vllm_version: 0.24.0` declared above is the first upstream release
+  expected to carry that path natively. On the dev image the model serves and
+  the `minimax_m3` reasoning/tool parsers split `reasoning` from `content`
+  correctly.
 
   ## Troubleshooting
 

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -444,11 +444,23 @@ guide: |
   ## Quantized Variant (MXFP4, AMD)
 
   [`amd/MiniMax-M3-MXFP4`](https://huggingface.co/amd/MiniMax-M3-MXFP4) is an
-  AMD-quantized MXFP4 checkpoint for CDNA4 (MI350X/MI355X, gfx950) — roughly
-  half the VRAM of MXFP8, so M3 fits a single 8x MI355X node from **TP=4**. It
-  runs through the **AITER MoE backend** and the same Triton MSA attention path
-  as the other AMD variants. Select the **mxfp4** variant above, or run it
-  directly:
+  AMD-quantized MXFP4 checkpoint (weights + activations OCP MXFP4, via
+  AMD-Quark) for CDNA4 (MI350X/MI355X, gfx950) — roughly half the VRAM of MXFP8,
+  so M3 fits a single 8x MI355X node from **TP=4**. It uses the same Triton MSA
+  attention path as the other AMD variants. This variant is AMD-only (use the
+  **mxfp8** variant on Blackwell for native MX matrix cores).
+
+  ### MoE backend: `aiter` (performance) vs `emulation` (works today)
+
+  > **Image requirement for the AITER path.** MXFP4 MoE on the high-performance
+  > **AITER** backend needs aiter `>= 0.1.16.post2`
+  > ([vllm#46692](https://github.com/vllm-project/vllm/pull/46692)) **and** the
+  > MoE enablement [vllm#46419](https://github.com/vllm-project/vllm/pull/46419).
+  > Until #46419 ships in a published `vllm/vllm-openai-rocm` image, a plain
+  > nightly will **not** bring up MXFP4 on `--moe-backend aiter` — build from
+  > source (or use the `emulation` backend below, which runs on current images).
+
+  **AITER MoE (recommended for serving once available):**
 
   ```bash
   export VLLM_USE_BREAKABLE_CUDAGRAPH=0
@@ -465,6 +477,28 @@ guide: |
     --enable-auto-tool-choice
   ```
 
+  **Emulation MoE (numerically faithful, slower — runs on current images).**
+  This is the path AMD used to measure accuracy (TP=8); swap
+  `--moe-backend emulation` for `aiter` and drop the AITER env:
+
+  ```bash
+  vllm serve amd/MiniMax-M3-MXFP4 \
+    --tensor-parallel-size 8 \
+    --block-size 128 \
+    --moe-backend emulation \
+    --attention-backend TRITON_ATTN \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    --enable-auto-tool-choice
+  ```
+
+  ### Accuracy
+
+  AMD reports **gsm8k (5-shot, flexible-extract) 94.19** for `amd/MiniMax-M3-MXFP4`
+  vs **95.30** for the BF16 `MiniMaxAI/MiniMax-M3` — **98.84% recovery**
+  (lm-eval, `--moe-backend emulation`, per the
+  [model card](https://huggingface.co/amd/MiniMax-M3-MXFP4#reproduction)).
+
   > **KV cache dtype on the MXFP4 variant.** Unlike the BF16 and MXFP8
   > checkpoints, `amd/MiniMax-M3-MXFP4` ships no calibrated KV scales. Adding
   > `--kv-cache-dtype fp8` still starts and serves, but vLLM falls back to an
@@ -472,12 +506,10 @@ guide: |
   > This may cause accuracy issues`. Leave the KV cache at its default dtype
   > unless you have validated accuracy for your workload.
 
-  This variant is AMD-only; it is not applicable to NVIDIA hardware (use the
-  **mxfp8** variant on Blackwell for native MX matrix cores).
-
-  Validated on 8x MI355X (gfx950), TP=4, with the `rocm/vllm-dev` ROCm image
-  (vLLM 0.23.1): the model serves and the `minimax_m3` reasoning/tool parsers
-  split `reasoning` from `content` correctly.
+  Serving validated on 8x MI355X (gfx950), TP=4, `--moe-backend aiter`, with a
+  ROCm `vllm-dev` image carrying the AITER MXFP4 MoE path (vLLM 0.23.1): the
+  model serves and the `minimax_m3` reasoning/tool parsers split `reasoning`
+  from `content` correctly.
 
   ## Troubleshooting
 

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -145,12 +145,28 @@ function matchesConstraint(profile, constraint) {
 }
 
 /**
+ * Variant-level GPU-arch gate. Some quantized checkpoints only run on one
+ * micro-architecture even though the precision string is shared — e.g.
+ * `amd/MiniMax-M3-MXFP4` needs CDNA4 (gfx950) AITER MoE kernels and does NOT
+ * run on CDNA3 (gfx942) or NVIDIA, whereas the gpt-oss MXFP4 checkpoints run on
+ * NVIDIA too. A variant opts in via `requires_arch`; profiles without a matching
+ * `arch` (e.g. all NVIDIA profiles) are excluded.
+ */
+function matchesVariantArch(profile, variant) {
+  if (!variant?.requires_arch) return true;
+  const arch = profile.arch;
+  const archs = Array.isArray(arch) ? arch : [arch];
+  return archs.includes(variant.requires_arch);
+}
+
+/**
  * Check whether a hardware profile is compatible with a variant based on
- * precision constraints (e.g., NVFP4 requires Blackwell). Does NOT check VRAM.
+ * precision constraints (e.g., NVFP4 requires Blackwell) and any variant-level
+ * arch gate (e.g. MXFP4 on CDNA4 only). Does NOT check VRAM.
  */
 export function isPrecisionCompatible(profile, variant) {
   const constraint = PRECISION_HARDWARE_CONSTRAINTS[variant?.precision];
-  return matchesConstraint(profile, constraint);
+  return matchesConstraint(profile, constraint) && matchesVariantArch(profile, variant);
 }
 
 /**
@@ -251,7 +267,10 @@ export function pdFitsSingleNode(hwProfile, variant) {
 export function pickDefaultHardware(hwProfiles, variant, recipe) {
   const constraint = PRECISION_HARDWARE_CONSTRAINTS[variant?.precision];
   const compatible = Object.entries(hwProfiles).filter(
-    ([id, p]) => matchesConstraint(p, constraint) && isHardwareSupported(recipe, id)
+    ([id, p]) =>
+      matchesConstraint(p, constraint) &&
+      matchesVariantArch(p, variant) &&
+      isHardwareSupported(recipe, id)
   );
 
   if (constraint?.generation === "blackwell") {

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -95,6 +95,7 @@ hardware_profiles:
   mi300x:
     brand: AMD
     generation: amd
+    arch: gfx942
     display_name: "MI300X"
     description: "AMD Instinct MI300X 192 GB HBM3 · 8-GPU OAM node (CDNA 3)"
     gpu_count: 8
@@ -104,6 +105,7 @@ hardware_profiles:
   mi325x:
     brand: AMD
     generation: amd
+    arch: gfx942
     display_name: "MI325X"
     description: "AMD Instinct MI325X 256 GB HBM3e · 8-GPU OAM node (CDNA 3)"
     gpu_count: 8
@@ -113,6 +115,7 @@ hardware_profiles:
   mi355x:
     brand: AMD
     generation: amd
+    arch: gfx950
     display_name: "MI355X"
     description: "AMD Instinct MI355X 288 GB HBM3e · 8-GPU OAM node (CDNA 4)"
     gpu_count: 8


### PR DESCRIPTION
## Summary

Adds an **`mxfp4` variant** to the MiniMax-M3 recipe for `amd/MiniMax-M3-MXFP4`, targeting AMD CDNA4 (MI350X/MI355X, gfx950) served through the **AITER MoE backend**. At ~0.5 bytes/param it is roughly half the VRAM of the existing MXFP8 variant and fits a single 8×MI355X node from **TP=4**.

The variant reuses the recipe's existing AMD path (block-size 128, TRITON_ATTN MSA attention, `minimax_m3` parsers, CUDA-graph env) and adds only `--moe-backend aiter` + the AITER MoE env vars. No NVIDIA changes; the variant is AMD-only (`mxfp4` is ungated, so it does not force Blackwell and does not disable the AMD hardware pill).

## Validation

Validated **single-node on 8×MI355X (gfx950), TP=4**, vLLM `0.23.1` (`rocm/vllm-dev` ROCm image):

- `vllm serve amd/MiniMax-M3-MXFP4 --tensor-parallel-size 4 --block-size 128 --moe-backend aiter --attention-backend TRITON_ATTN --language-model-only --no-enable-prefix-caching --tool-call-parser minimax_m3 --reasoning-parser minimax_m3 --enable-auto-tool-choice` reaches `Application startup complete`.
- Engine reports `quantization=quark`, `moe_backend='aiter'`, `kv_cache_dtype=auto`.
- Chat completions return coherent output and the `minimax_m3` reasoning parser splits `reasoning` from `content` correctly.

### KV cache note (corrected after testing)

`amd/MiniMax-M3-MXFP4` ships **no calibrated KV scales**. I verified that `--kv-cache-dtype fp8` **does still start and serve** on vLLM — it falls back to an uncalibrated KV scale of 1.0 and logs `Using uncalibrated q_scale 1.0 ... This may cause accuracy issues` (it does **not** hard-fail). The variant therefore keeps the KV cache at its default dtype, and the guide documents the fp8 behavior so users can opt in only after validating accuracy.

The MXFP4 sharding/KV constraints were cross-referenced against the [ROCm/ATOM MiniMax-M3 recipe](https://github.com/ROCm/ATOM/blob/main/recipes/MiniMax-M3.md).

## Test plan

- [x] `node scripts/build-recipes-api.mjs` passes (`✓ JSON API: 142 models, 8 strategies`)
- [x] Single-node TP=4 serve + chat completion on MI355X (gfx950)
- [x] Confirmed fp8-KV fallback behavior (uncalibrated scale, not a crash)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/recipes/pr/579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785006091&installation_id=142609222&pr_number=579&repository=vllm-project%2Frecipes&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Frecipes%2Fpull%2F579&signature=780e6b396e273fe5e3e8ef1960f50349767e96e0a9da3ec9fc1bc89be661a3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->