### PR TITLE
[ROCm][AMD] MiniMax-M3 MXFP8 MI355x recipe update

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -112,6 +112,10 @@ variants:
     hardware_overrides:
       mi355x:
         docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          # run linear-layer GEMMs through the bf16 hipblasLT on MI355X.
+          - "--linear-backend"
+          - "emulation"
         extra_env:
           VLLM_ROCM_USE_AITER: "1"
           VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -109,6 +109,18 @@ variants:
     # comfortably, ~4 GPUs for weights alone on Blackwell (B200/B300) or AMD MI350X/MI355X (gfx950)).
     vram_minimum_gb: 513
     description: "NVIDIA-quantized MXFP8 weights — Blackwell (B200/B300) for native MX tensor cores, and AMD CDNA4 (MI350X/MI355X, gfx950) for native MXFP8 Matrix Cores."
+    # MI355X-only acceleration for the MXFP8 path: AITER kernels, the fused
+    # shared-experts MoE, and INT6 QuickReduce, on the nightly ROCm image (the
+    # minimax-m3 pinned tag predates these). Other MI3xx GPUs and the NVIDIA
+    # MXFP8 command are untouched. (VLLM_USE_BREAKABLE_CUDAGRAPH=0 is already
+    # set AMD-wide below.)
+    hardware_overrides:
+      mi355x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
+          VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT6"
   mxfp4:
     model_id: "amd/MiniMax-M3-MXFP4"
     precision: mxfp4
@@ -444,6 +456,26 @@ guide: |
 
   For best MXFP8 throughput, prefer Blackwell (B200/B300) for native MX tensor cores,
   or AMD CDNA4 (MI350X/MI355X, gfx950) for native MXFP8 matrix cores.
+
+  On AMD MI355X the **mxfp8** variant additionally enables the AITER kernels,
+  the fused shared-experts MoE, and INT6 QuickReduce, and pulls the nightly ROCm
+  image (`vllm/vllm-openai-rocm:nightly`) — selected automatically in the command
+  builder; other MI3xx GPUs keep the pinned image. If you launch by hand:
+
+  ```bash
+  export VLLM_USE_BREAKABLE_CUDAGRAPH=0
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT6
+
+  vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
+    --tensor-parallel-size 8 \
+    --block-size 128 \
+    --attention-backend TRITON_ATTN \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    --enable-auto-tool-choice
+  ```
 
   ## Quantized Variant (MXFP4 on MI355X)
 

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -109,11 +109,6 @@ variants:
     # comfortably, ~4 GPUs for weights alone on Blackwell (B200/B300) or AMD MI350X/MI355X (gfx950)).
     vram_minimum_gb: 513
     description: "NVIDIA-quantized MXFP8 weights — Blackwell (B200/B300) for native MX tensor cores, and AMD CDNA4 (MI350X/MI355X, gfx950) for native MXFP8 Matrix Cores."
-    # MI355X-only acceleration for the MXFP8 path: AITER kernels, the fused
-    # shared-experts MoE, and INT6 QuickReduce, on the nightly ROCm image (the
-    # minimax-m3 pinned tag predates these). Other MI3xx GPUs and the NVIDIA
-    # MXFP8 command are untouched. (VLLM_USE_BREAKABLE_CUDAGRAPH=0 is already
-    # set AMD-wide below.)
     hardware_overrides:
       mi355x:
         docker_image: "vllm/vllm-openai-rocm:nightly"


### PR DESCRIPTION
Update recipe for MiniMax-M3 MXFP8 on MI355x only

- Added several environment variables

  - VLLM_ROCM_USE_AITER=1 — aiter master: grouped-topk shared-expert fusion (this image's fusion needs it) + fused RMSNorm/quant. Set 0 for --moe-backend triton (native mxfp8) — it conflicts there.
  - VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 — explicit shared-expert fusion enable.
  - VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT6 — INT6 quantized all-reduce (+6–14% at batch). gsm8k 0.9143 (= baseline); NONE to disable.


VLLM_USE_BREAKABLE_CUDAGRAPH=0 — still needed.
 
- Depending on the following vLLM PRs to be merged. 

1. https://github.com/vllm-project/vllm/pull/46545 fused experts for mxfp8 model
2. https://github.com/vllm-project/vllm/pull/46184  aiter flydsl moe backend enablement 

- updated to use nightly image after the above PRs are merged .. 

Only Merge this PR after that.



<img width="1482" height="1070" alt="image" src="https://github.com/user-attachments/assets/8d2b52de-56f6-4852-850e-02ce682238a0" />
