### PR TITLE
Update Mellum2 Instruct serve command

### DIFF
--- a/models/JetBrains/Mellum2-12B-A2.5B-Instruct.yaml
+++ b/models/JetBrains/Mellum2-12B-A2.5B-Instruct.yaml
@@ -12,6 +12,9 @@ meta:
     - "JetBrains/Mellum2-12B-A2.5B-Thinking"
   hardware:
     h200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "JetBrains/Mellum2-12B-A2.5B-Instruct"
@@ -23,6 +26,7 @@ model:
   base_args:
     - "--max-model-len"
     - "131072"
+    - "--trust-remote-code"
   base_env: {}
 
 features:
@@ -46,6 +50,8 @@ compatible_strategies:
   - single_node_tep
   - single_node_dep
 
+hardware_overrides: {}
+
 strategy_overrides:
   single_node_tp:
     tp: 1
@@ -65,7 +71,8 @@ guide: |
 
   ## Prerequisites
 
-  - Hardware: a single H200, H100, or A100 (~29 GB at bf16) is plenty
+  - Hardware: a single H200, H100, or A100 (~29 GB at bf16) is plenty. On AMD,
+    use MI300X / MI325X / MI355X with TP=1.
   - vLLM **nightly** — `MellumForCausalLM` support landed after v0.22.0 and is not yet in a
     stable release. Install the nightly wheels until the next tagged release ships.
 
@@ -82,14 +89,40 @@ guide: |
   Unlike the Thinking checkpoint, Instruct does not emit `<think>` blocks, so no
   `--reasoning-parser` is needed.
 
+  ### Single GPU
+
+  ```bash
+  vllm serve JetBrains/Mellum2-12B-A2.5B-Instruct \
+    --max-model-len 131072 \
+    --trust-remote-code \
+    --tensor-parallel-size 1
+
+  # Optional: add tool calling.
+  vllm serve JetBrains/Mellum2-12B-A2.5B-Instruct \
+    --max-model-len 131072 \
+    --trust-remote-code \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser hermes
+  ```
+
+  ### Docker (AMD MI300X / MI325X / MI355X)
+
+  MI300X / MI325X / MI355X GPUs have larger per-GPU HBM, so you can use
+  `--max-model-len auto`.
+
   ```bash
   # Plain serving
   vllm serve JetBrains/Mellum2-12B-A2.5B-Instruct \
-    --max-model-len 131072
+    --max-model-len auto \
+    --trust-remote-code \
+    --tensor-parallel-size 1
 
-  # Add tool calling
+  # Add tool calling.
   vllm serve JetBrains/Mellum2-12B-A2.5B-Instruct \
-    --max-model-len 131072 \
+    --max-model-len auto \
+    --trust-remote-code \
+    --tensor-parallel-size 1 \
     --enable-auto-tool-choice \
     --tool-call-parser hermes
   ```


### PR DESCRIPTION
## Summary
- Mark Mellum2 Instruct as verified on MI300X, MI325X, and MI355X in addition to H200.
- Restore `--max-model-len 131072` alongside `--trust-remote-code` for the default single-GPU config.
- Add AMD MI300X / MI325X / MI355X launch examples using `--max-model-len auto` and `--tensor-parallel-size 1` for plain serving and tool-calling paths.

## Test plan
- `python` YAML parse and top-level schema-order check for `models/JetBrains/Mellum2-12B-A2.5B-Instruct.yaml`
- `git diff --check -- models/JetBrains/Mellum2-12B-A2.5B-Instruct.yaml`
- `ReadLints` on `models/JetBrains/Mellum2-12B-A2.5B-Instruct.yaml`
- `node scripts/build-recipes-api.mjs`