### PR TITLE
Update ERNIE 4.5 21B ROCm serve command

### DIFF
--- a/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
@@ -17,7 +17,8 @@ model:
   parameter_count: "21B"
   active_parameters: "3B"
   context_length: 131072
-  base_args: []
+  base_args:
+    - "--trust-remote-code"
   base_env: {}
 
 features:
@@ -58,12 +59,16 @@ compatible_strategies:
 hardware_overrides:
   amd:
     extra_args:
+      - "--tensor-parallel-size"
+      - "4"
       - "--gpu-memory-utilization"
       - "0.9"
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       SAFETENSORS_FAST_GPU: "1"
-strategy_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 4
 
 guide: |
   ## Overview
@@ -92,10 +97,13 @@ guide: |
 
   ## Launch commands
 
-  21B on 1x80GB GPU:
+  21B on AMD ROCm with 4-way tensor parallelism:
 
   ```bash
-  vllm serve baidu/ERNIE-4.5-21B-A3B-PT
+  VLLM_ROCM_USE_AITER=1 SAFETENSORS_FAST_GPU=1 vllm serve baidu/ERNIE-4.5-21B-A3B-PT \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.9 \
+    --trust-remote-code
   ```
 
   300B on 8x80GB with vLLM FP8 online quantization:

--- a/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
@@ -10,6 +10,11 @@ meta:
     - text
   related_recipes:
     - baidu/ERNIE-4.5-VL-28B-A3B-PT
+  hardware:
+    h200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "baidu/ERNIE-4.5-21B-A3B-PT"
@@ -18,7 +23,8 @@ model:
   parameter_count: "21B"
   active_parameters: "3B"
   context_length: 131072
-  base_args: []
+  base_args:
+    - "--trust-remote-code"
   base_env: {}
 
 features:
@@ -68,7 +74,9 @@ hardware_overrides:
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       SAFETENSORS_FAST_GPU: "1"
-strategy_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 4
 
 guide: |
   ## Overview
@@ -97,10 +105,13 @@ guide: |
 
   ## Launch commands
 
-  21B on 1x80GB GPU:
+  21B on AMD ROCm with 4-way tensor parallelism:
 
   ```bash
-  vllm serve baidu/ERNIE-4.5-21B-A3B-PT
+  VLLM_ROCM_USE_AITER=1 SAFETENSORS_FAST_GPU=1 vllm serve baidu/ERNIE-4.5-21B-A3B-PT \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.9 \
+    --trust-remote-code
   ```
 
   300B on 8x80GB with vLLM FP8 online quantization:

--- a/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
@@ -102,16 +102,12 @@ guide: |
   source .venv/bin/activate
   uv pip install vllm --torch-backend=auto
   ```
-
   ## Launch commands
 
-  21B on AMD ROCm with 4-way tensor parallelism:
+  21B on 1x80GB GPU:
 
   ```bash
-  VLLM_ROCM_USE_AITER=1 SAFETENSORS_FAST_GPU=1 vllm serve baidu/ERNIE-4.5-21B-A3B-PT \
-    --tensor-parallel-size 4 \
-    --gpu-memory-utilization 0.9 \
-    --trust-remote-code
+  vllm serve baidu/ERNIE-4.5-21B-A3B-PT
   ```
 
   300B on 8x80GB with vLLM FP8 online quantization:
@@ -135,7 +131,18 @@ guide: |
   vllm serve baidu/ERNIE-4.5-21B-A3B-PT \
     --speculative-config '{"method":"ernie_mtp","model":"baidu/ERNIE-4.5-21B-A3B-PT","num_speculative_tokens":1}'
   ```
+  
+  ### Docker (AMD MI300X / MI325X / MI355X)
+  MI300X / MI325X / MI355X GPUs have larger per-GPU HBM, so you can deploy
+  21B on AMD ROCm with 4-way tensor parallelism:
 
+  ```bash
+  VLLM_ROCM_USE_AITER=1 SAFETENSORS_FAST_GPU=1 vllm serve baidu/ERNIE-4.5-21B-A3B-PT \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.9 \
+    --trust-remote-code
+  ```
+  
   ## Client Usage
 
   Standard OpenAI-compatible API; model ID is the HF repo.


### PR DESCRIPTION
## Summary
- Add verified hardware tags for ERNIE 4.5 21B, including H200 and AMD MI300X / MI325X / MI355X.
- Keep AMD ROCm env and GPU memory guidance while avoiding duplicate `--tensor-parallel-size` injection from hardware overrides.
- Use `strategy_overrides.single_node_tp.tp: 4` as the single source for the TP=4 setting.

## Test plan
- Parsed `models/baidu/ERNIE-4.5-21B-A3B-PT.yaml` with PyYAML and checked top-level key order.
- Verified AMD hardware tags and confirmed `hardware_overrides.amd.extra_args` no longer contains `--tensor-parallel-size`.
- Ran `git diff --check -- models/baidu/ERNIE-4.5-21B-A3B-PT.yaml`.
- Ran `node scripts/build-recipes-api.mjs`.