### PR TITLE
[ROCm] Add MiniMax-M3 AMD AITER MoE env vars

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -199,6 +199,8 @@ hardware_overrides:
       # Run MiniMax-M3 with CUDA graphs on AMD MI3xx; avoids the decode
       # breakable-cudagraph path that otherwise forces eager (per @hongxiayang).
       VLLM_USE_BREAKABLE_CUDAGRAPH: "0"
+      VLLM_ROCM_USE_AITER_MOE: "1"
+      VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
 
 guide: |
   ## Overview


### PR DESCRIPTION
## Summary
- Add `VLLM_ROCM_USE_AITER_MOE=1` to the AMD MiniMax-M3 hardware override.
- Add `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` so the production command builder includes the ROCm AITER shared-experts path noted after PR #672.

## Test plan
- `python` YAML parse and AMD extra_env assertion for `models/MiniMaxAI/MiniMax-M3.yaml`
- `git diff --check -- models/MiniMaxAI/MiniMax-M3.yaml`
- `ReadLints` on `models/MiniMaxAI/MiniMax-M3.yaml`

Follow-up to #672.