### PR TITLE
[AMD][ROCm]Minimax-M3 Eagle3 MTP attn backend override for perf

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -59,6 +59,12 @@ features:
     args:
       - "--speculative-config"
       - '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
+    hardware_overrides:
+      # On ROCm the Eagle3 draft head prefers the TRITON_ATTN attn backend as it has better performance than the default.
+      amd:
+        args:
+          - "--speculative-config"
+          - '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3", "num_speculative_tokens": 3, "attention_backend": "TRITON_ATTN"}'
   text_only:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:


### PR DESCRIPTION
For Minimax-M3, override the drafter's attention backend to TRITON_ATTN.

When using eagle3 MTP:
Using
```
    --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"TRITON_ATTN\"}" \
```
has much better performance than without it, like below:
```
    --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS} \
```

For 8k/1k, con1 to con256, perf improved from 4% to 151%

<img width="1826" height="985" alt="image" src="https://github.com/user-attachments/assets/08b79488-404d-412f-91c3-0c468fc98e86" />

