### PR TITLE
Add DGX Spark (GB10) support to Nemotron-3-Super recipe

### DIFF
--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -65,6 +65,20 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 75
     description: "NVFP4 weights for Blackwell"
+    hardware_overrides:
+      # DGX Spark (GB10 / SM121) only — single-GPU tuning + explicit opt-in to the
+      # flashinfer_b12x CuteDSL NVFP4 kernels (excluded from auto-selection on SM121
+      # pending the upstream CUTLASS SM121 MMA-op guard).
+      dgx_spark_gb10:
+        extra_args:
+          - "--gpu-memory-utilization"
+          - "0.85"
+          - "--max-model-len"
+          - "131072"
+          - "--moe-backend"
+          - "flashinfer_b12x"
+          - "--linear-backend"
+          - "flashinfer_b12x"
 
   base_bf16:
     model_id: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base-BF16"
@@ -144,17 +158,25 @@ guide: |
     is too aggressive here. A slightly higher value (e.g. 0.87) may also work.
   - **`--max-model-len 131072`** caps the context so the KV cache is sized appropriately
     for DGX Spark's memory; the model's full 262144 context would leave too little room.
-  - **No backend flag is needed.** On GB10 (SM121) vLLM's auto backend selection already
-    lands on FlashInfer, faster than the Marlin fallback:
+  - **Backends.** On GB10 (SM121) auto selection already lands on FlashInfer, faster than
+    the Marlin fallback:
     - `linear_backend='auto'` → `FLASHINFER_CUTLASS`
     - `moe_backend='auto'` → `FLASHINFER_CUTLASS`
     - `--attention-backend='auto'` → `FLASHINFER`
+
+    This recipe additionally opts into the newer **`flashinfer_b12x`** CuteDSL NVFP4 kernels
+    via `--moe-backend flashinfer_b12x --linear-backend flashinfer_b12x`. These are
+    *excluded from auto-selection* on SM121 pending an upstream CUTLASS SM121 MMA-op guard,
+    so they are experimental/opt-in — drop both flags to fall back to the auto
+    `FLASHINFER_CUTLASS` path if you hit issues.
 
   ```bash
   vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
     --trust-remote-code \
     --max-model-len 131072 \
     --gpu-memory-utilization 0.85 \
+    --moe-backend flashinfer_b12x \
+    --linear-backend flashinfer_b12x \
     --enable-auto-tool-choice \
     --tool-call-parser qwen3_coder \
     --reasoning-parser nemotron_v3

--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -138,23 +138,23 @@ guide: |
 
   ### DGX Spark (GB10)
 
-  The NVFP4 variant runs on a single DGX Spark (GB10) at TP=1. Two notes:
+  The NVFP4 variant runs on a single DGX Spark (GB10) at TP=1. A few notes:
 
   - **Set `--gpu-memory-utilization 0.85`** to avoid an OOM at startup — the default 0.92
     is too aggressive here. A slightly higher value (e.g. 0.87) may also work.
+  - **`--max-model-len 131072`** caps the context so the KV cache is sized appropriately
+    for DGX Spark's memory; the model's full 262144 context would leave too little room.
   - **No backend flag is needed.** On GB10 (SM121) vLLM's auto backend selection already
-    lands on FlashInfer: the NVFP4 MoE backend resolves to `FLASHINFER_CUTLASS` and the
-    NVFP4 GEMM to `FlashInferCutlassNvFp4LinearKernel`, which is faster than the Marlin
-    fallback. FlashInfer is the default here, so there is nothing extra to pass.
+    lands on FlashInfer, faster than the Marlin fallback:
+    - `linear_backend='auto'` → `FLASHINFER_CUTLASS`
+    - `moe_backend='auto'` → `FLASHINFER_CUTLASS`
+    - `--attention-backend='auto'` → `FLASHINFER`
 
   ```bash
   vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
-    --tensor-parallel-size 1 \
     --trust-remote-code \
-    --served-model-name nemotron-3-super \
     --max-model-len 131072 \
     --gpu-memory-utilization 0.85 \
