### PR TITLE
Update MiniCPM5 serve command

### DIFF
--- a/models/openbmb/MiniCPM5-1B.yaml
+++ b/models/openbmb/MiniCPM5-1B.yaml
@@ -18,7 +18,8 @@ model:
   parameter_count: "1.1B"
   active_parameters: "1.1B"
   context_length: 131072
-  base_args: []
+  base_args:
+    - "--trust-remote-code"
   base_env: {}
 
 features:
@@ -40,6 +41,8 @@ variants:
 compatible_strategies:
   - single_node_tp
   - multi_node_tp
+
+hardware_overrides: {}
 
 strategy_overrides:
   single_node_tp:
@@ -69,7 +72,9 @@ guide: |
   Use the command builder above. The baseline is simply:
 
   ```bash
-  vllm serve openbmb/MiniCPM5-1B --port 8000
+  vllm serve openbmb/MiniCPM5-1B \
+    --trust-remote-code \
+    --tensor-parallel-size 1
   ```
 
   At ~1.1B params the model fits on a single GPU (TP=1). It supports the full

--- a/models/openbmb/MiniCPM5-1B.yaml
+++ b/models/openbmb/MiniCPM5-1B.yaml
@@ -11,6 +11,11 @@ meta:
   performance_headline: "1B-class open-source SOTA on tool use, code, and reasoning"
   related_recipes:
     - openbmb/MiniCPM-V-4.6
+  hardware:
+    h200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "openbmb/MiniCPM5-1B"
@@ -19,7 +24,8 @@ model:
   parameter_count: "1.1B"
   active_parameters: "1.1B"
   context_length: 131072
-  base_args: []
+  base_args:
+    - "--trust-remote-code"
   base_env: {}
 
 features:
@@ -45,6 +51,8 @@ compatible_strategies:
 kv_offload_support:
   offloading_cpu: verified
   offloading_fs: verified
+
+hardware_overrides: {}
 
 strategy_overrides:
   single_node_tp:
@@ -74,7 +82,9 @@ guide: |
   Use the command builder above. The baseline is simply:
 
   ```bash
-  vllm serve openbmb/MiniCPM5-1B --port 8000
+  vllm serve openbmb/MiniCPM5-1B \
+    --trust-remote-code \
+    --tensor-parallel-size 1
   ```
 
   At ~1.1B params the model fits on a single GPU (TP=1). It supports the full


### PR DESCRIPTION
## Summary
- Add trust-remote-code to the MiniCPM5 recipe and show the TP=1 launch command.
- Aligns the recipe launch guidance with the provided vLLM serve command.

## Test plan
- Ran `node scripts/build-recipes-api.mjs` on the complete validated recipe update set.

