### PR TITLE
[ROCm] Add tuned AITER MXFP4 MoE config for Kimi-K2.5 on MI355X

### DIFF
--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -283,6 +283,50 @@ guide: |
     --max-num-batched-tokens 32768 --max-num-seqs 512`. These are
     throughput-sweep tunings; leave vLLM's defaults for general serving.
 
+  #### Tuned AITER MXFP4 MoE (MI355X)
+
+  For higher MoE throughput on MI355X, run the AITER MXFP4 (RadeonFlow)
+  intermediate GEMM path with fused shared experts. This requires a
+  `vllm/vllm-openai-rocm:nightly` built after vLLM
+  [#48683](https://github.com/vllm-project/vllm/pull/48683) (AITER `v0.1.16.post5`,
+  which includes the [ROCm/aiter#3832](https://github.com/ROCm/aiter/pull/3832)
+  gfx950 MXFP4 MoE backend). Export the AITER MoE kernel-selection vars and add the
+  batching/scheduling flags below. `AITER_MXFP4_INTERMEDIATE=1` is what selects the
+  RadeonFlow MXFP4 intermediate path — without it (and `VLLM_ROCM_USE_AITER=1`) the
+  MoE oracle falls back to a different kernel. Runs at TP4 or TP8; for **TP < 8**
+  disable AITER RMSNorm.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+  export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+  export VLLM_ROCM_USE_SKINNY_GEMM=0
+  export AITER_MXFP4_INTERMEDIATE=1
+  export AITER_BYPASS_TUNE_CONFIG=0
+  export AITER_MOE_SORT_BACKEND=auto
+  export OMP_NUM_THREADS=1
+  # TP < 8 only:
+  export VLLM_ROCM_USE_AITER_RMSNORM=0
+
+  vllm serve amd/Kimi-K2.5-MXFP4 \
+    --tensor-parallel-size 4 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.90 \
+    --kv-cache-dtype fp8 \
+    --block-size 16 \
+    --async-scheduling \
+    --no-enable-prefix-caching \
+    --mm-encoder-tp-mode data
+  ```
+
+  These AITER MXFP4 MoE env vars are kernel-selection choices (same MXFP4 math,
+  faster kernel), not precision reductions.
+
+  For fixed-length throughput sweeping, additionally cap `--max-model-len` to the
+  working sequence length (e.g. `9472` for an 8k/1k workload) and set
+  `--max-num-batched-tokens 16384 --max-num-seqs 512`. Leave these off for general
+  serving.
+
   ## Client Usage
 
   Once the vLLM server is running, consume it via the OpenAI-compatible API:


### PR DESCRIPTION
## Summary

The Kimi-K2.5 MXFP4 (MI355X) section of `models/moonshotai/Kimi-K2.5.yaml` (added in #650) documents the base AITER MXFP4 path + fp8 KV cache. This PR adds a **"Tuned AITER MXFP4 MoE (MI355X)"** subsection covering the higher-throughput MoE configuration on gfx950: the AITER MXFP4 (RadeonFlow) intermediate GEMM path with fused shared experts.

Kernel-selection env vars:

```bash
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
export VLLM_ROCM_USE_SKINNY_GEMM=0
export AITER_MXFP4_INTERMEDIATE=1   # selects the RadeonFlow MXFP4 intermediate GEMM path
export AITER_BYPASS_TUNE_CONFIG=0
export AITER_MOE_SORT_BACKEND=auto
# TP < 8 only:
export VLLM_ROCM_USE_AITER_RMSNORM=0
```

plus batching/scheduling flags (`--block-size 16 --max-num-batched-tokens 16384 --max-num-seqs 512 --async-scheduling --no-enable-prefix-caching`). Runs at TP4 or TP8.

`AITER_MXFP4_INTERMEDIATE=1` selects the RadeonFlow MXFP4 intermediate path — without it (and `VLLM_ROCM_USE_AITER=1`) the MoE oracle falls back to a different kernel. These env vars are kernel-selection choices (same MXFP4 math, faster kernel), not precision reductions.

Requires a `vllm/vllm-openai-rocm:nightly` built after vLLM #48683 (AITER `v0.1.16.post5`, which includes ROCm/aiter#3832).

## Context

Docs-only update to the existing recipe (follow-up to #650); the structured default command is unchanged. Distinct from #296, which edits the deprecated `moonshotai/Kimi-K2.5.md`.

## Test plan

- [x] `models/moonshotai/Kimi-K2.5.yaml` still parses as YAML.
- [x] The env vars / flags match the deployed AMD MXFP4 MI355X configuration.
