### PR TITLE
Update the Qwen3.6-27B DGX Spark guide with tuned arguments

### DIFF
--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -11,6 +11,8 @@ meta:
   performance_headline: "Qwen3.6 flagship dense — single-GPU FP8 or 2x GPU BF16"
   related_recipes:
     - "Qwen/Qwen3.6-35B-A3B"
+  hardware:
+    dgx_spark_gb10:
 
 model:
   model_id: "Qwen/Qwen3.6-27B"
@@ -67,6 +69,10 @@ variants:
     extra_args:
       - "--max-num-seqs"
       - "512"
+    hardware_overrides:
+      dgx_spark_gb10:
+        extra_env:
+          VLLM_USE_DEEP_GEMM: "0"
   nvfp4:
     model_id: "nvidia/Qwen3.6-27B-NVFP4"
     precision: nvfp4
@@ -94,6 +100,7 @@ guide: |
   ## Prerequisites
 
   - **vLLM version:** >= 0.17.0
+  - **DGX Spark NVFP4 vLLM version:** >= 0.24.0
   - **Hardware (BF16):** 1x H200 or 2x H100
   - **Hardware (FP8):** single 40 GB GPU (H100/H200/L40S)
   - **Hardware (Int4):** single 24 GB GPU
@@ -141,6 +148,33 @@ guide: |
     --language-model-only \
     --reasoning-parser qwen3 \
     --enable-prefix-caching
+  ```
+
+  ### DGX Spark GB10 NVFP4
+
+  The NVIDIA ModelOpt NVFP4 checkpoint is served from
+  [`nvidia/Qwen3.6-27B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4)
+  and requires vLLM 0.24.0+.
+
+  ```bash
+  # Use container: vllm/vllm-openai:v0.24.0-ubuntu2404
+
+  vllm serve nvidia/Qwen3.6-27B-NVFP4 \
+    --trust-remote-code \
+    --kv-cache-dtype fp8 \
+    --attention-backend flashinfer \
+    --gpu-memory-utilization 0.5 \
+    --max-model-len 262144 \
+    --max-num-seqs 8 \
+    --max-num-batched-tokens 8192 \
+    --enable-chunked-prefill \
+    --async-scheduling \
+    --enable-prefix-caching \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+    --load-format fastsafetensors \
+    --reasoning-parser qwen3 \
+    --tool-call-parser qwen3_xml \
+    --enable-auto-tool-choice
   ```
 
   ### NVFP4 on Blackwell


### PR DESCRIPTION
Add the NVFP4 guide on DGX Spark with arguments for faster model loading, better latency, speculative decoding and optimized memory utilization.