### PR TITLE
Update Trinity Large Thinking ROCm command

### DIFF
--- a/models/arcee-ai/Trinity-Large-Thinking.yaml
+++ b/models/arcee-ai/Trinity-Large-Thinking.yaml
@@ -17,8 +17,9 @@ model:
   active_parameters: "13B"
   context_length: 262144
   base_args:
-    - "--dtype"
-    - "bfloat16"
+    - "--trust-remote-code"
+    - "--max-model-len"
+    - "32768"
   base_env: {}
 
 features:
@@ -59,8 +60,14 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
-hardware_overrides: {}
-strategy_overrides: {}
+hardware_overrides:
+  amd:
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+
+strategy_overrides:
+  single_node_tp:
+    tp: 8
 
 guide: |
   ## Overview
@@ -90,8 +97,19 @@ guide: |
   ## Launch command
 
   ```bash
-  vllm serve arcee-ai/Trinity-Large-Thinking \
-    --dtype bfloat16 \
+  VLLM_ROCM_USE_AITER=1 vllm serve arcee-ai/Trinity-Large-Thinking \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --max-model-len 32768
+  ```
+
+  Optional parser flags:
+
+  ```bash
+  VLLM_ROCM_USE_AITER=1 vllm serve arcee-ai/Trinity-Large-Thinking \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --max-model-len 32768 \
     --reasoning-parser deepseek_r1 \
     --enable-auto-tool-choice \
     --tool-call-parser qwen3_coder
@@ -101,7 +119,7 @@ guide: |
   - `--reasoning-parser deepseek_r1` extracts `<think>...</think>` into `message.reasoning`.
   - `--enable-auto-tool-choice` lets the model decide when to call tools.
   - `--tool-call-parser qwen3_coder` converts tool calls into OpenAI-style `tool_calls`.
-  - `--dtype bfloat16` matches the recommended serving dtype.
+  - `--max-model-len 32768` keeps the KV cache practical for the TP=8 AMD launch.
 
   Add parallelism flags (`--tensor-parallel-size`, `--data-parallel-size`, or
   `--enable-expert-parallel`) for your hardware. Lower `--max-model-len` if you don't

--- a/models/arcee-ai/Trinity-Large-Thinking.yaml
+++ b/models/arcee-ai/Trinity-Large-Thinking.yaml
@@ -9,6 +9,11 @@ meta:
   tasks:
     - text
   related_recipes: []
+  hardware:
+    h200: verified
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "arcee-ai/Trinity-Large-Thinking"
@@ -18,8 +23,9 @@ model:
   active_parameters: "13B"
   context_length: 262144
   base_args:
-    - "--dtype"
-    - "bfloat16"
+    - "--trust-remote-code"
+    - "--max-model-len"
+    - "32768"
   base_env: {}
 
 features:
@@ -61,7 +67,10 @@ compatible_strategies:
   - multi_node_dep
 
 hardware_overrides: {}
-strategy_overrides: {}
+
+strategy_overrides:
+  single_node_tp:
+    tp: 8
 
 guide: |
   ## Overview
@@ -92,7 +101,18 @@ guide: |
 
   ```bash
   vllm serve arcee-ai/Trinity-Large-Thinking \
-    --dtype bfloat16 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --max-model-len 32768
+  ```
+
+  Optional parser flags:
+
+  ```bash
+  vllm serve arcee-ai/Trinity-Large-Thinking \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --max-model-len 32768 \
     --reasoning-parser deepseek_r1 \
     --enable-auto-tool-choice \
     --tool-call-parser qwen3_coder
@@ -102,7 +122,7 @@ guide: |
   - `--reasoning-parser deepseek_r1` extracts `<think>...</think>` into `message.reasoning`.
   - `--enable-auto-tool-choice` lets the model decide when to call tools.
   - `--tool-call-parser qwen3_coder` converts tool calls into OpenAI-style `tool_calls`.
-  - `--dtype bfloat16` matches the recommended serving dtype.
+  - `--max-model-len 32768` keeps the KV cache practical for the TP=8 launch.
 
   Add parallelism flags (`--tensor-parallel-size`, `--data-parallel-size`, or
   `--enable-expert-parallel`) for your hardware. Lower `--max-model-len` if you don't


### PR DESCRIPTION
## Summary
- Add verified hardware tags for H200, MI300X, MI325X, and MI355X.
- Keep the Trinity Large Thinking launch guidance generic across platforms by removing explicit ROCm env exports from the guide/config.
- Preserve the TP=8 and `--max-model-len 32768` launch configuration for this large BF16 model.

## Test plan
- `python` YAML parse and top-level schema-order check for `models/arcee-ai/Trinity-Large-Thinking.yaml`
- `git diff --check -- models/arcee-ai/Trinity-Large-Thinking.yaml`
- `ReadLints` on `models/arcee-ai/Trinity-Large-Thinking.yaml`
- `node scripts/build-recipes-api.mjs`