### PR TITLE
docs(google/gemma-4-31b-it): document compact JSON workaround

### DIFF
--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "gemma-4-31b-it"
   provider: "Google"
   description: "Google's unified multimodal Gemma 4 dense model (31B) with native text, image, and audio, plus thinking mode and tool-use protocol."
-  date_updated: 2026-05-11
+  date_updated: 2026-07-24
   difficulty: intermediate
   tasks:
     - multimodal
@@ -287,6 +287,12 @@ guide: |
 
   ### Structured Outputs
   vLLM guided decoding constrains output to a JSON schema. Include semantic instructions in the system prompt — the model does not see schema descriptions.
+
+  Gemma 4 31B can enter a grammar-valid whitespace loop after producing a valid JSON prefix, eventually reaching `max_tokens` with `finish_reason="length"`. If you observe this failure mode, add the following option to your existing server launch command to enable compact xgrammar JSON:
+  ```bash
+  --structured-outputs-config '{"backend":"xgrammar","disable_any_whitespace":true}'
+  ```
+  This disables optional whitespace between JSON tokens; it does not remove whitespace inside string values. See [vLLM #40080](https://github.com/vllm-project/vllm/issues/40080) for background.
 
   ## Configuration Tips
 


### PR DESCRIPTION
<html><head></head><body><h2><span>Summary</span></h2><ul><li><p><span>document the grammar-valid whitespace-loop symptom for Gemma 4 31B JSON Schema output</span></p></li><li><p><span>add the existing compact-xgrammar mitigation to the canonical model recipe</span></p></li><li><p><span>clarify that the setting removes optional whitespace between JSON tokens, not whitespace inside string values</span></p></li></ul><p><span>Related to vllm-project/vllm#40080.</span></p><h2><span>Why</span></h2><p><span>The current Gemma 4 31B recipe mentions structured outputs but does not document a known failure mode where the model produces a valid JSON prefix and then emits optional whitespace until </span><code><span>max_tokens</span></code><span>.</span></p><p><span>I revalidated the behavior with the same request body across both server configurations:</span></p><ul><li><p><span>Model: </span><code><span>google/gemma-4-31B-it</span></code></p></li><li><p><span>Revision: </span><code><span>842da3794eaa0b77d5f08bae87a17459d91ff475</span></code></p></li><li><p><span>vLLM: </span><code><span>0.25.1</span></code></p></li><li><p><span>Transformers: </span><code><span>5.13.1</span></code></p></li><li><p><span>xgrammar: </span><code><span>0.2.3</span></code></p></li><li><p><span>CUDA / GPU: CUDA 13.0 / NVIDIA B200</span></p></li><li><p><span>Precision: BF16, TP=1</span></p></li></ul>
Server structured-output configuration | Runs | Result
-- | -- | --
default (backend=auto, whitespace allowed) | 3/3 | finish_reason=length, 8,000 completion tokens, invalid/incomplete JSON, 93.6555% whitespace
backend=xgrammar, disable_any_whitespace=true | 3/3 | finish_reason=stop, 368 completion tokens, valid JSON Schema output

<p><span>The prompt, JSON Schema, request body, sampling parameters, model snapshot, and runtime were held constant. The mitigation is documented conditionally rather than changing the recipe's default server arguments.</span></p><h2><span>Validation</span></h2><ul><li><p><span>YAML parses successfully with </span><code><span>js-yaml</span></code></p></li><li><p><span>Markdown fences in the rendered </span><code><span>guide</span></code><span> are balanced</span></p></li><li><p><code><span>git diff --check</span></code><span> passes</span></p></li><li><p><span>the repository API validator was also attempted; current </span><code><span>main</span></code><span> fails first on an unrelated pre-existing </span><code><span>models/zai-org/GLM-5.2.yaml</span></code><span> feature-mode validation error</span></p></li></ul></body></html>