### PR TITLE
Add Intel XPU (Max 1550) deployment recipe for Gemma 4 12B QAT W4A16

### DIFF
--- a/models/Google/gemma-4-12B-it.yaml
+++ b/models/Google/gemma-4-12B-it.yaml
@@ -15,6 +15,7 @@ meta:
     - google/gemma-4-31B-it
   hardware:
     h100: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-12B-it"
@@ -73,7 +74,13 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  xpu:
+    extra_args:
+      tensor_parallel_size: 2
+      quantization: compressed-tensors
+    extra_env:
+      ZE_AFFINITY_MASK: "0,1"
 
 strategy_overrides:
   single_node_tp:
@@ -164,6 +171,23 @@ guide: |
       --host 0.0.0.0 --port 8000
   ```
   On CUDA 12.9 hosts, use the `vllm/vllm-openai:gemma4-unified-cu129` tag instead.
+
+  ### Docker (Intel XPU — Max 1550)
+  The W4A16 QAT variant fits on 2 tiles of a Max 1550 with mixed attention backends
+  (Flash Attention SYCL for sliding-window layers, Triton for full-attention layers).
+  ```bash
+  docker run -itd --name gemma4-12b-xpu \
+    --device /dev/dri --network host --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e ZE_AFFINITY_MASK="0,1" \
+    intel/vllm:latest \
+      --model google/gemma-4-12B-it-qat-w4a16-ct \
+      --dtype bfloat16 \
+      --quantization compressed-tensors \
+      --tensor-parallel-size 2 \
+      --max-model-len 16384 \
+      --host 0.0.0.0 --port 8000
+  ```
 
   ### Docker (Cloud TPU — Trillium / Ironwood)
   TPU uses the separate `vllm/vllm-tpu` image (no pip wheel). Pull the tag specified by the upstream [Trillium](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Gemma4) or [Ironwood](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/inference/ironwood/vLLM/Gemma4/) recipe, then run:

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -144,6 +144,16 @@ hardware_profiles:
     restricted: true
 
   # ── Intel Xeon CPU ──
+  max1550:
+    brand: Intel
+    generation: xpu
+    display_name: "Data Center GPU Max 1550"
+    description: "Intel Data Center GPU Max 1550 · 64 GB HBM2e per tile · 2-tile OAM module"
+    gpu_count: 4
+    vram_gb: 256
+    multi_node: false
+    restricted: true
+
   xeon6:
     brand: Intel
     generation: cpu


### PR DESCRIPTION
## Motivation

Add Intel Data Center GPU Max 1550 as a verified hardware target for google/gemma-4-12B-it-qat-w4a16-ct.

## Changes

- **taxonomy.yaml**: Add `max1550` hardware profile (Intel Data Center GPU Max 1550, 64 GB HBM2e/tile)
- **models/Google/gemma-4-12B-it.yaml**: Add `max1550: verified` to hardware, add XPU hardware_overrides (TP=2, compressed-tensors quantization), add Docker deployment section for Intel XPU

## Technical Details

Gemma 4 uses heterogeneous head dimensions (256 for sliding-window, 512 for global attention). On XPU, vLLM now uses mixed attention backends per-layer:
- Sliding window layers → Flash Attention SYCL kernel (fast path)
- Full attention layers → Triton Attention (fallback for head_dim=512)

This provides ~55% decode throughput improvement over the previous Triton-only path.

## Validation

- Model loads and generates correct output on 2-tile Max 1550
- Mixed backend selection confirmed via server logs
- W4A16 quantization via compressed-tensors works with both backends