### PR TITLE
Remove redundant CUDA attention backend overrides

### DIFF
--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -187,7 +187,7 @@ guide: |
   For H200 FP8, choose the attention backend by sequence length for best performance:
   shorter sequences (e.g. 1024) should keep the command above with `--attention-backend FLASHINFER`
   and `--enable-flashinfer-autotune`, while longer input sequences (e.g. 8192)
-  can prefer FlashAttention by replacing those flags with `--attention-backend FLASH_ATTN`.
+  should remove those flags to use the auto-selected FlashAttention backend.
 
   Pure TP8 is not supported. For >4 GPUs use DP+EP or TP+EP.
 

--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -171,7 +171,6 @@ guide: |
   vllm serve nvidia/Qwen3.6-27B-NVFP4 \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
     --gpu-memory-utilization 0.5 \
     --max-model-len 262144 \
     --max-num-seqs 8 \
@@ -198,7 +197,6 @@ guide: |
   vllm serve nvidia/Qwen3.6-27B-NVFP4 \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
     --gpu-memory-utilization 0.9 \
     --max-model-len 262144 \
     --max-num-seqs 8 \

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -90,8 +90,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-      - "--attention-backend"
-      - "flashinfer"
       - "--moe-backend"
       - "marlin"
       - "--enable-prefix-caching"
@@ -188,7 +186,6 @@ guide: |
   vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
     --moe-backend marlin \
     --gpu-memory-utilization 0.5 \
     --max-model-len 262144 \
@@ -217,7 +214,6 @@ guide: |
     --tensor-parallel-size 1 \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
     --moe-backend marlin \
     --gpu-memory-utilization 0.9 \
     --max-model-len 262144 \

--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -204,7 +204,6 @@ guide: |
       --max-model-len 262144 \
       --gpu-memory-utilization 0.92 \
       --max-num-seqs 8 \
-      --attention-backend flashinfer \
       --max-num-batched-tokens 16384 \
       --kv-cache-dtype fp8 \
       --mamba-cache-mode align \


### PR DESCRIPTION
## Summary

These manual overrides match what the automatic selector would pick by default. Remove the overrides.

## Testing

- `node scripts/build-recipes-api.mjs`