### PR TITLE
[ROCm] Document AITER MXFP4 MoE backend in MiniMax-M3 MI355X reproduction

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -642,21 +642,34 @@ guide: |
   configuration — not the recipe default. To reproduce that sweep, start from the
   default command above and apply these deltas: use `--tensor-parallel-size 4`
   (the sweep runs TP4; the default recipe keeps TP8 for KV-cache and
-  multimodal-encoder headroom), add `--kv-cache-dtype fp8`, run on a current
-  `vllm/vllm-openai-rocm:nightly` (the lane pins a specific nightly build — don't
-  hard-code a transient tag), and export INT4 quantized all-reduce before launch:
+  multimodal-encoder headroom), add `--kv-cache-dtype fp8`, force the AITER MXFP4
+  MoE backend with `--moe-backend aiter` plus the AITER MoE env vars below, run on
+  a current `vllm/vllm-openai-rocm:nightly` (the lane pins a specific nightly
+  build — don't hard-code a transient tag), and export INT4 quantized all-reduce
+  before launch:
 
   ```bash
+  # Kernel selection — required to match the benchmarked MoE path.
+  # Without these (and `--moe-backend aiter` on the serve command), vLLM's MXFP4
+  # MoE oracle selects the TRITON_UNFUSED fallback on gfx950 instead of the
+  # AITER_MXFP4_MXFP4 kernel the InferenceX lane actually runs.
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_USE_AITER_MOE=1
+  export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+
   # Benchmark-only — accuracy-sensitive; NOT part of the default command.
   export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
   export VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0
   export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256
   ```
 
-  The INT4 all-reduce and fp8 KV-cache levers are throughput optimizations for
-  high concurrency and are **kept out of the default command pending accuracy
-  validation**. Performance figures on the InferenceX dashboard are **reported
-  externally by SemiAnalysis and have not been reproduced in this repository.**
+  Then add `--moe-backend aiter` to the serve command. Selecting the AITER MXFP4
+  MoE backend is a kernel-selection choice (same MXFP4 math, faster kernel), not a
+  precision reduction. The INT4 all-reduce and fp8 KV-cache levers are throughput
+  optimizations for high concurrency and are **kept out of the default command
+  pending accuracy validation**. Performance figures on the InferenceX dashboard
+  are **reported externally by SemiAnalysis and have not been reproduced in this
+  repository.**
 
   ## Troubleshooting
 

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -663,9 +663,26 @@ guide: |
   export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256
   ```
 
-  Then add `--moe-backend aiter` to the serve command. Selecting the AITER MXFP4
-  MoE backend is a kernel-selection choice (same MXFP4 math, faster kernel), not a
-  precision reduction. The INT4 all-reduce and fp8 KV-cache levers are throughput
+  The full reproduction serve command is then:
+
+  ```bash
+  vllm serve amd/MiniMax-M3-MXFP4 \
+    --tensor-parallel-size 4 \
+    --trust-remote-code \
+    --block-size 128 \
+    --attention-backend TRITON_ATTN \
+    --moe-backend aiter \
+    --kv-cache-dtype fp8 \
+    --mm-encoder-tp-mode data \
+    --mm-encoder-attn-backend ROCM_AITER_FA \
+    --tool-call-parser minimax_m3 \
+    --enable-auto-tool-choice \
+    --reasoning-parser minimax_m3
+  ```
+
+  Selecting the AITER MXFP4 MoE backend (`--moe-backend aiter`) is a
+  kernel-selection choice (same MXFP4 math, faster kernel), not a precision
+  reduction. The INT4 all-reduce and fp8 KV-cache levers are throughput
   optimizations for high concurrency and are **kept out of the default command
   pending accuracy validation**. Performance figures on the InferenceX dashboard
   are **reported externally by SemiAnalysis and have not been reproduced in this

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -640,13 +640,16 @@ guide: |
   [SemiAnalysis InferenceX](https://inferencex.semianalysis.com/) MI355X
   benchmark lane for this checkpoint is a separate **high-concurrency benchmark**
   configuration — not the recipe default. To reproduce that sweep, start from the
-  default command above and apply these deltas: use `--tensor-parallel-size 4`
-  (the sweep runs TP4; the default recipe keeps TP8 for KV-cache and
-  multimodal-encoder headroom), add `--kv-cache-dtype fp8`, force the AITER MXFP4
-  MoE backend with `--moe-backend aiter` plus the AITER MoE env vars below, run on
-  a current `vllm/vllm-openai-rocm:nightly` (the lane pins a specific nightly
-  build — don't hard-code a transient tag), and export INT4 quantized all-reduce
-  before launch:
+  default command above and apply these deltas:
+
+  - Use `--tensor-parallel-size 4` (the sweep runs TP4; the default recipe keeps
+    TP8 for KV-cache and multimodal-encoder headroom).
+  - Add `--kv-cache-dtype fp8`.
+  - Force the AITER MXFP4 MoE backend with `--moe-backend aiter` plus the AITER
+    MoE env vars below.
+  - Run on a current `vllm/vllm-openai-rocm:nightly` (the lane pins a specific
+    nightly build — don't hard-code a transient tag).
+  - Export INT4 quantized all-reduce before launch:
 
   ```bash
   # Kernel selection — required to match the benchmarked MoE path.


### PR DESCRIPTION
## Summary

The MiniMax-M3 MXFP4 (MI355X) **benchmark reproduction** section documents TP4, `--kv-cache-dtype fp8`, and INT4 quantized all-reduce, but omits the AITER MoE kernel-selection knobs that the [SemiAnalysis InferenceX](https://inferencex.semianalysis.com/) MI355X lane actually runs with:

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
# plus --moe-backend aiter on the serve command
```

Without these, vLLM's MXFP4 MoE oracle selects the `TRITON_UNFUSED` fallback on gfx950 instead of the `AITER_MXFP4_MXFP4` kernel the lane benchmarks — a materially different (slower) kernel profile — so following the published recipe does **not** reproduce the benchmarked configuration.

This PR adds the AITER MoE enablement to the MXFP4 reproduction section and clarifies that AITER MoE is a kernel-selection choice (same MXFP4 math, faster kernel), distinct from the accuracy-sensitive INT4 all-reduce / fp8 KV levers that are intentionally kept out of the default command.

## Context

Follow-up to the merged #635, which documented the InferenceX MXFP4 lane but left the AITER MoE kernel selection undocumented. Docs-only change to `models/MiniMaxAI/MiniMax-M3.yaml`; the structured default command is unchanged.

## Test plan

- [x] `models/MiniMaxAI/MiniMax-M3.yaml` still parses as YAML.
- [x] The flags match the InferenceX launcher (`benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh`): `VLLM_ROCM_USE_AITER`, `VLLM_ROCM_USE_AITER_MOE`, `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS`, `--moe-backend aiter`.

Made with [Cursor](https://cursor.com)