### PR TITLE
Add GLM-5.2 MXFP4 recipe support

### DIFF
--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -65,10 +65,17 @@ variants:
     model_id: "amd/GLM-5.2-MXFP4"
     precision: mxfp4
     vram_minimum_gb: 446
-    description: "AMD Quark MXFP4 checkpoint — MoE weights quantized for MI350 / MI355X"
+    supported_hardware:
+      - mi355x
+    description: "AMD Quark MXFP4 checkpoint — MoE weights quantized for MI355X (gfx950)"
     extra_args:
       - "--quantization"
       - "quark"
+    tp: 8
+    hardware_overrides:
+      mi355x:
+        extra_args:
+          - "--trust-remote-code"
   bf16:
     precision: bf16
     vram_minimum_gb: 1786
@@ -114,7 +121,7 @@ guide: |
 
   This recipe targets the **FP8** checkpoint, the practical default: it fits on a single
   8xH200 / 8xH20 node and — with FP8 KV cache — reaches the full 1M-token context on 8xB200.
-  On AMD MI350 / MI355X, use the **MXFP4** variant when HBM footprint is the priority.
+  On AMD MI355X hardware, use the **MXFP4** variant when HBM footprint is the priority.
 
   ## Prerequisites
 
@@ -122,7 +129,7 @@ guide: |
     `main` branch.
   - **GPU:** 8xH200 or 8xH20 (141 GB each) for single-node FP8; 8xB200 (180 GB each) for the
     full 1M context.
-  - **MXFP4:** use the AMD Quark checkpoint on MI350 / MI355X with ROCm and AITER enabled.
+  - **MXFP4:** use the AMD Quark checkpoint on MI355X with ROCm and AITER enabled.
 
   ## Installation
 
@@ -207,10 +214,11 @@ guide: |
     MoE path. `VLLM_ROCM_USE_AITER_LINEAR` and `VLLM_ROCM_USE_AITER_MOE` default to enabled
     when `VLLM_ROCM_USE_AITER=1`.
 
-  ### MXFP4 on AMD MI350 / MI355X
+  ### MXFP4 on AMD MI355X
 
   The AMD Quark MXFP4 checkpoint quantizes the MoE weights while leaving non-MoE modules in
-  higher precision. Use Quark quantization and ROCm AITER kernels:
+  higher precision. The recipe UI only enables this variant for supported AMD MI355X
+  hardware. Use Quark quantization and ROCm AITER kernels:
 
   ```bash
   export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -61,6 +61,14 @@ variants:
     precision: fp8
     vram_minimum_gb: 893
     description: "Native FP8 checkpoint — 8xH200/H20 (141GB × 8) single-node serving"
+  mxfp4:
+    model_id: "amd/GLM-5.2-MXFP4"
+    precision: mxfp4
+    vram_minimum_gb: 446
+    description: "AMD Quark MXFP4 checkpoint — MoE weights quantized for MI350 / MI355X"
+    extra_args:
+      - "--quantization"
+      - "quark"
   bf16:
     precision: bf16
     vram_minimum_gb: 1786
@@ -101,10 +109,12 @@ guide: |
   Z-AI. The
   headline change over GLM-5 / 5.1 is that **Multi-Token Prediction (MTP) is extended from 3 to
   5 draft tokens**, lifting end-to-end throughput on reasoning, coding, and agentic workloads.
-  It ships as BF16 and native-FP8 checkpoints and keeps the GLM thinking-mode behavior.
+  It ships as BF16, native-FP8, and AMD Quark MXFP4 checkpoints, and keeps the GLM
+  thinking-mode behavior.
 
   This recipe targets the **FP8** checkpoint, the practical default: it fits on a single
   8xH200 / 8xH20 node and — with FP8 KV cache — reaches the full 1M-token context on 8xB200.
+  On AMD MI350 / MI355X, use the **MXFP4** variant when HBM footprint is the priority.
 
   ## Prerequisites
 
@@ -112,6 +122,7 @@ guide: |
     `main` branch.
   - **GPU:** 8xH200 or 8xH20 (141 GB each) for single-node FP8; 8xB200 (180 GB each) for the
     full 1M context.
+  - **MXFP4:** use the AMD Quark checkpoint on MI350 / MI355X with ROCm and AITER enabled.
 
   ## Installation
 
@@ -195,6 +206,40 @@ guide: |
   - **`VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`** — enables the shared-expert fused
     MoE path. `VLLM_ROCM_USE_AITER_LINEAR` and `VLLM_ROCM_USE_AITER_MOE` default to enabled
     when `VLLM_ROCM_USE_AITER=1`.
+
+  ### MXFP4 on AMD MI350 / MI355X
+
+  The AMD Quark MXFP4 checkpoint quantizes the MoE weights while leaving non-MoE modules in
+  higher precision. Use Quark quantization and ROCm AITER kernels:
+
+  ```bash
+  export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+  export VLLM_ROCM_USE_AITER_FP8BMM=0
+  export VLLM_ROCM_USE_AITER_FP4BMM=0
+
+  vllm serve amd/GLM-5.2-MXFP4 \
+    --quantization quark \
+    --trust-remote-code \
+    --kv-cache-dtype fp8_e4m3 \
+    --tensor-parallel-size 8 \
+    --gpu-memory-utilization 0.90 \
+    --max-model-len 32768 \
+    --tool-call-parser glm47 \
+    --enable-auto-tool-choice \
+    --reasoning-parser glm45 \
+    --no-enable-prefix-caching \
+    --served-model-name glm-5.2-mxfp4
+  ```
+
+  Add the `spec_decoding` feature, or pass GLM-5.2's MTP flags directly, only after verifying
+  your vLLM build honors Quark `exclude` entries for the unquantized MTP layer:
+
+  ```bash
+  --speculative-config.method mtp \
+  --speculative-config.num_speculative_tokens 5
+  ```
 
   ### FP8 on 8xB200 (full 1M context)
 
@@ -323,3 +368,4 @@ guide: |
 
   - [Model card](https://huggingface.co/zai-org/GLM-5.2)
   - [FP8 checkpoint](https://huggingface.co/zai-org/GLM-5.2-FP8)
+  - [MXFP4 checkpoint](https://huggingface.co/amd/GLM-5.2-MXFP4)

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -242,7 +242,9 @@ guide: |
   ```
 
   Add the `spec_decoding` feature, or pass GLM-5.2's MTP flags directly, only after verifying
