### PR TITLE
fix  h20*8 deepseek-v4-pro-dspark bug

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -136,7 +136,7 @@ hardware_overrides:
       - "--gpu-memory-utilization"
       - "0.95"
       - "--max-num-seqs"
-      - "512"
+      - "16"
       - "--max-num-batched-tokens"
       - "512"
       - "--no-enable-flashinfer-autotune"

--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -132,13 +132,13 @@ hardware_overrides:
     # ~960 GB mixed-precision weights replicated across DP ranks — cap to 800K.
     extra_args:
       - "--max-model-len"
-      - "800000"
+      - "200000"
       - "--gpu-memory-utilization"
       - "0.95"
       - "--max-num-seqs"
       - "16"
       - "--max-num-batched-tokens"
-      - "512"
+      - "16384"
       - "--no-enable-flashinfer-autotune"
       - "--compilation-config"
       - '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'


### PR DESCRIPTION
fix  h20*8 deepseek-v4-pro-dspark bug
--max-num-seqs must set to 16

recep cookbook  512 can not be started successful 

it have been test many times ~ 

thanks~