### PR TITLE
[ROCm] Document MiniMax-M3 MXFP4 MI355X benchmark reproduction

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -645,6 +645,8 @@ guide: |
   - Use `--tensor-parallel-size 4` (the sweep runs TP4; the default recipe keeps
     TP8 for KV-cache and multimodal-encoder headroom).
   - Add `--kv-cache-dtype fp8`.
+  - Use the text-only language-model path with `--no-enable-prefix-caching`,
+    `--language-model-only`, and an explicit `--max-model-len`.
   - Force the AITER MXFP4 MoE backend with `--moe-backend aiter` plus the AITER
     MoE env vars below.
   - Run on a current `vllm/vllm-openai-rocm:nightly` (the lane pins a specific
@@ -656,6 +658,8 @@ guide: |
   # Without these (and `--moe-backend aiter` on the serve command), vLLM's MXFP4
   # MoE oracle selects the TRITON_UNFUSED fallback on gfx950 instead of the
   # AITER_MXFP4_MXFP4 kernel the InferenceX lane actually runs.
+  export VLLM_ENGINE_READY_TIMEOUT_S=3600
+  export VLLM_USE_BREAKABLE_CUDAGRAPH=0
   export VLLM_ROCM_USE_AITER=1
   export VLLM_ROCM_USE_AITER_MOE=1
   export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
@@ -670,14 +674,16 @@ guide: |
 
   ```bash
   vllm serve amd/MiniMax-M3-MXFP4 \
+    --port "${PORT:-8000}" \
     --tensor-parallel-size 4 \
     --trust-remote-code \
     --block-size 128 \
+    --no-enable-prefix-caching \
+    --language-model-only \
+    --max-model-len "$MAX_MODEL_LEN" \
     --attention-backend TRITON_ATTN \
     --moe-backend aiter \
     --kv-cache-dtype fp8 \
-    --mm-encoder-tp-mode data \
-    --mm-encoder-attn-backend ROCM_AITER_FA \
     --tool-call-parser minimax_m3 \
     --enable-auto-tool-choice \
     --reasoning-parser minimax_m3


### PR DESCRIPTION
## Summary
- Align the MiniMax-M3 MXFP4 MI355X benchmark reproduction section with SemiAnalysisAI/InferenceX PR #2104.
- Add the PR #2104 runtime exports for engine timeout and breakable cudagraph handling.
- Update the reproduction serve command to use the text-only benchmark path, explicit `--max-model-len`, `--no-enable-prefix-caching`, and remove multimodal encoder flags from this benchmark-specific command.

## Test plan
- `python` YAML parse and top-level schema-order check for `models/MiniMaxAI/MiniMax-M3.yaml`
- `git diff --check -- models/MiniMaxAI/MiniMax-M3.yaml`
- `node scripts/build-recipes-api.mjs`