-  your vLLM build honors Quark `exclude` entries for the unquantized MTP layer:
+  your vLLM build honors Quark `exclude` entries for the unquantized MTP layer. See
+  [vLLM PR #46757](https://github.com/vllm-project/vllm/pull/46757) for the related Quark
+  MXFP4 MTP loading fix:
 
   ```bash
   --speculative-config.method mtp \

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -244,13 +244,6 @@ guide: |
   For TP=4 validation runs, use `HIP_VISIBLE_DEVICES=0,1,2,3` and
   `--tensor-parallel-size 4`.
 
-  For GLM-5.2 MXFP4 MTP/speculative decoding, the MTP layer needs a vLLM build with
-  [PR #46757](https://github.com/vllm-project/vllm/pull/46757), or the checkpoint
-  `config.json` should exclude the full MTP experts module with a regex entry such as
-  `"re:model.layers.78.mlp.experts.*"`. Older builds may fail during MTP weight loading
-  because the draft MoE layer is unquantized while the main MoE layers are MXFP4.
-
-
   ### FP8 on 8xB200 (full 1M context)
 
   GLM-5.2 has a native 1M-token window. Whether the full window fits is a KV-cache VRAM

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -244,6 +244,12 @@ guide: |
   For TP=4 validation runs, use `HIP_VISIBLE_DEVICES=0,1,2,3` and
   `--tensor-parallel-size 4`.
 
+  For GLM-5.2 MXFP4 MTP/speculative decoding, the MTP layer needs a vLLM build with
+  [PR #46757](https://github.com/vllm-project/vllm/pull/46757), or the checkpoint
+  `config.json` should exclude the full MTP experts module with a regex entry such as
+  `"re:model.layers.78.mlp.experts.*"`. Older builds may fail during MTP weight loading
+  because the draft MoE layer is unquantized while the main MoE layers are MXFP4.
+
 
   ### FP8 on 8xB200 (full 1M context)
 

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -68,9 +68,6 @@ variants:
     supported_hardware:
       - mi355x
     description: "AMD Quark MXFP4 checkpoint — MoE weights quantized for MI355X (gfx950)"
-    extra_args:
-      - "--quantization"
-      - "quark"
     tp: 8
     hardware_overrides:
       mi355x:
@@ -130,6 +127,8 @@ guide: |
   - **GPU:** 8xH200 or 8xH20 (141 GB each) for single-node FP8; 8xB200 (180 GB each) for the
     full 1M context.
   - **MXFP4:** use the AMD Quark checkpoint on MI355X with ROCm and AITER enabled.
+    TP=8 is recommended for the full MXFP4 model on an 8x MI355X node; TP=4 is
+    also supported when memory headroom allows.
 
   ## Installation
 
@@ -218,17 +217,14 @@ guide: |
 
   The AMD Quark MXFP4 checkpoint quantizes the MoE weights while leaving non-MoE modules in
   higher precision. The recipe UI only enables this variant for supported AMD MI355X
-  hardware. Use Quark quantization and ROCm AITER kernels:
+  hardware. Use ROCm AITER kernels:
 
   ```bash
   export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
   export VLLM_ROCM_USE_AITER=1
   export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
-  export VLLM_ROCM_USE_AITER_FP8BMM=0
-  export VLLM_ROCM_USE_AITER_FP4BMM=0
-
+  
   vllm serve amd/GLM-5.2-MXFP4 \
-    --quantization quark \
     --trust-remote-code \
     --kv-cache-dtype fp8_e4m3 \
     --tensor-parallel-size 8 \
@@ -240,6 +236,9 @@ guide: |
     --no-enable-prefix-caching \
     --served-model-name glm-5.2-mxfp4
   ```
+
+  For TP=4 validation runs, use `HIP_VISIBLE_DEVICES=0,1,2,3` and
+  `--tensor-parallel-size 4`.
 
   Add the `spec_decoding` feature, or pass GLM-5.2's MTP flags directly, only after verifying
   your vLLM build honors Quark `exclude` entries for the unquantized MTP layer. See

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -68,7 +68,6 @@ variants:
     supported_hardware:
       - mi355x
     description: "AMD Quark MXFP4 checkpoint — MoE weights quantized for MI355X (gfx950)"
-    tp: 8
     hardware_overrides:
       mi355x:
         extra_args:
@@ -245,15 +244,6 @@ guide: |
   For TP=4 validation runs, use `HIP_VISIBLE_DEVICES=0,1,2,3` and
   `--tensor-parallel-size 4`.
 
-  Add the `spec_decoding` feature, or pass GLM-5.2's MTP flags directly, only after verifying
-  your vLLM build honors Quark `exclude` entries for the unquantized MTP layer. See
-  [vLLM PR #46757](https://github.com/vllm-project/vllm/pull/46757) for the related Quark
-  MXFP4 MTP loading fix:
-
-  ```bash
-  --speculative-config.method mtp \
-  --speculative-config.num_speculative_tokens 5
-  ```
 
   ### FP8 on 8xB200 (full 1M context)
 

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -229,8 +229,6 @@ guide: |
   export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
   export VLLM_ROCM_USE_AITER=1
   export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
-  export VLLM_ROCM_USE_AITER_FP8BMM=0
-  export VLLM_ROCM_USE_AITER_FP4BMM=0
 
   vllm serve amd/GLM-5.2-MXFP4 \
     --quantization quark \


### PR DESCRIPTION
## Summary

- Add GLM-5.2 MXFP4 as a recipe variant alongside the existing FP8 and BF16 options.
- Restrict the MXFP4 variant to supported MI355X hardware, following the MiniMax-M3 MXFP4 recipe pattern.
- Set the MXFP4 generated command to the validated TP8 path and include the MI355X-specific `--trust-remote-code` override.
- Add ROCm/AITER serving guidance for GLM-5.2 MXFP4, including recommended MI355X launch flags and KV-cache settings.
- Document MTP usage caveats for MXFP4, including the need for a vLLM build that honors Quark `exclude` entries for the unquantized MTP layer.

[PR Link for mxfp4 MTP support](https://github.com/vllm-project/vllm/pull/46757)

## Motivation

GLM-5.2 has an AMD Quark MXFP4 checkpoint that significantly reduces HBM footprint compared with the FP8 and BF16 variants. This recipe update makes that checkpoint selectable in the recipe UI while preventing unsupported hardware combinations from being generated.

The MTP note is tied to the corresponding vLLM Quark loading fix: [vLLM PR #46757](https://github.com/vllm-project/vllm/pull/46757).

## Test Plan

- Verified the GLM-5.2 recipe YAML parses successfully.
- Compared the MXFP4 hardware gating pattern with `models/MiniMaxAI/MiniMax-M3.yaml`.
- Confirmed the generated diff updates the GLM-5.2 recipe metadata, variant config, and guide text only.