### PR TITLE
Verify DeepSeek-V4-Flash on MI325X

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -273,11 +273,10 @@ guide: |
     --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
   ```
 
-  ### MI325X single-GPU compatibility path
+  ### MI325X (1×256GB)
 
-  DeepSeek-V4-Flash was validated end-to-end on one 256 GB MI325X with
-  vLLM 0.25.0 and PyTorch HIP 7.2.53211. Use the conservative TP1 eager-mode
-  launch below instead of the MI355X throughput-oriented settings:
+  Validated end-to-end with vLLM 0.25.0 and PyTorch HIP 7.2.53211. Use this
+  conservative TP1 eager-mode launch instead of the MI355X throughput settings:
 
   ```bash
   export VLLM_ROCM_USE_AITER=1
@@ -288,6 +287,7 @@ guide: |
     --tensor-parallel-size 1 \
     --kv-cache-dtype fp8_e4m3 \
     --max-model-len 4096 \
+    --enable-chunked-prefill \
     --max-num-batched-tokens 256 \
     --kv-cache-memory-bytes 10000000000 \
     --distributed-executor-backend mp \
@@ -297,15 +297,11 @@ guide: |
     --enforce-eager
   ```
 
-  This configuration loaded the 148.66 GiB checkpoint, started the API server,
-  and served requests for a 24-hour allocation. It passed model-list and chat
-  completion probes in non-thinking and Think High modes, including arithmetic,
-  time arithmetic, and constrained word counting.
-
-  Only TP1 with a 4K maximum sequence length is verified on MI325X. TP2 and
-  larger tensor-parallel configurations were not validated successfully, and
-  Think Max requires at least 384K context, so it is not available with this
-  compatibility configuration.
+  Chunked prefill allows 4K requests while scheduling at most 256 tokens per
+  batch. This configuration loaded the 148.66 GiB checkpoint and passed model-list
+  and chat probes in non-thinking and Think High modes during a 24-hour allocation.
+  Only TP1 at 4K context is verified; TP2+ did not validate successfully. Think Max
+  requires at least 384K context and is not available with this configuration.
 
   ### MI355X (4×288GB)
 

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "deepseek-v4-flash"
   provider: "DeepSeek"
   description: "DeepSeek V4 MoE model with hybrid CSA+HCA attention, manifold-constrained hyper-connections, and three-tier reasoning (Non-think / Think High / Think Max)."
-  date_updated: 2026-05-01
+  date_updated: 2026-07-16
   difficulty: hard
   tasks:
     - text
@@ -17,7 +17,7 @@ meta:
     gb300: verified
     dgx_station_gb300: verified
     mi300x: unsupported
-    mi325x: unsupported
+    mi325x: verified
     mi355x: verified
 
 model:
@@ -272,6 +272,40 @@ guide: |
     --max-cudagraph-capture-size 128 \
     --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
   ```
+
+  ### MI325X single-GPU compatibility path
+
+  DeepSeek-V4-Flash was validated end-to-end on one 256 GB MI325X with
+  vLLM 0.25.0 and PyTorch HIP 7.2.53211. Use the conservative TP1 eager-mode
+  launch below instead of the MI355X throughput-oriented settings:
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+
+  vllm serve deepseek-ai/DeepSeek-V4-Flash \
+    --host 0.0.0.0 \
+    --port 8002 \
+    --tensor-parallel-size 1 \
+    --kv-cache-dtype fp8_e4m3 \
+    --max-model-len 4096 \
+    --max-num-batched-tokens 256 \
+    --kv-cache-memory-bytes 10000000000 \
+    --distributed-executor-backend mp \
+    --trust-remote-code \
+    --tokenizer-mode deepseek_v4 \
+    --moe-backend triton_unfused \
+    --enforce-eager
+  ```
+
+  This configuration loaded the 148.66 GiB checkpoint, started the API server,
+  and served requests for a 24-hour allocation. It passed model-list and chat
+  completion probes in non-thinking and Think High modes, including arithmetic,
+  time arithmetic, and constrained word counting.
+
+  Only TP1 with a 4K maximum sequence length is verified on MI325X. TP2 and
+  larger tensor-parallel configurations were not validated successfully, and
+  Think Max requires at least 384K context, so it is not available with this
+  compatibility configuration.
 
   ### MI355X (4×288GB)
 


### PR DESCRIPTION
## Summary

- mark AMD Instinct MI325X as verified for `deepseek-ai/DeepSeek-V4-Flash`
- document the exact conservative TP1/eager-mode launch used on a 256 GB MI325X
- record the tested software versions, workload checks, and explicit limits of the validation

## Why

The recipe currently marks MI325X unsupported and only documents the MI355X throughput-oriented launch. DeepSeek-V4-Flash now runs end-to-end on MI325X with vLLM 0.25.0 and PyTorch HIP 7.2.53211, but it needs a materially different compatibility configuration.

The verified launch uses TP1, a 4K maximum model length, a 10 GB manual FP8 KV cache, `triton_unfused` MoE, and eager mode. The guide intentionally does not apply the MI355X TP4/compiled settings to MI325X.

## Validation

Local MI325X serving validation:

- GPU: 1x AMD Instinct MI325X, 256 GB
- vLLM: 0.25.0
- PyTorch HIP: 7.2.53211
- checkpoint: 46 safetensors shards, 148.66 GiB
- server reached application startup and served for a 24-hour allocation
- model-list and chat-completion probes passed
- Think High probes passed for multiplication, time arithmetic, and constrained word counting

Repository validation:

```text
✓ JSON API: 148 models (126 with recommended_command, 648 default-hw alternatives, 1158 per-hw renderings), 127 promoted variants, 8 strategies, 2 kv-store deployments, 2 platforms (1 variant collision skipped)
```

Only TP1 at 4K context is claimed as verified. TP2 and larger tensor-parallel configurations were not validated successfully. Think Max is not available with this 4K compatibility configuration because it requires at least 384K context.
