### PR TITLE
Fix DeepSeek-V4-Pro multi-node TEP TP size

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -147,6 +147,11 @@ strategy_overrides:
       - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
   multi_node_tep:
     extra_args:
+      # Keep TP at 8 for the default FP4+FP8 checkpoint: TP=16 partitions the
+      # 3072 MoE intermediate size into 192-wide shards, which is not compatible
+      # with the current FP8 block layout.
+      - "--tensor-parallel-size"
+      - "8"
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
   single_node_dep:


### PR DESCRIPTION
## Summary

Fixes #497.

DeepSeek-V4-Pro currently inherits the generic `multi_node_tep` behavior that sets `--tensor-parallel-size` to the total GPU count across nodes. On 2x H200 nodes this renders TP=16, but the default FP4+FP8 checkpoint has `moe_intermediate_size=3072`, which produces 192-wide shards at TP=16 and is not compatible with the current FP8 block layout.

This PR overrides only the DeepSeek-V4-Pro `multi_node_tep` recipe to keep TP at 8 while preserving the existing multi-node flags and compilation config.

## Testing

- `node scripts/build-recipes-api.mjs`
- Direct command synthesis check for `DeepSeek-V4-Pro` + `h200` + `multi_node_tep` + `nodeCount=2`: head and worker argv both render `--tensor-parallel-size 8`
- `NODE_OPTIONS=--use-env-proxy HTTP_PROXY=http://127.0.0.1:7897 HTTPS_PROXY=http://127.0.0.1:7897 ALL_PROXY=socks5://127.0.0.1:7897 pnpm --config.verify-deps-before-run=false build`
