### PR TITLE
Update Nemotron-3-Super DGX Spark config

### DIFF
--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "NVIDIA"
   description: "NVIDIA Nemotron-3-Super Mamba-hybrid latent-MoE (~120B total / ~12B active) with BF16, FP8, and NVFP4 variants"
   date_added: 2026-04-28
-  date_updated: 2026-04-28
+  date_updated: 2026-07-15
   difficulty: advanced
   tasks:
     - text
@@ -68,19 +68,6 @@ variants:
     vram_minimum_gb: 75
     description: "NVFP4 weights for Blackwell"
     hardware_overrides:
-      # DGX Spark (GB10 / SM121) only — single-GPU tuning + explicit opt-in to the
-      # flashinfer_b12x CuteDSL NVFP4 kernels (excluded from auto-selection on SM121
-      # pending the upstream CUTLASS SM121 MMA-op guard).
-      dgx_spark_gb10:
-        extra_args:
-          - "--gpu-memory-utilization"
-          - "0.85"
-          - "--max-model-len"
-          - "131072"
-          - "--moe-backend"
-          - "flashinfer_b12x"
-          - "--linear-backend"
-          - "flashinfer_b12x"
       rtx_pro_6000:
         extra_args:
           - "--max-num-seqs"
@@ -158,34 +145,39 @@ guide: |
 
   ### DGX Spark (GB10)
 
-  The NVFP4 variant runs on a single DGX Spark (GB10) at TP=1. A few notes:
-
-  - **Set `--gpu-memory-utilization 0.85`** to avoid an OOM at startup — the default 0.92
-    is too aggressive here. A slightly higher value (e.g. 0.87) may also work.
-  - **`--max-model-len 131072`** caps the context so the KV cache is sized appropriately
-    for DGX Spark's memory; the model's full 262144 context would leave too little room.
-  - **Backends.** On GB10 (SM121) auto selection already lands on FlashInfer, faster than
-    the Marlin fallback:
-    - `linear_backend='auto'` → `FLASHINFER_CUTLASS`
-    - `moe_backend='auto'` → `FLASHINFER_CUTLASS`
-    - `--attention-backend='auto'` → `FLASHINFER`
-
-    This recipe additionally opts into the newer **`flashinfer_b12x`** CuteDSL NVFP4 kernels
-    via `--moe-backend flashinfer_b12x --linear-backend flashinfer_b12x`. These are
-    *excluded from auto-selection* on SM121 pending an upstream CUTLASS SM121 MMA-op guard,
-    so they are experimental/opt-in — drop both flags to fall back to the auto
-    `FLASHINFER_CUTLASS` path if you hit issues.
+  The NVFP4 variant runs on a single DGX Spark (GB10) at TP=1 inside the
+  `vllm/vllm-openai:v0.24.0-ubuntu2404` container. The command below is the optimal
+  config tuned end-to-end on DGX Spark: the full 262144-token context fits with an FP8
+  KV cache and a float32 Mamba SSM cache (`VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` allows the
+  long context, `VLLM_FLOAT32_MATMUL_PRECISION=high` keeps the Mamba scan numerically
+  stable), `--gpu-memory-utilization 0.8` leaves headroom in the 128 GB unified memory,
+  batching is sized for a single GB10 (`--max-num-seqs 8`,
+  `--max-num-batched-tokens 16384`), `--load-format fastsafetensors` speeds up weight
+  loading, and MTP speculative decoding plus prefix caching are enabled for lower
+  latency:
 
   ```bash
+  # Use container: vllm/vllm-openai:v0.24.0-ubuntu2404
+
+  VLLM_FLOAT32_MATMUL_PRECISION="high" \
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
   vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 \
-    --trust-remote-code \
-    --max-model-len 131072 \
-    --gpu-memory-utilization 0.85 \
-    --moe-backend flashinfer_b12x \
-    --linear-backend flashinfer_b12x \
-    --enable-auto-tool-choice \
-    --tool-call-parser qwen3_coder \
-    --reasoning-parser nemotron_v3
+      --host 0.0.0.0 \
+      --port 8000 \
+      --max-model-len 262144 \
+      --gpu-memory-utilization 0.8 \
+      --max-num-seqs 8 \
+      --load-format fastsafetensors \
+      --attention-backend flashinfer \
+      --max-num-batched-tokens 16384 \
+      --kv-cache-dtype fp8 \
+      --mamba-cache-mode align \
+      --mamba_ssm_cache_dtype float32 \
+      --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+      --enable-prefix-caching \
+      --reasoning-parser nemotron_v3 \
+      --enable-auto-tool-choice \
+      --tool-call-parser qwen3_xml
   ```
 
   ### RTX Pro 6000 NVFP4


### PR DESCRIPTION
Simplify the DGX Spark (GB10) support on the Nemotron-3-Super recipe: drop the per-variant flashinfer_b12x/context-cap override so the interactive builder emits the general base config when DGX Spark is selected, and rewrite the guide's DGX Spark section around the end-to-end tuned command on the vllm/vllm-openai:v0.24.0-ubuntu2404 container (full 262k context with FP8 KV cache and float32 Mamba SSM cache, gpu-memory-utilization 0.8, fastsafetensors loading, MTP speculative decoding, and prefix caching).