### PR TITLE
Update PLaMo 2 Translate serve command

### DIFF
--- a/models/pfnet/plamo-2-translate.yaml
+++ b/models/pfnet/plamo-2-translate.yaml
@@ -20,8 +20,6 @@ model:
   context_length: 8192
   base_args:
     - "--trust-remote-code"
-    - "--max-model-len"
-    - "8192"
   base_env: {}
 
 features: {}
@@ -41,7 +39,9 @@ compatible_strategies:
 
 hardware_overrides: {}
 
-strategy_overrides: {}
+strategy_overrides:
+  single_node_tp:
+    tp: 4
 
 guide: |
   ## Overview
@@ -61,7 +61,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware:** 1x GPU with at least 24 GB VRAM, such as L40S, A30, or RTX 4090
+  - **Hardware:** 4 GPUs for the TP=4 launch below, or 1 GPU with at least
+    24 GB VRAM if you override tensor parallelism to TP=1
   - **vLLM:** >= 0.8.5
   - **License:** PLaMo community license
 
@@ -78,7 +79,7 @@ guide: |
   ```bash
   vllm serve pfnet/plamo-2-translate \
     --trust-remote-code \
-    --max-model-len 8192
+    --tensor-parallel-size 4
   ```
 
   For tighter memory budgets, reduce `--max-model-len` (the model card

--- a/models/pfnet/plamo-2-translate.yaml
+++ b/models/pfnet/plamo-2-translate.yaml
@@ -10,6 +10,10 @@ meta:
   performance_headline: "PLaMo 2 post-trained for English/Japanese translation"
   related_recipes:
     - "pfnet/plamo-3-nict-31b-base"
+  hardware:
+    mi300x: verified
+    mi325x: verified
+    mi355x: verified
 
 model:
   model_id: "pfnet/plamo-2-translate"
@@ -20,8 +24,6 @@ model:
   context_length: 8192
   base_args:
     - "--trust-remote-code"
-    - "--max-model-len"
-    - "8192"
   base_env: {}
 
 features: {}
@@ -61,7 +63,8 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware:** 1x GPU with at least 24 GB VRAM, such as L40S, A30, or RTX 4090
+  - **Hardware:** MI300X / MI325X / MI355X verified. NVIDIA GPUs with smaller
+    VRAM can run the model by capping `--max-model-len`.
   - **vLLM:** >= 0.8.5
   - **License:** PLaMo community license
 
@@ -72,17 +75,45 @@ guide: |
   source .venv/bin/activate
   uv pip install -U vllm --torch-backend=auto
   ```
+  ## Deployment Configurations
 
-  ## Launching the Server
+  ### NVIDIA (small VRAM)
+
+  On NVIDIA GPUs with tighter memory budgets, cap `--max-model-len` (the model
+  card examples use 2000).
 
   ```bash
   vllm serve pfnet/plamo-2-translate \
     --trust-remote-code \
-    --max-model-len 8192
+    --tensor-parallel-size 1 \
+    --max-model-len 2000
   ```
 
-  For tighter memory budgets, reduce `--max-model-len` (the model card
-  examples use 2000).
+  ### AMD MI300X / MI325X / MI355X
+
+  ```bash
+  vllm serve pfnet/plamo-2-translate \
+    --trust-remote-code \
+    --tensor-parallel-size 1
+  ```
+
+  ### Docker (AMD MI300X / MI325X / MI355X)
+
+  ```bash
+  docker run --rm -it \
+    --cap-add=SYS_PTRACE \
+    --ipc=host \
+    --privileged=true \
+    --shm-size=128GB \
+    --network=host \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --group-add video \
+    vllm/vllm-openai-rocm:latest \
+      pfnet/plamo-2-translate \
+      --trust-remote-code \
+      --tensor-parallel-size 1
+  ```
 
   ## Prompt Format
 


### PR DESCRIPTION
## Summary
- Remove the hardcoded `single_node_tp` `tp: 4` override so tensor parallelism can adapt to selected hardware.
- Split PLaMo 2 Translate launch guidance into NVIDIA small-VRAM and AMD MI300X / MI325X / MI355X sections.
- Keep AMD MI300X, MI325X, and MI355X marked as verified and fix the ROCm command to serve `pfnet/plamo-2-translate`.

## Test plan
- `python` YAML parse and top-level schema-order check for `models/pfnet/plamo-2-translate.yaml`
- `git diff --check -- models/pfnet/plamo-2-translate.yaml`
- `ReadLints` on `models/pfnet/plamo-2-translate.yaml`
- `node scripts/build-recipes-api.mjs`