### PR TITLE
Make recipe URLs case-insensitive

### DIFF
--- a/src/app/[org]/[repo]/page.js
+++ b/src/app/[org]/[repo]/page.js
@@ -77,6 +77,9 @@ export default async function RecipePage({ params }) {
     if (v) redirect(`/${v.parent.hf_org}/${v.parent.hf_repo}?variant=${encodeURIComponent(v.variantKey)}`);
     notFound();
   }
+  if (org !== recipe.hf_org || repo !== recipe.hf_repo) {
+    redirect(`/${recipe.hf_org}/${recipe.hf_repo}`);
+  }
 
   const strategies = loadStrategies();
   const taxonomy = loadTaxonomy();

--- a/src/app/[org]/[repo]/page.js
+++ b/src/app/[org]/[repo]/page.js
@@ -69,7 +69,7 @@ export async function generateMetadata({ params }) {
   };
 }
 
-export default async function RecipePage({ params }) {
+export default async function RecipePage({ params, searchParams }) {
   const { org, repo } = await params;
   const recipe = getRecipeByHfId(org, repo);
   if (!recipe) {
@@ -78,7 +78,8 @@ export default async function RecipePage({ params }) {
     notFound();
   }
   if (org !== recipe.hf_org || repo !== recipe.hf_repo) {
-    redirect(`/${recipe.hf_org}/${recipe.hf_repo}`);
+    const qs = new URLSearchParams(await searchParams).toString();
+    redirect(`/${recipe.hf_org}/${recipe.hf_repo}${qs ? `?${qs}` : ""}`);
   }
 
   const strategies = loadStrategies();

--- a/src/app/[org]/page.js
+++ b/src/app/[org]/page.js
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import { notFound } from "next/navigation";
-import { getAllRecipes } from "@/lib/recipes";
+import { notFound, redirect } from "next/navigation";
+import { getAllRecipes, getRecipesByOrg } from "@/lib/recipes";
 import { getProviderLogo, getProviderLogoClass, getProviderDisplayName } from "@/lib/providers";
 import { recipeHref } from "@/lib/recipe-utils";
 import { siteUrl } from "@/lib/site-url";
@@ -16,7 +16,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }) {
   const { org } = await params;
   const displayName = getProviderDisplayName(org);
-  const count = getAllRecipes().filter((r) => r.hf_org === org).length;
+  const count = getRecipesByOrg(org).length;
   const description = `vLLM serve recipes for ${displayName} models — ${count} recipe${count === 1 ? "" : "s"} with hardware-tuned commands.`;
   const ogUrl = `/og?title=${encodeURIComponent(displayName)}&subtitle=${encodeURIComponent(
     `${count} recipe${count === 1 ? "" : "s"}`
@@ -55,9 +55,12 @@ const TASK_ORDER = ["multimodal", "text", "omni", "embedding"];
 
 export default async function OrgPage({ params }) {
   const { org } = await params;
-  const all = getAllRecipes();
-  const models = all.filter((r) => r.hf_org === org);
+  const models = getRecipesByOrg(org);
   if (models.length === 0) notFound();
+  const canonicalOrg = models[0].hf_org;
+  if (org !== canonicalOrg) {
+    redirect(`/${canonicalOrg}`);
+  }
 
   const logo = getProviderLogo(org);
   const displayName = getProviderDisplayName(org);

--- a/src/lib/recipes.js
+++ b/src/lib/recipes.js
@@ -66,8 +66,13 @@ export function getAllRecipes() {
 }
 
 export function getRecipeByHfId(org, repo) {
-  const all = getAllRecipes();
-  return all.find((r) => r.hf_org === org && r.hf_repo === repo) || null;
+  const o = org.toLowerCase(), r = repo.toLowerCase();
+  return getAllRecipes().find((x) => x.hf_org.toLowerCase() === o && x.hf_repo.toLowerCase() === r) || null;
+}
+
+export function getRecipesByOrg(org) {
+  const o = org.toLowerCase();
+  return getAllRecipes().filter((r) => r.hf_org.toLowerCase() === o);
 }
 
 /**
@@ -79,13 +84,13 @@ export function getRecipeByHfId(org, repo) {
  * parent's own HF id (those are just the base recipe).
  */
 export function findVariantRedirect(org, repo) {
-  const target = `${org}/${repo}`;
+  const target = `${org}/${repo}`.toLowerCase();
   for (const r of getAllRecipes()) {
-    if (r.hf_id === target) return null;
+    if (r.hf_id.toLowerCase() === target) return null;
     const variants = r.variants || {};
     for (const [key, v] of Object.entries(variants)) {
       if (key === "default") continue;
-      if (v?.model_id && v.model_id === target) {
+      if (v?.model_id && v.model_id.toLowerCase() === target) {
         return { parent: r, variantKey: key };
       }
     }


### PR DESCRIPTION
## Summary
- Recipe and org URLs now resolve regardless of casing, matching HuggingFace behavior (e.g. `/thinkingmachines/inkling` → redirects to `/thinkingmachines/Inkling`).

## Test plan
- [x] Visit a recipe URL with wrong casing (e.g. `/thinkingmachines/inkling`) and confirm it 302-redirects to the canonical URL
- [ ] Visit an org URL with wrong casing and confirm redirect
- [ ] Confirm canonical URLs still render directly with no redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)