### PR TITLE
chore: remove VLLM_USE_FLASHINFER_MOE_FP4 flag

### DIFF
--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -18,7 +18,7 @@ meta:
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2.5"
-  min_vllm_version: "0.20.2"
+  min_vllm_version: "0.24.0"
   docker_image: "vllm/vllm-openai:v0.20.2"
   architecture: moe
   parameter_count: "230B"
@@ -56,8 +56,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -19,7 +19,7 @@ meta:
 model:
   model_id: "MiniMaxAI/MiniMax-M2.5"
   min_vllm_version: "0.24.0"
-  docker_image: "vllm/vllm-openai:v0.20.2"
+  docker_image: "vllm/vllm-openai:v0.24.0"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"
@@ -144,7 +144,7 @@ guide: |
     -e VLLM_USE_DEEP_GEMM=0 \
     -e VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER=0 \
     -e VLLM_FLOAT32_MATMUL_PRECISION=high \
-    vllm/vllm-openai:v0.20.2 MiniMaxAI/MiniMax-M2.5 \
+    vllm/vllm-openai:v0.24.0 MiniMaxAI/MiniMax-M2.5 \
         --tensor-parallel-size 4 \
         --max-num-seqs 512 \
         --max-num-batched-tokens 32768 \

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -19,7 +19,7 @@ meta:
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2.7"
-  min_vllm_version: "0.20.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"
@@ -56,8 +56,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -18,7 +18,7 @@ meta:
 
 model:
   model_id: "MiniMaxAI/MiniMax-M2"
