### PR TITLE
docs: document You.com as alternative browser backend for gpt-oss

### DIFF
--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "gpt-oss"
   provider: "OpenAI"
   description: "OpenAI's gpt-oss family (20B / 120B) with MXFP4 MoE, attention-sinks, built-in tools via Responses API"
-  date_updated: 2026-05-10
+  date_updated: 2026-06-30
   difficulty: intermediate
   tasks:
     - text
@@ -198,6 +198,23 @@ guide: |
   ```bash
   vllm serve ... --tool-call-parser openai --enable-auto-tool-choice
   ```
+
+  ### Browser backend
+
+  The demo tool server uses [Exa](https://exa.ai) by default — set `EXA_API_KEY` to enable web search. To use [You.com](https://you.com) instead, run the reference MCP browser server (defaults to `BROWSER_BACKEND=youcom`) with `YDC_API_KEY`:
+
+  ```bash
+  export YDC_API_KEY=<your-key>
+  mcp run -t sse browser_server.py:mcp
+  ```
+
+  Then, in a separate terminal, start the vLLM server pointing to the MCP server's address:
+
+  ```bash
+  vllm serve ... --tool-server <browser-server-ip>:<port>
+  ```
+
+  Get a You.com API key at [you.com/platform](https://you.com/platform).
 
   ## Client Usage
 

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -208,10 +208,10 @@ guide: |
   mcp run -t sse browser_server.py:mcp
   ```
 
-  Then, in a separate terminal, start the vLLM server pointing to the MCP server's address:
+  The MCP browser server listens on port `8001` by default. Then, in a separate terminal, start the vLLM server pointing to it:
 
   ```bash
-  vllm serve ... --tool-server <browser-server-ip>:<port>
+  vllm serve ... --tool-server localhost:8001
   ```
 
   Get a You.com API key at [you.com/platform](https://you.com/platform).

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "gpt-oss-20b"
   provider: "OpenAI"
   description: "OpenAI's gpt-oss-20b — 21B-total / 3.6B-active MoE reasoning model with native MXFP4 quant; fits in 16GB VRAM"
-  date_updated: 2026-05-08
+  date_updated: 2026-06-30
   difficulty: beginner
   tasks:
     - text
@@ -153,6 +153,23 @@ guide: |
   ```bash
   vllm serve openai/gpt-oss-20b --tool-call-parser openai --enable-auto-tool-choice
   ```
+
+  ### Browser backend
+
+  The demo tool server uses [Exa](https://exa.ai) by default — set `EXA_API_KEY` to enable web search. To use [You.com](https://you.com) instead, run the reference MCP browser server (defaults to `BROWSER_BACKEND=youcom`) with `YDC_API_KEY`:
+
+  ```bash
+  export YDC_API_KEY=<your-key>
+  mcp run -t sse browser_server.py:mcp
+  ```
+
+  Then, in a separate terminal, start the vLLM server pointing to the MCP server's address:
+
+  ```bash
+  vllm serve openai/gpt-oss-20b --tool-server <browser-server-ip>:<port>
+  ```
+
+  Get a You.com API key at [you.com/platform](https://you.com/platform).
 
   ## Reasoning effort
 

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -163,10 +163,10 @@ guide: |
   mcp run -t sse browser_server.py:mcp
   ```
 
-  Then, in a separate terminal, start the vLLM server pointing to the MCP server's address:
+  The MCP browser server listens on port `8001` by default. Then, in a separate terminal, start the vLLM server pointing to it:
 
   ```bash
-  vllm serve openai/gpt-oss-20b --tool-server <browser-server-ip>:<port>
+  vllm serve openai/gpt-oss-20b --tool-server localhost:8001
   ```
 
   Get a You.com API key at [you.com/platform](https://you.com/platform).


### PR DESCRIPTION
The gpt-oss reference library ships a `YouComBackend` and the MCP browser server (`browser_server.py`) defaults to `BROWSER_BACKEND=youcom`, but the vLLM gpt-oss recipes only documented the Exa backend.

This adds a brief "Browser backend" section to both the 20b and 120b recipe guides showing how to use You.com via the MCP browser server with `YDC_API_KEY`.

The demo tool server path (`--tool-server demo`) still uses Exa by default and is noted as such. The You.com path applies to the MCP browser server, which defaults to `BROWSER_BACKEND=youcom`.

The `mcp run` and `vllm serve` commands are in separate code blocks since both are long-running blocking processes that need separate terminals.