### PR TITLE
Add MI325X recipe for Laguna S 2.1

### DIFF
--- a/models/poolside/Laguna-S-2.1.yaml
+++ b/models/poolside/Laguna-S-2.1.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Poolside"
   description: "Poolside's 118B total / 8B activated MoE coding model with mixed sliding-window + global attention, native interleaved reasoning, and 256K context — the larger sibling of Laguna XS-2.1, tuned for agentic coding."
   date_added: 2026-07-21
-  date_updated: 2026-07-21
+  date_updated: 2026-07-22
   difficulty: intermediate
   tasks:
     - text
@@ -14,6 +14,7 @@ meta:
     - "poolside/Laguna-M.1"
   hardware:
     h200: verified
+    mi325x: verified
 
 model:
   model_id: "poolside/Laguna-S-2.1"
@@ -54,6 +55,13 @@ variants:
     precision: bf16
     vram_minimum_gb: 282
     description: "BF16 weights (~235GB) — needs a multi-GPU node (≥2× H200/B200, or a full HGX node)"
+    hardware_overrides:
+      mi325x:
+        docker_image: "vllm/vllm-openai-rocm:nightly-387189c42997b27e2c04b5d97ef8190ffa2bf909"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
+          VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
   fp8:
     model_id: "poolside/Laguna-S-2.1-FP8"
     precision: fp8
@@ -158,6 +166,21 @@ guide: |
     --enable-auto-tool-choice \
     --tool-call-parser poolside_v1 \
     --reasoning-parser poolside_v1
+  ```
+
+  ### AMD ROCm — 8× MI325X (BF16, TP8)
+  ```bash
+  VLLM_ROCM_USE_AITER=1 \
+  VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 \
+  VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
+  vllm serve poolside/Laguna-S-2.1 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --max-model-len 262144 \
+    --enable-auto-tool-choice \
+    --tool-call-parser poolside_v1 \
+    --reasoning-parser poolside_v1 \
+    --default-chat-template-kwargs '{"enable_thinking":true}'
   ```
 
   ### Single GPU (INT4 on H200, or NVFP4 on B200)

--- a/models/poolside/Laguna-S-2.1.yaml
+++ b/models/poolside/Laguna-S-2.1.yaml
@@ -69,6 +69,14 @@ variants:
     description: "Block-FP8 weights + FP8 KV cache (~121GB) — a hair over one 141GB H200, so TP2 (or a single 268GB B300)"
     extra_env:
       VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: "0"
+    hardware_overrides:
+      mi325x:
+        docker_image: "vllm/vllm-openai-rocm:nightly-387189c42997b27e2c04b5d97ef8190ffa2bf909"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "0"
+          VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
+          VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
   nvfp4:
     model_id: "poolside/Laguna-S-2.1-NVFP4"
     precision: nvfp4
@@ -182,6 +190,25 @@ guide: |
     --reasoning-parser poolside_v1 \
     --default-chat-template-kwargs '{"enable_thinking":true}'
   ```
+
+  ### AMD ROCm — 8× MI325X (FP8, TP8)
+  ```bash
+  VLLM_ROCM_USE_AITER=1 \
+  VLLM_ROCM_USE_AITER_MOE=0 \
+  VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 \
+  VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
+  vllm serve poolside/Laguna-S-2.1-FP8 \
+    --trust-remote-code \
+    --tensor-parallel-size 8 \
+    --max-model-len 262144 \
+    --enable-auto-tool-choice \
+    --tool-call-parser poolside_v1 \
+    --reasoning-parser poolside_v1 \
+    --default-chat-template-kwargs '{"enable_thinking":true}'
+  ```
+
+  For FP8 on MI325X, disable AITER MoE because its blockscale kernel currently
+  corrupts logits. Other AITER operators remain enabled; vLLM uses Triton MoE.
 
   ### Single GPU (INT4 on H200, or NVFP4 on B200)
   ```bash

--- a/models/poolside/Laguna-S-2.1.yaml
+++ b/models/poolside/Laguna-S-2.1.yaml
@@ -57,7 +57,6 @@ variants:
     description: "BF16 weights (~235GB) — needs a multi-GPU node (≥2× H200/B200, or a full HGX node)"
     hardware_overrides:
       mi325x:
-        docker_image: "vllm/vllm-openai-rocm:nightly-387189c42997b27e2c04b5d97ef8190ffa2bf909"
         extra_env:
           VLLM_ROCM_USE_AITER: "1"
           VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
@@ -71,7 +70,6 @@ variants:
       VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: "0"
     hardware_overrides:
       mi325x:
-        docker_image: "vllm/vllm-openai-rocm:nightly-387189c42997b27e2c04b5d97ef8190ffa2bf909"
         extra_env:
           VLLM_ROCM_USE_AITER: "1"
           VLLM_ROCM_USE_AITER_MOE: "0"
@@ -176,39 +174,11 @@ guide: |
     --reasoning-parser poolside_v1
   ```
 
-  ### AMD ROCm — 8× MI325X (BF16, TP8)
-  ```bash
-  VLLM_ROCM_USE_AITER=1 \
-  VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 \
-  VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
-  vllm serve poolside/Laguna-S-2.1 \
-    --trust-remote-code \
-    --tensor-parallel-size 8 \
-    --max-model-len 262144 \
-    --enable-auto-tool-choice \
-    --tool-call-parser poolside_v1 \
-    --reasoning-parser poolside_v1 \
-    --default-chat-template-kwargs '{"enable_thinking":true}'
-  ```
+  ### AMD ROCm — 8× MI325X
 
-  ### AMD ROCm — 8× MI325X (FP8, TP8)
-  ```bash
-  VLLM_ROCM_USE_AITER=1 \
-  VLLM_ROCM_USE_AITER_MOE=0 \
-  VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 \
-  VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
-  vllm serve poolside/Laguna-S-2.1-FP8 \
-    --trust-remote-code \
-    --tensor-parallel-size 8 \
-    --max-model-len 262144 \
-    --enable-auto-tool-choice \
-    --tool-call-parser poolside_v1 \
-    --reasoning-parser poolside_v1 \
-    --default-chat-template-kwargs '{"enable_thinking":true}'
-  ```
-
-  For FP8 on MI325X, disable AITER MoE because its blockscale kernel currently
-  corrupts logits. Other AITER operators remain enabled; vLLM uses Triton MoE.
+  For FP8, the MI325X override disables AITER MoE because its blockscale kernel
+  currently corrupts logits; other AITER operators remain enabled, while vLLM
+  uses Triton MoE.
 
   ### Single GPU (INT4 on H200, or NVFP4 on B200)
   ```bash


### PR DESCRIPTION
## Validation
- Hardware: 8× AMD MI325X (`gfx942`)
- ROCm: 7.2
- vLLM image: `vllm/vllm-openai-rocm:nightly-387189c42997b27e2c04b5d97ef8190ffa2bf909`
- Chat-completion smoke test passed.
- `node scripts/build-recipes-api.mjs` passed with 149 models.