### PR TITLE
[Docs]add default max-model-len in single node

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -477,7 +477,8 @@ guide: |
     --block-size 128 \
     --tool-call-parser minimax_m3 \
     --reasoning-parser minimax_m3 \
-    --enable-auto-tool-choice
+    --enable-auto-tool-choice \
+    --max-model-len 131072
   ```
 
   For best MXFP8 throughput, prefer Blackwell (B200/B300) for native MX tensor cores,

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -113,6 +113,13 @@ variants:
     vram_minimum_gb: 513
     description: "NVIDIA-quantized MXFP8 weights — Blackwell (B200/B300) for native MX tensor cores, and AMD CDNA4 (MI350X/MI355X, gfx950) for native MXFP8 Matrix Cores."
     hardware_overrides:
+      h100:
+        # 8x H100 80GB (640 GB node) fits the ~513 GB MXFP8 weights but not the
+        # full 1M-token KV cache — cap the context to 128K so the engine starts.
+        # H200 (1128 GB node) has the headroom and keeps the full window.
+        extra_args:
+          - "--max-model-len"
+          - "131072"
       mi300x:
         docker_image: "docker pull vllm/vllm-openai-rocm:nightly"
         extra_args:
@@ -477,8 +484,7 @@ guide: |
     --block-size 128 \
     --tool-call-parser minimax_m3 \
     --reasoning-parser minimax_m3 \
-    --enable-auto-tool-choice \
-    --max-model-len 131072
+    --enable-auto-tool-choice
   ```
 
   For best MXFP8 throughput, prefer Blackwell (B200/B300) for native MX tensor cores,


### PR DESCRIPTION
In single 8*H100 80GB node, canot use default max-model-len, because gpu memory not enough, so set `128k` as max-model-len.


If not set start faild.
```
ValueError: To serve at least one request with the model's max seq len (1048576), (44.25 GiB KV cache is needed, which is larger than the available KV cache memory (8.42 GiB). Based on the available memory, the estimated maximum model length is 199552. Try increasing gpu_memory_utilization (which also controls CPU memory on the CPU backend) or decreasing max_model_len when initializing the engine. See https://docs.vllm.ai/en/latest/configuration/conserving_memory/ for more details.
```