### PR TITLE
SEO: canonicalize on recipes.vllm.ai + make model pages discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [vLLM Recipes](https://docs.vllm.ai/projects/recipes)
+# [vLLM Recipes](https://recipes.vllm.ai/)
 
 This repo intends to host community maintained common recipes to run vLLM answering the question:
 **How do I run model X on hardware Y for task Z?**

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,6 +9,15 @@
 
 {% block extrahead %}
   {{ super() }}
+  {# Legacy MkDocs site has moved to recipes.vllm.ai. Redirect the landing
+     page (an instant meta-refresh passes ranking signals like a 301) and
+     noindex the remaining historical-reference pages so they stop competing
+     with the new portal in search. #}
+  {% if page and page.url == "index.html" %}
+  <meta http-equiv="refresh" content="0; url=https://recipes.vllm.ai/">
+  {% else %}
+  <meta name="robots" content="noindex, follow">
+  {% endif %}
   {% if page %}
   <meta property="og:type" content="article">
   <meta property="og:title" content="{{ page.meta.title or page.title }}">
@@ -36,27 +45,9 @@
       Go to recipes.vllm.ai →
     </a>
     <p style="margin-top:1.5rem;font-size:0.85rem;color:var(--md-default-fg-color--lighter);">
-      Redirecting automatically in <span id="countdown">5</span> seconds…
-      <a id="cancel-redirect" href="#" style="margin-left:0.5rem;color:var(--md-default-fg-color--light);text-decoration:underline;">Cancel</a>
+      If you are not redirected automatically, use the link above.
     </p>
   </div>
-  <script>
-    (function () {
-      var n = 5;
-      var el = document.getElementById("countdown");
-      var iv = setInterval(function () {
-        n -= 1;
-        if (el) el.textContent = n;
-        if (n <= 0) { clearInterval(iv); window.location.href = "https://recipes.vllm.ai"; }
-      }, 1000);
-      document.getElementById("cancel-redirect").addEventListener("click", function (e) {
-        e.preventDefault();
-        clearInterval(iv);
-        var p = this.parentElement;
-        p.textContent = "Redirect cancelled. Use the link above to navigate manually.";
-      });
-    })();
-  </script>
   {% else %}
     {{ super() }}
   {% endif %}

--- a/src/app/browse/page.js
+++ b/src/app/browse/page.js
@@ -59,6 +59,27 @@ export default function BrowsePage() {
       <Suspense fallback={<div className="text-sm text-muted-foreground py-8">Loading...</div>}>
         <BrowseList recipes={slim} />
       </Suspense>
+
+      {/* Server-rendered crawlable index. BrowseList above is client-rendered,
+          so without this the model pages have no internal links pointing at
+          them and search engines can only discover them via the sitemap. A
+          plain <a> list gives every recipe a real internal link from this
+          indexable hub page. */}
+      <nav aria-label="All recipes" className="mt-12 pt-6 border-t border-border">
+        <h2 className="text-sm font-semibold text-muted-foreground mb-3">All recipes</h2>
+        <ul className="columns-2 sm:columns-3 lg:columns-4 gap-x-6 text-sm">
+          {slim
+            .slice()
+            .sort((a, b) => a.hf_id.localeCompare(b.hf_id))
+            .map((r) => (
+              <li key={r.hf_id} className="mb-1 break-inside-avoid">
+                <a href={`/${r.hf_org}/${r.hf_repo}`} className="text-vllm-blue hover:underline">
+                  {r.hf_id}
+                </a>
+              </li>
+            ))}
+        </ul>
+      </nav>
     </main>
   );
 }


### PR DESCRIPTION
## Problem

Two related SEO gaps keep the new portal (`recipes.vllm.ai`) from winning search:

1. **Navigational queries** ("vllm recipes") surface the legacy MkDocs site (`docs.vllm.ai/projects/recipes`) instead of the new portal. The old pages are fully indexable and the repo README still links its main heading to the old location.
2. **Model-specific queries** ("vllm recipes gpt oss") never surface the corresponding new page (e.g. `recipes.vllm.ai/openai/gpt-oss-120b`). Each model page is server-rendered and indexable and is in the sitemap, **but has no internal links pointing at it** — the homepage links only a few recent models and `/browse` renders its list client-side (zero `<a>` links in the server HTML). With no internal link equity, deep pages don't rank.

## Changes

- **README**: link the main "vLLM Recipes" heading to `recipes.vllm.ai/` instead of `docs.vllm.ai/projects/recipes`.
- **Legacy MkDocs landing page**: replace the 5-second JS countdown with an instant `meta refresh` redirect to `recipes.vllm.ai` (treated like a 301, passes ranking signals).
- **Remaining legacy pages**: add `noindex, follow` so the historical-reference guides stop competing in search while staying reachable by direct link.
- **`/browse`**: add a server-rendered, crawlable `<a>` index of every recipe so search engines (and users) get a real internal link to each model page.

The new Next.js site already emits correct canonical/robots/sitemap (verified 200 in production); no changes needed there.

## Follow-ups (need Read the Docs dashboard / GSC access, not a repo change)

- Server-side 301 from old `latest`/`stable` URLs (strongest signal); hide stale `stable` RTD version.
- Submit `recipes.vllm.ai/sitemap.xml` in Search Console and request indexing for key model pages.
- Consider high-authority backlinks to model pages (docs.vllm.ai, vllm.ai, HF model cards) — the biggest lever for ranking deep pages.

## Testing

- `bun install && bun run build` succeeds (303 static pages, `/browse` prerendered static). Built `/browse` HTML now contains 142 crawlable model-page links (was 0), including `/openai/gpt-oss-120b`.
- Verified live: `recipes.vllm.ai/robots.txt` + `/sitemap.xml` return 200 (176 URLs incl. gpt-oss); model page `openai/gpt-oss-120b` returns 200, server-rendered, correct canonical, no robots block.
- Confirmed the gap before the fix: legacy landing page has no `robots` meta; `/browse` server HTML had 0 model-page links.

AI assistance (Claude) was used to investigate and draft these changes.