### PR TITLE
Add Intel XPU (Max 1550) deployment recipe for Gemma 4 12B QAT W4A16

### DIFF
--- a/models/Google/gemma-4-12B-it.yaml
+++ b/models/Google/gemma-4-12B-it.yaml
@@ -15,6 +15,7 @@ meta:
     - google/gemma-4-31B-it
   hardware:
     h100: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-12B-it"
@@ -73,7 +74,12 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  xpu:
+    extra_args:
+      tensor_parallel_size: 2
+    extra_env:
+      ZE_AFFINITY_MASK: "0,1"
 
 strategy_overrides:
   single_node_tp:
@@ -177,6 +183,26 @@ guide: |
       --disable_chunked_mm_input \
       --host 0.0.0.0 --port 8000
   ```
+
+  ### Intel XPU Deployment via Docker (Max 1550)
+
+  Launch the W4A16 QAT variant on Intel Data Center GPU Max 1550 (2-tile TP):
+
+  ```bash
+  docker run -itd --name gemma4-12b-qat-xpu \
+    --device /dev/dri --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e ZE_AFFINITY_MASK=0,1 \
+    intel/vllm:latest \
+      --model google/gemma-4-12B-it-qat-w4a16-ct \
+      --dtype bfloat16 \
+      --tensor-parallel-size 2 \
+      --max-model-len 32768 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  > **Note:** Requires vLLM with the memory reporting fix for Max 1550 — the `intel/vllm:latest` image includes this fix. The W4A16 QAT model uses ~9 GB VRAM for weights, leaving ample HBM for KV cache.
 
   ## Client Usage
 

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -164,6 +164,17 @@ hardware_profiles:
     multi_node: false
     restricted: true
 
+  # ── Intel Data Center GPU (XPU) ──
+  max1550:
+    brand: Intel
+    generation: xpu
+    display_name: "Data Center GPU Max 1550"
+    description: "Intel Data Center GPU Max 1550 · 64 GB HBM2e per tile · 4 tiles per node"
+    gpu_count: 4
+    vram_gb: 256
+    multi_node: false
+    restricted: true
+
 tasks:
   - id: text
     display_name: "Text"


### PR DESCRIPTION
## Motivation

Add Intel Data Center GPU Max 1550 as a verified deployment target for the Gemma 4 12B QAT W4A16 model (`google/gemma-4-12B-it-qat-w4a16-ct`).

## Changes

- **taxonomy.yaml**: Add `max1550` hardware profile (Intel Data Center GPU Max 1550, 64 GB HBM2e per tile, XPU generation)
- **models/Google/gemma-4-12B-it.yaml**:
  - Mark `max1550: verified` in `meta.hardware`
  - Add `hardware_overrides.xpu` with `tensor_parallel_size: 2` and `ZE_AFFINITY_MASK: "0,1"`
  - Add Intel XPU Docker deployment section to the guide with full launch command

## Validation

- Model loads and runs end-to-end inference on 2x Intel Data Center GPU Max 1550 tiles
- Required vLLM fix: memory reporting workaround (`torch.xpu.mem_get_info` instead of `getMemoryInfo` C++ op) — merged in vllm-project/vllm
- W4A16 group_size=32 support via XPU int4 linear kernel path

## Context

Companion to the CPU recipe added in #463. This PR adds the discrete GPU (XPU) path as discussed in that review thread.

AI assistance was used (GitHub Copilot) for recipe authoring.