-    --max-num-seqs 4 \
     --enable-auto-tool-choice \
     --tool-call-parser qwen3_coder \
     --reasoning-parser nemotron_v3

--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -136,17 +136,16 @@ guide: |
     --reasoning-parser nemotron_v3
   ```
 
-  ### DGX Spark (GB10) — single-GPU NVFP4
+  ### DGX Spark (GB10)
 
-  The NVFP4 variant runs on a single DGX Spark (GB10, 128 GB unified memory) at TP=1.
-  Two GB10-specific notes:
+  The NVFP4 variant runs on a single DGX Spark (GB10) at TP=1. Two notes:
 
-  - **`--gpu-memory-utilization 0.85`** is required — GB10's unified memory can't satisfy
-    vLLM's default 0.92 and OOMs at startup.
-  - **No backend flag is needed.** On GB10 (SM121) vLLM auto-selects the `FLASHINFER_CUTLASS`
-    NVFP4 MoE kernel (with `FlashInferCutlassNvFp4LinearKernel` for the GEMMs), which is
-    faster than the Marlin fallback. FlashInfer is the default here, so there is nothing
-    extra to pass.
+  - **Set `--gpu-memory-utilization 0.85`** to avoid an OOM at startup — the default 0.92
+    is too aggressive here. A slightly higher value (e.g. 0.87) may also work.
+  - **No backend flag is needed.** On GB10 (SM121) vLLM's auto backend selection already
+    lands on FlashInfer: the NVFP4 MoE backend resolves to `FLASHINFER_CUTLASS` and the
+    NVFP4 GEMM to `FlashInferCutlassNvFp4LinearKernel`, which is faster than the Marlin
+    fallback. FlashInfer is the default here, so there is nothing extra to pass.
 
   ```bash
   vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \

--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -14,6 +14,7 @@ meta:
     h200: verified
     b200: verified
     dgx_station_gb300: verified
+    dgx_spark_gb10: verified
 
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
@@ -135,6 +136,31 @@ guide: |
     --reasoning-parser nemotron_v3
   ```
 
+  ### DGX Spark (GB10) — single-GPU NVFP4
+
+  The NVFP4 variant runs on a single DGX Spark (GB10, 128 GB unified memory) at TP=1.
+  Two GB10-specific notes:
+
+  - **`--gpu-memory-utilization 0.85`** is required — GB10's unified memory can't satisfy
+    vLLM's default 0.92 and OOMs at startup.
+  - **No backend flag is needed.** On GB10 (SM121) vLLM auto-selects the `FLASHINFER_CUTLASS`
+    NVFP4 MoE kernel (with `FlashInferCutlassNvFp4LinearKernel` for the GEMMs), which is
+    faster than the Marlin fallback. FlashInfer is the default here, so there is nothing
+    extra to pass.
+
+  ```bash
+  vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
+    --tensor-parallel-size 1 \
+    --trust-remote-code \
+    --served-model-name nemotron-3-super \
+    --max-model-len 131072 \
+    --gpu-memory-utilization 0.85 \
+    --max-num-seqs 4 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser nemotron_v3
+  ```
+
   ## Benchmarking
 
   ```bash
@@ -152,6 +178,7 @@ guide: |
   ## References
 
   - [vLLM blog: Nemotron-3-Super](https://vllm.ai/blog/nemotron-3-super)
+  - [vLLM blog: vLLM on DGX Spark](https://vllm.ai/blog/2026-06-01-vllm-dgx-spark)
   - [Nemotron-3-Super-120B-A12B-BF16](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16)
   - [Nemotron-3-Super-120B-A12B-FP8](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8)
   - [Nemotron-3-Super-120B-A12B-NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4)


### PR DESCRIPTION
Marks the Nemotron-3-Super NVFP4 variant as verified on DGX Spark (GB10) and documents the single-GPU launch command, which needs --gpu-memory-utilization 0.85 because GB10's unified memory can't satisfy the default 0.92; no backend flag is required since vLLM already auto-selects the FlashInfer CUTLASS NVFP4 MoE kernel on SM121, which outperforms the Marlin fallback.