### PR TITLE
Minimax M3 disagg

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -200,6 +200,18 @@ hardware_overrides:
       # breakable-cudagraph path that otherwise forces eager (per @hongxiayang).
       VLLM_USE_BREAKABLE_CUDAGRAPH: "0"
 
+strategy_overrides:
+  pd_cluster:
+    hardware_overrides:
+      blackwell:
+        extra_args:
+          - "--attention_config.backend"
+          - "FLASHINFER"
+          - "--attention_config.use_trtllm_attention"
+          - "true"
+          - "--attention_config.indexer_kv_dtype"
+          - "fp8"
+
 guide: |
   ## Overview
 

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -204,8 +204,6 @@ strategy_overrides:
   pd_cluster:
     hardware_overrides:
       blackwell:
-        # Validated by InferenceX disagg sweeps: #2230 (B200), #2310 (B300),
-        # #2338 (B300 MXFP8), #2339 (GB200 MXFP8), #2340 (GB300 MXFP8).
         extra_args:
           - "--attention_config.backend"
           - "FLASHINFER"

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -204,6 +204,8 @@ strategy_overrides:
   pd_cluster:
     hardware_overrides:
       blackwell:
+        # Validated by InferenceX disagg sweeps: #2230 (B200), #2310 (B300),
+        # #2338 (B300 MXFP8), #2339 (GB200 MXFP8), #2340 (GB300 MXFP8).
         extra_args:
           - "--attention_config.backend"
           - "FLASHINFER"


### PR DESCRIPTION
Set backend FLASHINFER, use_trtllm_attention, and indexer_kv_dtype fp8 in the attention config for MiniMax-M3 pd_cluster (disaggregated P/D) serving on Blackwell (B200/B300/GB200/GB300). Based on https://github.com/SemiAnalysisAI/InferenceX/pull/2230, https://github.com/SemiAnalysisAI/InferenceX/pull/2310, https://github.com/SemiAnalysisAI/InferenceX/pull/2338, https://github.com/SemiAnalysisAI/InferenceX/pull/2339, and https://github.com/SemiAnalysisAI/InferenceX/pull/2340.