### PR TITLE
add missing  Kimi-K3@B300 PD  attention config for `TRTLLM_RAGGED` for Prefill

### DIFF
--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -186,12 +186,18 @@ strategy_overrides:
     hardware_overrides:
       blackwell:
         extra_args:
+          - "--max-model-len"
+          - "1000000"
           - "--kv-cache-dtype"
           - "fp8"
           - "--attention-config"
           - '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}'
         extra_env:
           VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION: "1"
+          VLLM_ALLREDUCE_USE_FLASHINFER: "1"
+          VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+          VLLM_USE_V2_MODEL_RUNNER: "1"
+          VLLM_USE_RUST_FRONTEND: "1"
           UCX_TLS: "rc,cuda_copy"
     prefill:
       parallelism: tep

--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -185,6 +185,11 @@ strategy_overrides:
     # Blackwell only (cuda_copy is CUDA-only); replaces the recipe-level nvidia block.
     hardware_overrides:
       blackwell:
+        extra_args:
+          - "--kv-cache-dtype"
+          - "fp8"
+          - "--attention-config"
+          - '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}'
         extra_env:
           VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION: "1"
           UCX_TLS: "rc,cuda_copy"

--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -186,18 +186,10 @@ strategy_overrides:
     hardware_overrides:
       blackwell:
         extra_args:
-          - "--max-model-len"
-          - "1000000"
-          - "--kv-cache-dtype"
-          - "fp8"
           - "--attention-config"
-          - '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}'
+          - '{"mla_prefill_backend":"TRTLLM_RAGGED"}'
         extra_env:
           VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION: "1"
-          VLLM_ALLREDUCE_USE_FLASHINFER: "1"
-          VLLM_ENGINE_READY_TIMEOUT_S: "3600"
-          VLLM_USE_V2_MODEL_RUNNER: "1"
-          VLLM_USE_RUST_FRONTEND: "1"
           UCX_TLS: "rc,cuda_copy"
     prefill:
       parallelism: tep


### PR DESCRIPTION
## Summary

Select the `TRTLLM_RAGGED` MLA prefill backend for Kimi-K3's Blackwell PD profile.

This PR intentionally does not enable FP8 KV cache or prefill-query quantization, and does not copy the remaining aggregated Blackwell tuning into PD. Those choices need separate PD hardware validation. The role-specific prefill/decode batching and prefix-cache settings remain unchanged.

## Root cause

#689 added `TRTLLM_RAGGED` to the recipe-level Blackwell override. Kimi-K3's `pd_cluster` Blackwell override predates that change, and command synthesis treats a strategy hardware override as a full replacement of the recipe-level block. The PD profile therefore does not inherit the selected MLA prefill backend.

This is not a duplicate of an open PR. Searches for `Kimi-K3 PD`, `Kimi K3 attention config`, `TRTLLM_RAGGED`, and `kv-cache-dtype K3` found no open PR addressing this PD profile. #688 adds a separate RedHatAI checkpoint recipe, while #690 changed the minimum vLLM version and a shared PD environment variable.

## Validation

- `node scripts/build-recipes-api.mjs` — passed: 150 models, 1180 per-hardware renderings
- Direct `resolveCommand` assertions for B300 PD — passed: the generated attention config contains only `mla_prefill_backend=TRTLLM_RAGGED`; no FP8 KV/query-quantization settings are introduced; prefill keeps `max-num-batched-tokens=16384`; decode keeps `max-num-batched-tokens=32` and `--no-enable-prefix-caching`
- `git diff --check` — passed
- `pnpm validate` — unavailable on current `main`: `package.json` references the absent `hooks/validate.mjs`

Hardware/model evaluation was not run because Kimi-K3 weights plus a multi-node B300 environment are unavailable locally.

## AI assistance

AI assistance (OpenAI Codex) was used to trace command-synthesis precedence, prepare the patch, and run the checks. The human submitter must review every changed line and validate on the target hardware.
