### PR TITLE
[ROCm] Add Kimi-K2.5 AMD AITER MoE env vars

### DIFF
--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -130,6 +130,8 @@ hardware_overrides:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
+      VLLM_ROCM_USE_AITER_MOE: "1"
+      VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
       VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
 
 strategy_overrides:

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -103,6 +103,9 @@ variants:
       # TP comm overhead on the encoder.
       - "--mm-encoder-tp-mode"
       - "data"
+    extra_env:
+      VLLM_ROCM_USE_AITER_MOE: "1"
+      VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
     # AITER RMSNorm is left at its default (on when AITER is enabled): a local
     # TP4 GSM8K check measured identical accuracy on vs off (0.9697), so there is
     # no reason to disable it the way the single-node TP<8 guard used to.
@@ -130,8 +133,6 @@ hardware_overrides:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
-      VLLM_ROCM_USE_AITER_MOE: "1"
-      VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
       VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: "INT4"
 
 strategy_overrides:


### PR DESCRIPTION
## Summary
- Add `VLLM_ROCM_USE_AITER_MOE=1` to the AMD Kimi-K2.5 hardware override.
- Add `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` to match the benchmark reproduction path documented in PR #673.

## Test plan
- `python` YAML parse and top-level schema-order check for `models/moonshotai/Kimi-K2.5.yaml`
- `git diff --check -- models/moonshotai/Kimi-K2.5.yaml`
- `ReadLints` on `models/moonshotai/Kimi-K2.5.yaml`