-  min_vllm_version: "0.11.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"
@@ -60,8 +60,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp
@@ -230,7 +229,7 @@ guide: |
 
   [`RedHatAI/MiniMax-M2-NVFP4`](https://huggingface.co/RedHatAI/MiniMax-M2-NVFP4) is an NVFP4 (4-bit)
   checkpoint — roughly half the VRAM of the native FP8 checkpoint. Select the **nvfp4** variant
-  above (it sets `VLLM_USE_FLASHINFER_MOE_FP4=1` and `--kv-cache-dtype fp8`), or pass the repo id
+  above (it sets `--kv-cache-dtype fp8`; FlashInfer MoE is auto-selected on Blackwell), or pass the repo id
   directly to `vllm serve`. NVFP4 requires a Blackwell GPU (compute capability 10.0+).
 
   ## References

--- a/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -17,7 +17,7 @@ meta:
 
 model:
   model_id: "Qwen/Qwen3-235B-A22B-Instruct-2507"
-  min_vllm_version: "0.10.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "235B"
   active_parameters: "22B"
@@ -56,8 +56,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -18,7 +18,7 @@ meta:
 
 model:
   model_id: "Qwen/Qwen3-Coder-480B-A35B-Instruct"
-  min_vllm_version: "0.10.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "480B"
   active_parameters: "35B"
@@ -61,8 +61,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -17,7 +17,7 @@ meta:
 
 model:
   model_id: "Qwen/Qwen3-Next-80B-A3B-Instruct"
-  min_vllm_version: "0.10.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "80B"
   active_parameters: "3B"
@@ -60,8 +60,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp
@@ -76,7 +75,6 @@ hardware_overrides:
   blackwell:
     extra_args: []
     extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
       VLLM_FLASHINFER_MOE_BACKEND: "latency"
       VLLM_USE_DEEP_GEMM: "0"
       VLLM_USE_TRTLLM_ATTENTION: "0"
@@ -122,9 +120,8 @@ guide: |
     --enable-prefix-caching
   ```
 
-  On SM100, accelerate with the FP8 FlashInfer TRTLLM MoE kernel:
+  On SM100, tune the auto-selected FP8 FlashInfer TRTLLM MoE kernel for latency:
   ```bash
-  VLLM_USE_FLASHINFER_MOE_FP8=1 \
   VLLM_FLASHINFER_MOE_BACKEND=latency \
   VLLM_USE_DEEP_GEMM=0 \
   VLLM_USE_TRTLLM_ATTENTION=0 \

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -106,7 +106,7 @@ guide: |
   uv venv
   source .venv/bin/activate
 
-  # Install vLLM >= 0.11.0
+  # Install vLLM >= 0.24.0
   uv pip install -U vllm
 
   # Install Qwen-VL utility library (recommended for offline inference)

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -20,7 +20,7 @@ meta:
 
 model:
   model_id: "Qwen/Qwen3-VL-235B-A22B-Instruct"
-  min_vllm_version: "0.11.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "235B"
   active_parameters: "22B"
@@ -67,8 +67,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -20,7 +20,7 @@ meta:
 
 model:
   model_id: "Qwen/Qwen3.5-397B-A17B"
-  min_vllm_version: "0.17.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "397B"
   active_parameters: "17B"
@@ -75,8 +75,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
   gptq_int4:
     model_id: "Qwen/Qwen3.5-397B-A17B-GPTQ-Int4"
     precision: int4

--- a/models/arcee-ai/Trinity-Large-Thinking.yaml
+++ b/models/arcee-ai/Trinity-Large-Thinking.yaml
@@ -11,7 +11,7 @@ meta:
 
 model:
   model_id: "arcee-ai/Trinity-Large-Thinking"
-  min_vllm_version: "0.11.1"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "398B"
   active_parameters: "13B"
@@ -49,8 +49,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/arcee-ai/Trinity-Large-Thinking.yaml
+++ b/models/arcee-ai/Trinity-Large-Thinking.yaml
@@ -75,7 +75,7 @@ guide: |
 
   ## Prerequisites
 
-  - vLLM >= 0.11.1
+  - vLLM >= 0.24.0
   - Hardware: multi-GPU recommended for production deployments
 
   ### Install vLLM

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -18,7 +18,7 @@ meta:
 
 model:
   model_id: "deepseek-ai/DeepSeek-R1"
-  min_vllm_version: "0.12.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "671B"
   active_parameters: "37B"
@@ -64,8 +64,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp
@@ -80,12 +79,10 @@ compatible_strategies:
 hardware_overrides:
   hopper:
     extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
+    extra_env: {}
   blackwell:
     extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
   amd:
     # AITER attention wins over Triton FA for DeepSeek MoE on MI300X/MI325X/MI355X.
     extra_args: []
@@ -139,13 +136,7 @@ guide: |
 
   ### 4xB200 (FP4)
 
-  Enable FlashInfer MoE kernels before launching:
-  ```bash
-  # For FP4 (recommended on Blackwell)
-  export VLLM_USE_FLASHINFER_MOE_FP4=1
-  # For FP8 on Blackwell
-  export VLLM_USE_FLASHINFER_MOE_FP8=1
-  ```
+  On Blackwell, vLLM auto-selects the FlashInfer MoE kernels — no env vars needed.
 
   Tensor Parallel + Expert Parallel (TP4+EP):
   ```bash

--- a/models/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.1.yaml
@@ -16,7 +16,7 @@ meta:
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.1"
-  min_vllm_version: "0.12.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "671B"
   active_parameters: "37B"
@@ -57,8 +57,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2.yaml
@@ -15,7 +15,7 @@ meta:
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3.2"
-  min_vllm_version: "0.18.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "671B"
   active_parameters: "37B"
@@ -69,8 +69,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2.yaml
@@ -97,7 +97,7 @@ guide: |
   ## Prerequisites
 
   - **Hardware**: Minimum 8x H100/H200 80GB GPUs (BF16) or 3x H200 (NVFP4 variant).
-  - **vLLM**: Version 0.18.0 or later (nightly recommended).
+  - **vLLM**: Version 0.24.0 or later.
   - **Python**: 3.10+
   - **CUDA**: 12.x or later (CUDA 13.x may require extra env vars; see Troubleshooting).
   - **Disk**: ~1.3 TB for BF16 weights; ~350 GB for NVFP4 variant.

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -18,7 +18,7 @@ meta:
 
 model:
   model_id: "deepseek-ai/DeepSeek-V3"
-  min_vllm_version: "0.12.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "671B"
   active_parameters: "37B"
@@ -56,8 +56,7 @@ variants:
     precision: fp4
     vram_minimum_gb: 403
     description: "NVIDIA FP4 quantized weights for Blackwell (e.g. 4xB200)"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp
@@ -72,12 +71,10 @@ compatible_strategies:
 hardware_overrides:
   hopper:
     extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
+    extra_env: {}
   blackwell:
     extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
   amd:
     # AITER attention wins over Triton FA for DeepSeek MoE on MI300X/MI325X/MI355X.
     extra_args: []
@@ -131,13 +128,7 @@ guide: |
 
   ### 4xB200 (FP4)
 
-  Enable FlashInfer MoE kernels before launching:
-  ```bash
-  # For FP4 (recommended on Blackwell)
-  export VLLM_USE_FLASHINFER_MOE_FP4=1
-  # For FP8 on Blackwell
-  export VLLM_USE_FLASHINFER_MOE_FP8=1
-  ```
+  On Blackwell, vLLM auto-selects the FlashInfer MoE kernels — no env vars needed.
 
   Tensor Parallel + Expert Parallel (TP4+EP):
   ```bash

--- a/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -107,7 +107,7 @@ guide: |
   ## Prerequisites
 
   - Hardware: 1x B200 (FP4), 1x H100 (FP8), 4x GPUs (BF16) or 4x Xeon6/Xeon5 NUMA node for BF16
-  - vLLM >= 0.12.0
+  - vLLM >= 0.24.0
   - CUDA Driver >= 575 for GPUs
   - Docker with NVIDIA Container Toolkit (recommended) for GPUs
   - License: Must agree to Meta's Llama 4 Scout Community License for GPUs

--- a/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -18,7 +18,7 @@ meta:
 
 model:
   model_id: "meta-llama/Llama-4-Scout-17B-16E-Instruct"
-  min_vllm_version: "0.12.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "109B"
   active_parameters: "17B"
@@ -54,8 +54,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp
@@ -82,8 +81,7 @@ hardware_overrides:
       - "8192"
       - "--compilation-config"
       - '{"pass_config":{"fuse_allreduce_rms":true,"eliminate_noops":true}}'
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
+    extra_env: {}
   amd:
     # 8 GPUs required for 17B×16E MoE. AITER JIT-compiles on first launch.
     extra_args:

--- a/models/moonshotai/Kimi-K2-Thinking.yaml
+++ b/models/moonshotai/Kimi-K2-Thinking.yaml
@@ -16,7 +16,7 @@ meta:
 
 model:
   model_id: "moonshotai/Kimi-K2-Thinking"
-  min_vllm_version: "0.12.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "1T"
   active_parameters: "32B"
@@ -54,8 +54,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -44,7 +44,7 @@ features:
       - "--reasoning-parser"
       - "kimi_k2"
   spec_decoding:
-    description: "Eagle3 speculative decoding for accelerated inference (requires vLLM >= 0.18.0)"
+    description: "Eagle3 speculative decoding for accelerated inference"
     args:
       - "--speculative-config"
       - '{"model":"lightseekorg/kimi-k2.5-eagle3-mla","method":"eagle3","num_speculative_tokens":3}'
@@ -147,7 +147,7 @@ guide: |
 
   ## Prerequisites
 
-  - **vLLM version:** >= 0.15.0 (speculative decoding with Eagle3 requires >= 0.18.0)
+  - **vLLM version:** >= 0.24.0
   - **Hardware (BF16):** 8x H200 GPUs (verified), or equivalent aggregate VRAM (~640 GB)
   - **Hardware (NVFP4):** 4x Blackwell GPUs (e.g. GB200)
   - **AMD support:** 8x MI300X / MI325X / MI355X with ROCm 7.2.1 and Python 3.12

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -19,7 +19,7 @@ meta:
 
 model:
   model_id: "moonshotai/Kimi-K2.5"
-  min_vllm_version: "0.19.1"
+  min_vllm_version: "0.24.0"
   docker_image:
     nvidia: "vllm/vllm-openai:latest"
     amd: "vllm/vllm-openai-rocm:nightly"
@@ -80,8 +80,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -19,7 +19,7 @@ meta:
 
 model:
   model_id: "moonshotai/Kimi-K2.6"
-  min_vllm_version: "0.19.1"
+  min_vllm_version: "0.24.0"
   docker_image:
     nvidia: "vllm/vllm-openai:latest"
     amd: "vllm/vllm-openai-rocm:nightly"
@@ -80,8 +80,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -147,7 +147,7 @@ guide: |
 
   ## Prerequisites
 
-  - **vLLM version:** >= 0.19.1
+  - **vLLM version:** >= 0.24.0
   - **Hardware (INT4):** 8x H200 GPUs (verified), or equivalent aggregate VRAM (~640 GB)
   - **AMD support:** 8x MI300X / MI325X / MI355X with ROCm 7.2.1 and Python 3.12
 

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -15,7 +15,7 @@ meta:
 
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
-  min_vllm_version: "0.11.2"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "30B"
   active_parameters: "3B"
@@ -60,7 +60,6 @@ variants:
       - "--kv-cache-dtype"
       - "fp8"
     extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
       VLLM_FLASHINFER_MOE_BACKEND: "throughput"
 
 compatible_strategies:
@@ -108,10 +107,9 @@ guide: |
 
   ## Launch commands
 
-  FP8 with FlashInfer MoE backend (Blackwell/Hopper):
+  FP8 with FlashInfer MoE backend (Blackwell/Hopper — auto-selected):
 
   ```bash
-  export VLLM_USE_FLASHINFER_MOE_FP8=1
   export VLLM_FLASHINFER_MOE_BACKEND=throughput
 
   vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 \

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -83,14 +83,14 @@ guide: |
   ## Prerequisites
 
   - Hardware: 1x H100/H200 or comparable; DGX Spark and Jetson Thor supported
-  - vLLM >= 0.11.2 (0.12.0 recommended for full support)
+  - vLLM >= 0.24.0
   - Docker with NVIDIA Container Toolkit (recommended)
 
   ### Pull Docker Image
 
   ```bash
-  docker pull --platform linux/amd64 vllm/vllm-openai:v0.12.0
-  docker tag vllm/vllm-openai:v0.12.0 vllm/vllm-openai:deploy
+  docker pull --platform linux/amd64 vllm/vllm-openai:v0.24.0
+  docker tag vllm/vllm-openai:v0.24.0 vllm/vllm-openai:deploy
   ```
 
   DGX Spark users can build from source (see README) or use the NGC image:

--- a/models/zai-org/GLM-4.7.yaml
+++ b/models/zai-org/GLM-4.7.yaml
@@ -17,7 +17,7 @@ meta:
 
 model:
   model_id: "zai-org/GLM-4.7"
-  min_vllm_version: "0.11.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "358B"
   active_parameters: "32B"
@@ -73,8 +73,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/zai-org/GLM-5.1.yaml
+++ b/models/zai-org/GLM-5.1.yaml
@@ -14,7 +14,7 @@ meta:
 
 model:
   model_id: "zai-org/GLM-5.1"
-  min_vllm_version: "0.19.1"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "744B"
   active_parameters: "40B"
@@ -65,8 +65,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp

--- a/models/zai-org/GLM-5.1.yaml
+++ b/models/zai-org/GLM-5.1.yaml
@@ -93,7 +93,7 @@ guide: |
 
   ## Prerequisites
 
-  - **vLLM version:** 0.19.0 (stable — preferred over nightly for model performance).
+  - **vLLM version:** 0.24.0 (stable — preferred over nightly for model performance).
     Use the latest main branch if you need tool calling + MTP simultaneously.
   - **Hardware (FP8):** 8xH200 or 8xH20 (141GB × 8)
   - **DeepGEMM (FP8):** install via `install_deepgemm.sh` from vLLM repo
@@ -121,7 +121,7 @@ guide: |
   ```bash
   uv venv
   source .venv/bin/activate
-  uv pip install "vllm==0.19.0" --torch-backend=auto
+  uv pip install "vllm==0.24.0" --torch-backend=auto
   uv pip install "transformers>=5.4.0"
   ```
 
@@ -197,7 +197,7 @@ guide: |
 
   ## Troubleshooting
 
-  - **Accuracy drift:** Prefer the 0.19.0 stable release for best accuracy.
+  - **Accuracy drift:** Prefer the 0.24.0 stable release for best accuracy.
   - **Tool calling + MTP:** If both are needed, use the latest vLLM main branch.
   - **FP8 installation:** DeepGEMM required for FP8 performance.
 

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -25,8 +25,8 @@ model:
   base_env: {}
 
 dependencies:
-  - note: "Pin vllm==0.19.0 (avoid nightly)"
-    command: 'uv pip install "vllm==0.19.0" --torch-backend=auto'
+  - note: "Pin vllm==0.24.0 (avoid nightly)"
+    command: 'uv pip install "vllm==0.24.0" --torch-backend=auto'
   - note: "GLM-5 requires transformers >= 5.4.0"
     command: 'uv pip install "transformers>=5.4.0"'
   - note: "Optional: DeepGEMM for FP8 MoE kernels (FP8 variant only)"
@@ -102,7 +102,7 @@ guide: |
 
   ## Prerequisites
 
-  - **vLLM version:** 0.19.0 (stable — preferred over nightly for model performance)
+  - **vLLM version:** 0.24.0 (stable — preferred over nightly for model performance)
   - **Hardware (FP8):** 8xH200 or 8xH20 (141GB × 8)
   - **DeepGEMM (FP8):** install via `install_deepgemm.sh` from the vLLM repo
 
@@ -128,7 +128,7 @@ guide: |
   ```bash
   uv venv
   source .venv/bin/activate
-  uv pip install "vllm==0.19.0" --torch-backend=auto
+  uv pip install "vllm==0.24.0" --torch-backend=auto
   uv pip install "transformers>=5.4.0"
   ```
 
@@ -195,7 +195,7 @@ guide: |
 
   ## Troubleshooting
 
-  - **Accuracy drift:** Prefer the 0.19.0 stable release over nightly for best accuracy.
+  - **Accuracy drift:** Prefer the 0.24.0 stable release over nightly for best accuracy.
   - **Tool calling + MTP:** If you need both, use the latest vLLM main branch.
   - **FP8 installation:** DeepGEMM is required for FP8 performance.
 

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -14,7 +14,7 @@ meta:
 
 model:
   model_id: "zai-org/GLM-5"
-  min_vllm_version: "0.16.0"
+  min_vllm_version: "0.24.0"
   architecture: moe
   parameter_count: "744B"
   active_parameters: "40B"
@@ -74,8 +74,7 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+    extra_env: {}
 
 compatible_strategies:
   - single_node_tp


### PR DESCRIPTION
After v0.23.1rc0, the flag VLLM_USE_FLASHINFER_MOE_FP4 seems to be auto selected. See `vllm/model_executor/layers/fused_moe/oracle/nvfp4.py`, `select_nvfp4_moe_backend()`.

Users can now use `--moe-backend` to specify. 

Part of the clean up effort: https://github.com/vllm-project/recipes/issues/366