### PR TITLE
Add NVFP4 variant to GLM-5.2 recipe

### DIFF
--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "glm-5.2"
   provider: "GLM (Z-AI)"
   description: "GLM-5.2 — frontier-scale MoE language model (~743B total parameters, 39B active) with up to 5-token MTP speculative decoding and thinking mode"
-  date_updated: 2026-06-09
+  date_updated: 2026-06-27
   difficulty: advanced
   tasks:
     - text
@@ -61,6 +61,11 @@ variants:
     precision: fp8
     vram_minimum_gb: 893
     description: "Native FP8 checkpoint — 8xH200/H20 (141GB × 8) single-node serving"
+  nvfp4:
+    model_id: "nvidia/GLM-5.2-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 558
+    description: "NVIDIA modelopt NVFP4 checkpoint — only MoE expert linears are quantized to NVFP4; shared experts, attention, embeddings, and the early dense layers stay FP8/BF16, with FP8 KV cache. Blackwell GPUs (B200/B300) only."
   bf16:
     precision: bf16
     vram_minimum_gb: 1786
@@ -224,6 +229,25 @@ guide: |
     few requests compile kernels on demand instead.
   - **BF16** needs multi-node plus an extra loader flag — see [Troubleshooting](#troubleshooting).
 
+  ### NVFP4 on Blackwell (B200/B300)
+
+  The `nvidia/GLM-5.2-NVFP4` variant is NVIDIA's modelopt re-quantization: only the MoE
+  expert linears drop to NVFP4 while shared experts, attention, embeddings, and the early
+  dense layers stay FP8/BF16, with FP8 KV cache. The ~465 GB checkpoint fits comfortably on
+  Blackwell — vLLM auto-detects the quantization from the checkpoint, so no `--quantization`
+  flag is needed. Select the **NVFP4** variant above (Blackwell-only) or run NVIDIA's command:
+
+  ```bash
+  vllm serve nvidia/GLM-5.2-NVFP4 \
+    --tensor-parallel-size 8 \
+    --enable-expert-parallel \
+    --reasoning-parser glm45 \
+    --tool-call-parser glm47 \
+    --enable-auto-tool-choice \
+    --kv-cache-dtype fp8_e4m3 \
+    --served-model-name glm-5.2-nvfp4
+  ```
+
   ## Reasoning modes
 
   Thinking is **on by default**. GLM-5.2 reuses the DeepSeek-V4 `reasoning_effort` mechanism,
@@ -323,3 +347,4 @@ guide: |
 
   - [Model card](https://huggingface.co/zai-org/GLM-5.2)
   - [FP8 checkpoint](https://huggingface.co/zai-org/GLM-5.2-FP8)
+  - [NVFP4 checkpoint (NVIDIA)](https://huggingface.co/nvidia/GLM-5.2-NVFP4)


### PR DESCRIPTION
## Summary

Adds the [`nvidia/GLM-5.2-NVFP4`](https://huggingface.co/nvidia/GLM-5.2-NVFP4) modelopt checkpoint as a new variant of the existing GLM-5.2 recipe.

This is a mixed-precision NVFP4 checkpoint: only the MoE expert linears are quantized to NVFP4, while shared experts, attention, embeddings, and the early dense layers stay FP8/BF16, with FP8 KV cache. Quantized with `nvidia-modelopt` v0.46 (`quant_algo: NVFP4`, `kv_cache_quant_algo: FP8`).

## Details

- **`precision: nvfp4`** auto-gates the variant to Blackwell (B200/B300) — Hopper/AMD pills are disabled when this variant is selected.
- **`vram_minimum_gb: 558`** — derived from the actual safetensors footprint (~465 GB: BF16 57 + FP8 45 + packed-FP4 362) × 1.2, rather than the naive `params × 0.5 × 1.2`, since the checkpoint keeps attention/shared-experts/early-layers at higher precision.
- **No `extra_args` needed** — vLLM auto-detects the quantization from the checkpoint, and the recipe's existing `single_node_tep` strategy + features already emit NVIDIA's recommended serve flags (`--enable-expert-parallel --reasoning-parser glm45 --tool-call-parser glm47 --enable-auto-tool-choice --kv-cache-dtype fp8_e4m3`).
- Added a short NVFP4-on-Blackwell section to the guide and a reference link; bumped `date_updated`.

Validated with `node scripts/build-recipes-api.mjs` (clean across all per-hardware renderings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)