### PR TITLE
Document MiniMax-M3 index top-k reuse recipe

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "minimax-m3"
   provider: "MiniMax"
   description: "MiniMax M3 vision-language MoE (427B total / 26B active) for frontier coding, agent toolchains, and 1M-token reasoning via MSA sparse attention — native multimodal (image + video + computer use); BF16 plus MXFP8 and AMD MI355X MXFP4 variants. Runs on NVIDIA (Hopper/Blackwell) and AMD CDNA4/CDNA3."
-  date_updated: 2026-06-25
+  date_updated: 2026-07-07
   difficulty: advanced
   tasks:
     - text
@@ -479,7 +479,8 @@ guide: |
     --attention-backend TRITON_ATTN \
     --tool-call-parser minimax_m3 \
     --reasoning-parser minimax_m3 \
-    --enable-auto-tool-choice
+    --enable-auto-tool-choice \
+    --hf-overrides '{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}'
   ```
 
   ## Quantized Variant (MXFP4 on MI355X)
@@ -502,7 +503,8 @@ guide: |
     --mm-encoder-attn-backend ROCM_AITER_FA \
     --tool-call-parser minimax_m3 \
     --enable-auto-tool-choice \
-    --reasoning-parser minimax_m3
+    --reasoning-parser minimax_m3 \
+    --hf-overrides '{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}'
   ```
 
   ## Troubleshooting


### PR DESCRIPTION
## Purpose

Document the correct way to enable MiniMax-M3 sparse index top-k reuse from `--hf-overrides`.

MiniMax-M3 uses a wrapper config with a nested text config. The index top-k reuse knobs are read from the text config, so this flat override does **not** enable the runtime path:

```bash
--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}'
```

The working form is:

```bash
--hf-overrides '{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}'
```

This PR adds that nested override to the MiniMax-M3 recipe guide and reports the measured MI355X throughput impact.

## Validation

Validated on MI355X TP4 with latest ROCm nightly:

- **Image**: `vllm/vllm-openai-rocm:nightly`
- **Image digest**: `sha256:1d7ce278489df2a5d8016b6efcc9b5f6cdbad026d1137d64cee7a2242583ec88`
- **vLLM**: `0.23.1rc1.dev861+gcbe9c40f9`
- **Model**: `amd/MiniMax-M3-MXFP4`

| Override | Output tok/s/GPU | Mean TPOT | Delta vs no override |
|----------|------------------|-----------|----------------------|
| none | 708.0 | 69.9 ms | baseline |
| flat `{"use_index_cache": true, "index_topk_freq": 4}` | 707.7 | 70.1 ms | -0.05% |
| nested `{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}` | 781.2 | 63.3 ms | **+10.3%** |

The flat form is effectively identical to no override. The nested `text_config` form engages index top-k reuse and improves output throughput by **10.3%** for this shape.

## Reproduction Command

**Baseline server:**

```bash
vllm serve amd/MiniMax-M3-MXFP4 \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --block-size 128 \
  --language-model-only \
  --max-model-len 32768 \
  --attention-backend TRITON_ATTN \
  --moe-backend aiter \
  --tool-call-parser minimax_m3 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m3
```

**Nested override server:**

```bash
vllm serve amd/MiniMax-M3-MXFP4 \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --block-size 128 \
  --language-model-only \
  --max-model-len 32768 \
  --attention-backend TRITON_ATTN \
  --moe-backend aiter \
  --tool-call-parser minimax_m3 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m3 \
  --hf-overrides '{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}'
```

**Benchmark command:**

```bash
vllm bench serve \
  --backend vllm \
  --model amd/MiniMax-M3-MXFP4 \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/completions \
  --dataset-name random \
  --random-input-len 8192 \
  --random-output-len 1024 \
  --random-range-ratio 0.8 \
  --ignore-eos \
  --request-rate inf \
  --max-concurrency 256 \
  --num-prompts 512 \
  --temperature 0 \
  --save-result
```

## Accuracy Validation

I also ran full GSM8K to check that enabling index top-k reuse through the
nested text config does not regress accuracy.

Server setup: MI355X TP4, `amd/MiniMax-M3-MXFP4`, latest
`vllm/vllm-openai-rocm:nightly`, vLLM `0.23.1rc1.dev861+gcbe9c40f9`.

Metric | Value | Stderr
-- | -- | --
flexible exact match | 0.9447 | 0.0063
strict exact match | 0.9454 | 0.0063