### PR TITLE
Add MiniMax M3 NVFP4 for B200

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -2,8 +2,8 @@ meta:
   title: "MiniMax-M3"
   slug: "minimax-m3"
   provider: "MiniMax"
-  description: "MiniMax M3 vision-language MoE (427B total / 26B active) for frontier coding, agent toolchains, and 1M-token reasoning via MSA sparse attention — native multimodal (image + video + computer use); BF16 plus MXFP8 and AMD MI355X MXFP4 variants. Runs on NVIDIA (Hopper/Blackwell) and AMD CDNA4/CDNA3."
-  date_updated: 2026-06-25
+  description: "MiniMax M3 vision-language MoE (427B total / 26B active) for frontier coding, agent toolchains, and 1M-token reasoning via MSA sparse attention — native multimodal (image + video + computer use); BF16 plus MXFP8, NVIDIA Blackwell NVFP4, and AMD MI355X MXFP4 variants. Runs on NVIDIA (Hopper/Blackwell) and AMD CDNA4/CDNA3."
+  date_updated: 2026-07-01
   difficulty: advanced
   tasks:
     - text
@@ -12,6 +12,7 @@ meta:
   related_recipes: []
   hardware:
     h200: verified
+    b200: verified
     mi300x: verified
     mi355x: verified
 
@@ -126,6 +127,15 @@ variants:
           VLLM_ROCM_USE_AITER: "1"
           VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
           VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT6"
+  nvfp4:
+    model_id: "nvidia/MiniMax-M3-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 257
+    description: "NVIDIA-quantized NVFP4 weights (ModelOpt) for Blackwell (B200/B300) — native FP4 tensor cores, ~half the VRAM of MXFP8."
+    extra_args:
+      - "--trust-remote-code"
+    extra_env:
+      VLLM_FLOAT32_MATMUL_PRECISION: "high"
   mxfp4:
     model_id: "amd/MiniMax-M3-MXFP4"
     precision: mxfp4
@@ -482,6 +492,40 @@ guide: |
     --enable-auto-tool-choice
   ```
 
+  ## Quantized Variant (NVFP4 on Blackwell)
+
+  [`nvidia/MiniMax-M3-NVFP4`](https://huggingface.co/nvidia/MiniMax-M3-NVFP4)
+  is an NVFP4 checkpoint quantized by NVIDIA with ModelOpt. It requires a vLLM
+  build with MiniMax-M3 NVFP4 support (vllm-project/vllm PR #46380).
+
+  Select the **nvfp4** variant and **B200** hardware in the command builder, or
+  launch the tested B200 baseline directly:
+
+  ```bash
+  VLLM_FLOAT32_MATMUL_PRECISION=high \
+    vllm serve nvidia/MiniMax-M3-NVFP4 \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --block-size 128 \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    --enable-auto-tool-choice
+  ```
+
+  Pair it with EAGLE3 speculative decoding (the *Spec decoding* feature) for
+  faster decode — the validated B200 benchmark runs the NVFP4 target against the
+  `Inferact/MiniMax-M3-EAGLE3` draft head (3 speculative tokens):
+
+  ```bash
+  VLLM_FLOAT32_MATMUL_PRECISION=high \
+    vllm serve nvidia/MiniMax-M3-NVFP4 \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --block-size 128 \
+    --language-model-only \
+    --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
+  ```
+
   ## Quantized Variant (MXFP4 on MI355X)
 
   [`amd/MiniMax-M3-MXFP4`](https://huggingface.co/amd/MiniMax-M3-MXFP4)
@@ -528,6 +572,7 @@ guide: |
 
   - [Model card](https://huggingface.co/MiniMaxAI/MiniMax-M3)
   - [MXFP8 variant](https://huggingface.co/MiniMaxAI/MiniMax-M3-MXFP8)
+  - [NVFP4 variant](https://huggingface.co/nvidia/MiniMax-M3-NVFP4)
   - [AMD MXFP4 variant](https://huggingface.co/amd/MiniMax-M3-MXFP4)
   - [MiniMax](https://www.minimax.io/)
   - [MiniMax Agent](https://agent.minimax.io/)


### PR DESCRIPTION
Add the NVFP4 (nvidia/MiniMax-M3-NVFP4) Blackwell variant to the MiniMax-M3 recipe, validated on B200 with EAGLE3 speculative decoding, matching the InferenceX benchmark: --block-size 128, --trust-remote-code, and VLLM_FLOAT32_MATMUL_PRECISION=high, reusing the existing spec-decoding and text-only feature toggles. Based on SemiAnalysisAI/InferenceX#1933.