### PR TITLE
Add Intel XPU(B60, B70) deployment recipe for 4 models

### DIFF
--- a/models/Qwen/Qwen3-32B.yaml
+++ b/models/Qwen/Qwen3-32B.yaml
@@ -14,6 +14,8 @@ meta:
   hardware:
     trillium: verified
     ironwood: verified
+    arc_pro_b60: verified
+    arc_pro_b70: verified
 
 model:
   model_id: "Qwen/Qwen3-32B"
@@ -67,7 +69,11 @@ kv_offload_support:
   offloading_cpu: verified
   offloading_fs: verified
 
-hardware_overrides: {}
+hardware_overrides:
+  xpu:
+    extra_args:
+      - "--gpu-memory-utilization"
+      - "0.90"
 
 strategy_overrides: {}
 
@@ -92,6 +98,12 @@ guide: |
   ```bash
   export HF_HOME=/dev/shm
   export HF_TOKEN=<your HF token>
+  ```
+
+  ### Intel XPU (B60 / B70)
+  Use the official vLLM XPU image.
+  ```bash
+  docker pull vllm/vllm-openai-xpu:latest
   ```
 
   ## Deployment Configurations
@@ -143,6 +155,23 @@ guide: |
     --host 0.0.0.0 \
     --port 8000 \
     --tensor-parallel-size 2
+  ```
+
+  ### Intel XPU (B60, B70)
+
+  Validated on 4× Intel Arc Pro B60 / B70 (Battlemage; B60 24 GB, B70 32 GB per card) with the
+  official vLLM XPU image `vllm/vllm-openai-xpu:latest`.
+
+  ```bash
+  docker run --device /dev/dri \
+    -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --entrypoint bash vllm/vllm-openai-xpu:latest \
+    -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve Qwen/Qwen3-32B \
+    --gpu-memory-utilization 0.90 \
+    --tensor-parallel-size 4 \
+    --dtype float16 --max-model-len 8192"
   ```
 
   ## Configuration Tips

--- a/models/Qwen/Qwen3-32B.yaml
+++ b/models/Qwen/Qwen3-32B.yaml
@@ -159,7 +159,7 @@ guide: |
 
   ### Intel XPU (B60, B70)
 
-  Validated on 4× Intel Arc Pro B60 / B70 (Battlemage; B60 24 GB, B70 32 GB per card) with the
+  Validated on 4× Intel Arc Pro B60 / B70 (B60 24 GB, B70 32 GB per card) with the
   official vLLM XPU image `vllm/vllm-openai-xpu:latest`.
 
   ```bash

--- a/models/Qwen/Qwen3-32B.yaml
+++ b/models/Qwen/Qwen3-32B.yaml
@@ -171,7 +171,7 @@ guide: |
     -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve Qwen/Qwen3-32B \
     --gpu-memory-utilization 0.90 \
     --tensor-parallel-size 4 \
-    --dtype float16 --max-model-len 8192"
+    --max-model-len 8192"
   ```
 
   ## Configuration Tips

--- a/models/deepseek-ai/DeepSeek-OCR.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR.yaml
@@ -15,6 +15,8 @@ meta:
     mi300x: verified
     mi325x: verified
     mi355x: verified
+    arc_pro_b60: verified
+    arc_pro_b70: verified
 
 model:
   model_id: "deepseek-ai/DeepSeek-OCR"
@@ -74,7 +76,7 @@ guide: |
 
   ## Prerequisites
 
-  - **Hardware**: Single GPU with >=8 GB VRAM (CUDA or MI300X / MI325X / MI355X)
+  - **Hardware**: Single GPU with >=8 GB VRAM (CUDA, MI300X / MI325X / MI355X, or Intel XPU B60 / B70)
   - **vLLM**: Current stable release
   - **Python**: 3.10+ (CUDA) or 3.12 (ROCm)
 
@@ -93,6 +95,11 @@ guide: |
   uv venv --python 3.12
   source .venv/bin/activate
   uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/
+  ```
+
+  ### Intel XPU (B60 / B70)
+  ```bash
+  docker pull vllm/vllm-openai-xpu:latest
   ```
 
   ## Client Usage
@@ -153,6 +160,21 @@ guide: |
     --logits-processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor \
     --mm-processor-cache-gb 0
   ```
+
+  **Intel XPU (B60, B70)**
+
+  ```bash
+  docker run --device /dev/dri \
+    -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --entrypoint bash vllm/vllm-openai-xpu:latest \
+    -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve deepseek-ai/DeepSeek-OCR \
+    --logits-processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor \
+    --mm-processor-cache-gb 0"
+  ```
+
+  Query the running server with the OpenAI client (same for CUDA / ROCm / XPU):
 
   ```python
   import time

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -148,7 +148,7 @@ guide: |
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     --entrypoint bash vllm/vllm-openai-xpu:latest \
     -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve meta-llama/Llama-3.1-8B-Instruct \
-    --dtype float16 --max-model-len 8192"
+    --max-model-len 8192"
   ```
 
   ## Client Usage

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -151,6 +151,19 @@ guide: |
     --dtype float16 --max-model-len 8192"
   ```
 
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
+  response = client.chat.completions.create(
+      model="meta-llama/Llama-3.1-8B-Instruct",
+      messages=[{"role": "user", "content": "Hello, how are you?"}],
+  )
+  print(response.choices[0].message.content)
+  ```
+
   ## Speculative Decoding (EAGLE3)
 
   An EAGLE3 draft head is available at

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -15,6 +15,8 @@ meta:
     h200: verified
     trillium: verified
     xeon6: verified
+    arc_pro_b60: verified
+    arc_pro_b70: verified
 
 model:
   model_id: "meta-llama/Llama-3.1-8B-Instruct"
@@ -84,7 +86,7 @@ guide: |
 
   ## Prerequisites
 
-  - Hardware: 1x GPU with >=16 GB VRAM (e.g. A100, L40S, H100, H200) or 2x Xeon6/Xeon5 NUMA node
+  - Hardware: 1x GPU with >=16 GB VRAM (e.g. A100, L40S, H100, H200), Intel XPU B60/B70, or 2x Xeon6/Xeon5 NUMA node
   - vLLM >= 0.6.0
   - CUDA Driver compatible with your vLLM version for 1x GPU
   - Docker with NVIDIA Container Toolkit (recommended) for 1x GPU
@@ -103,6 +105,10 @@ guide: |
   ### Docker (Intel Xeon 6 CPUs)
   ```bash
   docker pull vllm/vllm-openai-cpu:latest-x86_64 # For Intel Xeon 6
+  ```
+  ### Docker (Intel XPU B60 / B70)
+  ```bash
+  docker pull vllm/vllm-openai-xpu:latest
   ```
   ### Docker (Cloud TPU — Trillium)
   TPU uses the separate `vllm/vllm-tpu` image (no pip wheel). Pull the tag specified by the upstream [Trillium recipe](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Llama3.x), then run:
@@ -133,17 +139,16 @@ guide: |
       --port 8000
   ```
 
-  ## Client Usage
+  ### Intel XPU (B60, B70)
 
-  ```python
-  from openai import OpenAI
-
-  client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
-  response = client.chat.completions.create(
-      model="meta-llama/Llama-3.1-8B-Instruct",
-      messages=[{"role": "user", "content": "Hello, how are you?"}],
-  )
-  print(response.choices[0].message.content)
+  ```bash
+  docker run --device /dev/dri \
+    -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --entrypoint bash vllm/vllm-openai-xpu:latest \
+    -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve meta-llama/Llama-3.1-8B-Instruct \
+    --dtype float16 --max-model-len 8192"
   ```
 
   ## Speculative Decoding (EAGLE3)

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -18,6 +18,8 @@ meta:
     mi300x: verified
     mi325x: verified
     mi355x: verified
+    arc_pro_b60: verified
+    arc_pro_b70: verified
 
 model:
   model_id: "openai/gpt-oss-20b"
@@ -83,7 +85,7 @@ guide: |
 
   ## Prerequisites
 
-  - Hardware: NVIDIA H100/H200/B200 or AMD MI300X/MI325X/MI355X (also runs on Ada/Ampere consumer cards with sufficient VRAM).
+  - Hardware: NVIDIA H100/H200/B200 or AMD MI300X/MI325X/MI355X or Intel XPU B60/B70 (also runs on Ada/Ampere consumer cards with sufficient VRAM).
   - vLLM >= 0.10.0.
   - CUDA >= 12.8 if building from source (must match between install and serving).
 
@@ -105,6 +107,11 @@ guide: |
 
   ```bash
   uv pip install vllm --extra-index-url https://wheels.vllm.ai/rocm
+  ```
+
+  Intel XPU (B60 / B70):
+  ```bash
+  docker pull vllm/vllm-openai-xpu:latest
   ```
 
   ## Launch commands
@@ -139,6 +146,19 @@ guide: |
     -cc.use_inductor_graph_partition=True \
     --gpu-memory-utilization 0.95 \
     --block-size 64
+  ```
+
+  ### Intel XPU(B60, B70)
+
+
+  ```bash
+  docker run --device /dev/dri \
+    -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --entrypoint bash vllm/vllm-openai-xpu:latest \
+    -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve openai/gpt-oss-20b \
+    --max-model-len 8192"
   ```
 
   ## Tool use

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -915,15 +915,22 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   // by the recipe. Same helpers as synthesis, so a disabled pill and an
   // empty command can't disagree.
   const kvOffloadOptions = taxonomy.kv_offload || {};
+  // Intel XPU: no KV-offload layer is validated on this backend, so gate every
+  // option off (and force the effective selection to Off further down).
+  const kvOffloadDisabledByHw = hwProfile?.generation === "xpu";
   const kvOptAllowed = (key) =>
-    isKvOffloadAllowedForStrategy(kvOffloadOptions[key], activeServingStrategy, strategies[activeServingStrategy])
+    !kvOffloadDisabledByHw
+    && isKvOffloadAllowedForStrategy(kvOffloadOptions[key], activeServingStrategy, strategies[activeServingStrategy])
     && isKvOffloadSupportedForRecipe(kvOffloadOptions[key], key, recipe)
     && isKvOffloadBrandSupported(kvOffloadOptions[key], hwProfile);
-  // Disabled reason, most-fixed-first (recipe, hardware, strategy). Shared
-  // by the row pills and the group sub-row.
+  // Disabled reason, most-fixed-first (hardware, recipe, hardware-brand,
+  // strategy). Shared by the row pills and the group sub-row.
   const kvDisabledReason = (key) => {
     const opt = kvOffloadOptions[key];
     const name = opt?.display_name || key;
+    if (kvOffloadDisabledByHw) {
+      return `${name} isn't validated on Intel XPU — serve directly with the Docker image.`;
+    }
     if (!isKvOffloadSupportedForRecipe(opt, key, recipe)) {
       return recipe.kv_offload_support?.[key] === "unsupported"
         ? `${name} is marked unsupported for this recipe.`
@@ -945,8 +952,13 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   for (const keys of Object.values(kvGroupMembers)) {
     keys.sort((a, b) => (kvOffloadOptions[a].order ?? 99) - (kvOffloadOptions[b].order ?? 99));
   }
+  // Force the effective selection to Off when the hardware disables KV offload
+  // (Intel XPU) regardless of a persisted pick from other hardware — keeps the
+  // generated command a plain single-instance serve.
   const activeKvOffload =
-    kvOffloadOptions[kvOffload]
+    kvOffloadDisabledByHw
+      ? ""
+      : kvOffloadOptions[kvOffload]
       ? (kvOptAllowed(kvOffload) ? kvOffload : "")
       : compatibleKvStoreStrategies.includes(kvOffload) && hwScalable
           && isKvStoreBrandSupported(hwProfile) && isKvStoreSupported(kvOffload)
@@ -1027,6 +1039,10 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     nodeCount === 1 && activeStrategy === "single_node_tp" && effectiveTp < hwGpuCount;
 
   const isSingleNode = nodeCount === 1 && typeof activeStrategy === "string" && activeStrategy.startsWith("single_node_");
+  // Intel XPU: the validated deployment is single-node, single-instance vLLM in
+  // the official Docker image. KV-offload layers (Simple / LMCache / Mooncake)
+  // and multi-node clustering aren't validated on this backend, so gate them off.
+  const isXpuHardware = hwProfile?.generation === "xpu";
   const needGb = currentVariant?.vram_minimum_gb;
   const availGb = hwProfile.vram_gb;
   const vramShortfall =
@@ -1215,8 +1231,9 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     const recipeDefault = recipe.default_strategy;
     const recipeDefaultsSingleNode =
       typeof recipeDefault === "string" && recipeDefault.startsWith("single_node_");
-    const shouldBumpNodes = nodeCount === 1 && supportsMultiNode && newScalable && !fitsNew;
-    const shouldUnbumpNodes = nodeCount > 1 && (!newScalable || (fitsNew && recipeDefaultsSingleNode));
+    const shouldBumpNodes = nodeCount === 1 && supportsMultiNode && newScalable && !fitsNew && newProfile?.generation !== "xpu";
+    // Intel XPU is validated single-node only — always clamp back to 1 node.
+    const shouldUnbumpNodes = nodeCount > 1 && (!newScalable || newProfile?.generation === "xpu" || (fitsNew && recipeDefaultsSingleNode));
     if (shouldBumpNodes) setNodeCount(2);
     if (shouldUnbumpNodes) setNodeCount(1);
     syncUrl({
@@ -1681,7 +1698,9 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   // the Install tab *and* the rendered command block to docker — they stay
   // in sync without requiring the user to re-click.
   const pipEffectivelyHidden =
-    recipe.model?.install?.pip === false || hwProfile?.generation === "tpu";
+    recipe.model?.install?.pip === false ||
+    hwProfile?.generation === "tpu" ||
+    hwProfile?.generation === "xpu";
   const dockerEffectivelyHidden = recipe.model?.install?.docker === false;
   const effectiveInstallMode =
     installMode === "pip" && pipEffectivelyHidden
@@ -2240,9 +2259,11 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                   // extra store process).
                   const supported = compatibleKvStoreStrategies.filter((s) => isKvStoreSupported(s));
                   const brandOk = isKvStoreBrandSupported(hwProfile);
-                  const selectable = hwScalable && brandOk && supported.length > 0;
+                  const selectable = !isXpuHardware && hwScalable && brandOk && supported.length > 0;
                   const defaultId = supported[0];
-                  const disabledTitle = !brandOk
+                  const disabledTitle = isXpuHardware
+                    ? "Mooncake isn't validated on Intel XPU — serve directly with the Docker image."
+                    : !brandOk
                     ? `Mooncake's transfer engine ships CUDA and ROCm builds only — not available on ${hwProfile.brand || ""} ${hwProfile.display_name || hwId} backends.`
                     : !hwScalable
                       ? `${hwProfile.display_name || "This hardware"} is a single-GPU workstation and can't run a multi-node KV-store deployment.`
@@ -2437,7 +2458,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                   // multi_node_* (or pd_cluster) strategy (small dense models
                   // commonly omit these), or when the active hardware can't be
                   // clustered (single-GPU workstation, e.g. DGX Station).
-                  const noMultiNode = n > 1 && (!supportsMultiNode || !hwScalable);
+                  const noMultiNode = n > 1 && (!supportsMultiNode || !hwScalable || isXpuHardware);
                   // Single-node pill is disabled when the variant can't fit on
                   // one node of the selected hardware — same struck-through
                   // treatment as unsupported hardware pills. Multi-node still
@@ -2453,7 +2474,9 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                       onClick={() => !disabled && selectNodes(n)}
                       title={
                         noMultiNode
-                          ? !hwScalable
+                          ? isXpuHardware
+                            ? "Multi-node clustering isn't validated on Intel XPU — serve single-node with the Docker image."
+                            : !hwScalable
                             ? `${hwProfile.display_name || "This hardware"} is a single-GPU workstation and can't be clustered into multiple nodes.`
                             : "This recipe does not declare a multi-node strategy. Fits in a single node."
                           : singleNodeDoesntFit
@@ -2869,13 +2892,20 @@ function CommandBody({ command }) {
 
 function SingleCommandBlock({ command, env, companions, verifyCmd, benchCmd, statusHeader, installMode, dockerMeta, configSummary, endpointsControls }) {
   const [tab, setTab] = useState("vllm");
+  // The `docker pull` for the image lives in the Install block above.
+  const isXpu = !!dockerMeta?.isXpu;
   const isDocker = installMode === "docker";
   // Docker mode: env vars fold into `-e` flags inside the wrapped `docker run`,
   // so there's no separate prelude (the `docker pull` lives in the Install
   // block tabs above). Pip mode: prelude = `export KEY=VAL` lines.
-  const prelude = isDocker ? "" : envToExports(env);
+  const preludeBase = isDocker ? "" : envToExports(env);
+  // XPU pip mode sources oneAPI on the host first; in docker mode the wrapper
+  // sources it inside the container, so no host prelude is needed.
+  const prelude = isXpu && !isDocker
+    ? ["source /opt/intel/oneapi/setvars.sh", preludeBase].filter(Boolean).join("\n")
+    : preludeBase;
   const displayCommand = isDocker
-    ? buildDockerRun({ command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+    ? buildDockerRun({ command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu })
     : command;
   // A companion process may ride along (`companions[]` from resolveCommand —
   // a feature's `companion:` or the active kv_offload option's, e.g.
@@ -2989,7 +3019,7 @@ function InstallBlock({ recipe, variant, dockerMeta, installMode, setInstallMode
   const pipHidden = pipCfg === false;
   const dockerHidden = dockerCfg === false;
   const [open, setOpen] = useState(false);
-  const { isAmd, isTpu, image: dockerImage, brandKey, cudaMap } = dockerMeta;
+  const { isAmd, isTpu, isXpu, image: dockerImage, brandKey, cudaMap } = dockerMeta;
   // A variant may require a newer vLLM than the recipe baseline (e.g. the DSpark
   // checkpoint needs 0.25.0, currently nightly). Take the higher version and OR
   // the nightly flag so the Install block reflects the selected checkpoint.
@@ -3046,11 +3076,13 @@ uv pip install -U vllm --torch-backend auto`;
   // serves the model is rendered in the main command block below. A YAML
   // override at `model.install.docker.command` still wins for recipes that
   // need a custom build step. The CUDA-version selector (below, next to Copy)
-  // drives the tag suffix for NVIDIA; AMD / TPU pull a single image.
+  // drives the tag suffix for NVIDIA; AMD / TPU / XPU pull a single image.
   const defaultDockerCmd = `docker pull ${dockerImage}`;
   const dockerCmd = dockerCfg?.command || defaultDockerCmd;
   const defaultDockerNote = isTpu
     ? "TPU builds are published by vllm-project/tpu-inference. See the Trillium and Ironwood tpu-recipes for pinned image tags and exact deployment flags."
+    : isXpu
+      ? "Intel XPU (Arc/Battlemage) image. The entrypoint does not initialize oneAPI — source /opt/intel/oneapi/setvars.sh before `vllm serve`, or torch.xpu.device_count() returns 0."
     : isAmd
       ? undefined
       : cudaMap
@@ -3076,8 +3108,9 @@ uv pip install -U vllm --torch-backend auto`;
       (installMode === "pip" && nightlyRequired && !pipCfg?.command));
 
   // TPU has no pip wheel — force-hide the pip tab regardless of recipe overrides.
-  const effectivePipHidden = pipHidden || isTpu;
-  const dockerLabel = isTpu ? "Docker (TPU)" : isAmd ? "Docker (ROCm)" : "Docker";
+  // Intel XPU is validated via the official `vllm-openai-xpu` Docker image;
+  const effectivePipHidden = pipHidden || isTpu || isXpu;
+  const dockerLabel = isTpu ? "Docker (TPU)" : isXpu ? "Docker (XPU)" : isAmd ? "Docker (ROCm)" : "Docker";
   const tabs = [
     !effectivePipHidden && {
       id: "pip",
@@ -3105,7 +3138,7 @@ uv pip install -U vllm --torch-backend auto`;
         <Package size={12} className="text-[var(--command-fg)]/50 shrink-0" />
         <span className="text-[11px] font-semibold text-[var(--command-fg)]/70 uppercase tracking-widest">Install</span>
         <span className="text-[11px] text-[var(--command-fg)]/40 font-mono">
-          vLLM {minV}+{isOmni ? " · vLLM-Omni nightly" : ""} · {isTpu ? "TPU" : isAmd ? "ROCm" : "CUDA"}
+          vLLM {minV}+{isOmni ? " · vLLM-Omni nightly" : ""} · {isTpu ? "TPU" : isXpu ? "XPU" : isAmd ? "ROCm" : "CUDA"}
         </span>
         {nightlyRequired && (
           <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30 uppercase tracking-wider">
@@ -3226,7 +3259,7 @@ function MultiNodeBlock({ result, verifyCmd, benchCmd, statusHeader, installMode
   const isDocker = installMode === "docker";
   const wrap = (cmd) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env: result.env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+      ? buildDockerRun({ command: cmd, env: result.env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu })
       : cmd;
   // One tab per node: Head (rank 0) then every follower rank, each with its own
   // --node-rank / --data-parallel-start-rank. `workerCommands` carries them all;
@@ -3292,7 +3325,7 @@ function PdClusterBlock({ result, verifyCmd, benchCmd, statusHeader, onRankChang
   // it stays as-is with its pip-install hint regardless of install mode.
   const wrap = (cmd, env) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu })
       : cmd;
   // Mooncake composed into PD (result.mooncake): a "Mooncake Config" tab
   // (launch step 0) writes the shared config file(s) once — every
@@ -3424,7 +3457,7 @@ function KvStoreLbBlock({ result, verifyCmd, benchCmd, statusHeader, onInstanceC
   const isDocker = installMode === "docker";
   const wrap = (cmd, env) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu })
       : cmd;
 
   const instances = result.instances || 2;

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -3082,7 +3082,7 @@ uv pip install -U vllm --torch-backend auto`;
   const defaultDockerNote = isTpu
     ? "TPU builds are published by vllm-project/tpu-inference. See the Trillium and Ironwood tpu-recipes for pinned image tags and exact deployment flags."
     : isXpu
-      ? "Intel XPU (Arc/Battlemage) image. The entrypoint does not initialize oneAPI — source /opt/intel/oneapi/setvars.sh before `vllm serve`, or torch.xpu.device_count() returns 0."
+      ? "Intel XPU image. The entrypoint does not initialize oneAPI — source /opt/intel/oneapi/setvars.sh before `vllm serve`, or torch.xpu.device_count() returns 0."
     : isAmd
       ? undefined
       : cudaMap

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -581,10 +581,10 @@ export function computeDockerMeta(recipe, variant, hwProfile, hwId = null) {
   // does not cover instead of skipping directly to the global default.
   applyOverride(recipe.model?.docker_image);
 
-  // Intel XPU (Arc Pro / Battlemage) ships in a dedicated image, not the CPU one.
-  // Otherwise, with a CUDA map, `image` defaults to the cu130 (upstream baseline)
-  // pick so toggle-unaware callers (the JSON API's renderings) still get a real
-  // tag; the client's CUDA selector re-picks from `cudaMap` on top of this.
+  // Intel XPU ships in a dedicated image, not the CPU one. Otherwise, with a
+  // CUDA map, `image` defaults to the cu130 (upstream baseline) pick so
+  // toggle-unaware callers (the JSON API's renderings) still get a real tag;
+  // the client's CUDA selector re-picks from `cudaMap` on top of this.
   const image = isXpu && !pinned
     ? "vllm/vllm-openai-xpu:latest"
     : pinned || (cudaMap ? cudaMap.cu130 || cudaMap.cu129 : null) || DEFAULT_IMAGE[brandKey];

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -543,7 +543,8 @@ export function computeDockerMeta(recipe, variant, hwProfile, hwId = null) {
       };
   const isAmd = hwProfile?.brand === "AMD";
   const isTpu = hwProfile?.generation === "tpu";
-  const isIntel = hwProfile?.generation === "cpu" ||hwProfile?.brand === "Intel";
+  const isXpu = hwProfile?.generation === "xpu";
+  const isIntel = hwProfile?.generation === "cpu" || isXpu || hwProfile?.brand === "Intel";
   const brandKey = isTpu ? "tpu" : isAmd ? "amd" : isIntel ? "intel" : "nvidia";
   // Exact variant+hardware image overrides win over variant-wide and
   // model-wide images (for example, an MI355X-only ROCm nightly).
@@ -580,18 +581,23 @@ export function computeDockerMeta(recipe, variant, hwProfile, hwId = null) {
   // does not cover instead of skipping directly to the global default.
   applyOverride(recipe.model?.docker_image);
 
-  // With a CUDA map, `image` defaults to the cu130 (upstream baseline) pick so
-  // toggle-unaware callers (the JSON API's renderings) still get a real tag;
-  // the client's CUDA selector re-picks from `cudaMap` on top of this.
-  const image = pinned || (cudaMap ? cudaMap.cu130 || cudaMap.cu129 : null) || DEFAULT_IMAGE[brandKey];
+  // Intel XPU (Arc Pro / Battlemage) ships in a dedicated image, not the CPU one.
+  // Otherwise, with a CUDA map, `image` defaults to the cu130 (upstream baseline)
+  // pick so toggle-unaware callers (the JSON API's renderings) still get a real
+  // tag; the client's CUDA selector re-picks from `cudaMap` on top of this.
+  const image = isXpu && !pinned
+    ? "vllm/vllm-openai-xpu:latest"
+    : pinned || (cudaMap ? cudaMap.cu130 || cudaMap.cu129 : null) || DEFAULT_IMAGE[brandKey];
   const gpuFlags = isTpu
     ? "--privileged --network host \\\n  -v /dev/shm:/dev/shm"
     : isAmd
       ? "--device=/dev/kfd --device=/dev/dri \\\n  --security-opt seccomp=unconfined --group-add video"
+    : isXpu
+      ? "--device /dev/dri \\\n  -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g"
     : isIntel
       ? "--shm-size=16g"	
       : "--gpus all";
-  return { image, gpuFlags, brandKey, isAmd, isTpu, isIntel, pinned, cudaMap, nightlyRequired };
+  return { image, gpuFlags, brandKey, isAmd, isTpu, isXpu, isIntel, pinned, cudaMap, nightlyRequired };
 }
 
 // argv form of the brand-specific GPU flags from computeDockerMeta. Mirrors
@@ -605,6 +611,9 @@ function dockerGpuArgv(meta) {
       "--security-opt", "seccomp=unconfined",
       "--group-add", "video",
     ];
+  }
+  if (meta.isXpu) {
+    return ["--device", "/dev/dri", "-v", "/dev/dri/by-path:/dev/dri/by-path", "--shm-size", "16g"];
   }
   if (meta.isIntel) {
     return ["--shm-size", "16g"];
@@ -638,8 +647,7 @@ function localModelMount(modelId) {
 // Wrap a `vllm serve MODEL <args>` command in `docker run`. The vllm/vllm-openai
 // image's entrypoint is `vllm serve`, so we pass MODEL and the trailing args as
 // CMD. Env vars become `-e KEY=VAL` inside the container.
-//
-export function buildDockerRun({ command, env, image, gpuFlags, port = 8000 }) {
+export function buildDockerRun({ command, env, image, gpuFlags, port = 8000, isXpu = false }) {
   const envFlags = Object.entries(env || {})
     .map(([k, v]) => `-e ${k}=${v}`)
     .join(" \\\n  ");
@@ -658,9 +666,16 @@ export function buildDockerRun({ command, env, image, gpuFlags, port = 8000 }) {
     ? `# ${modelId} must already exist on the host — bind-mounted read-only below.\n`
     : "";
   const serveBody = command.replace(/^vllm serve \S+\s*\\?\n?\s*/, "");
-  return `${prereq}docker run ${gpuFlags} \\
+  const base = `${prereq}docker run ${gpuFlags} \\
   --privileged --ipc=host -p ${port}:${port} \\
-  -v ~/.cache/huggingface:/root/.cache/huggingface \\${mountFlags ? `\n  ${mountFlags} \\` : ""}${envFlags ? `\n  ${envFlags} \\` : ""}
+  -v ~/.cache/huggingface:/root/.cache/huggingface \\${mountFlags ? `\n  ${mountFlags} \\` : ""}${envFlags ? `\n  ${envFlags} \\` : ""}`;
+  if (isXpu) {
+    const serve = `vllm serve ${modelId}${serveBody ? ` \\\n  ${serveBody}` : ""}`;
+    return `${base}
+  --entrypoint bash ${image} \\
+  -c "source /opt/intel/oneapi/setvars.sh && exec ${serve}"`;
+  }
+  return `${base}
   ${image} ${modelId}${serveBody ? ` \\\n  ${serveBody}` : ""}`;
 }
 
@@ -679,7 +694,7 @@ export function buildDockerArgv({ argv, env, meta, port = 8000 }) {
   for (const m of [...localModelMount(cmdArgs[0]), ...configPathMounts(env)]) {
     mountFlags.push("-v", m);
   }
-  return [
+  const base = [
     "docker", "run",
     ...dockerGpuArgv(meta),
     "--privileged", "--ipc=host",
@@ -687,6 +702,18 @@ export function buildDockerArgv({ argv, env, meta, port = 8000 }) {
     "-v", "~/.cache/huggingface:/root/.cache/huggingface",
     ...mountFlags,
     ...envFlags,
+  ];
+  // Intel XPU: override entrypoint to source oneAPI before serving (see
+  // buildDockerRun). The full serve invocation becomes a single `bash -c` arg.
+  if (meta.isXpu) {
+    return [
+      ...base,
+      "--entrypoint", "bash", meta.image,
+      "-c", `source /opt/intel/oneapi/setvars.sh && exec vllm serve ${cmdArgs.join(" ")}`,
+    ];
+  }
+  return [
+    ...base,
     meta.image,
     ...cmdArgs,
   ];

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -191,6 +191,30 @@ hardware_profiles:
     multi_node: false
     restricted: true
 
+  # ── Intel Arc Pro (Battlemage) XPU ──
+  # `restricted: true` keeps it out of the picker unless a recipe explicitly
+  # lists it in `meta.hardware` — XPU support ships in the separate
+  # `vllm/vllm-openai-xpu` image and is only declared on validated recipes.
+  arc_pro_b60:
+    brand: Intel
+    generation: xpu
+    display_name: "Arc Pro B60"
+    description: "Intel Arc Pro B60 (Battlemage) 24 GB · 4-card node · vLLM XPU backend"
+    gpu_count: 4
+    vram_gb: 96
+    multi_node: false
+    restricted: true
+
+  arc_pro_b70:
+    brand: Intel
+    generation: xpu
+    display_name: "Arc Pro B70"
+    description: "Intel Arc Pro B70 (Battlemage) 32 GB · 4-card node · vLLM XPU backend"
+    gpu_count: 4
+    vram_gb: 128
+    multi_node: false
+    restricted: true
+
 tasks:
   - id: text
     display_name: "Text"

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -191,7 +191,7 @@ hardware_profiles:
     multi_node: false
     restricted: true
 
-  # ── Intel Arc Pro (Battlemage) XPU ──
+  # ── Intel Arc Pro XPU ──
   # `restricted: true` keeps it out of the picker unless a recipe explicitly
   # lists it in `meta.hardware` — XPU support ships in the separate
   # `vllm/vllm-openai-xpu` image and is only declared on validated recipes.
@@ -199,7 +199,7 @@ hardware_profiles:
     brand: Intel
     generation: xpu
     display_name: "Arc Pro B60"
-    description: "Intel Arc Pro B60 (Battlemage) 24 GB · 4-card node · vLLM XPU backend"
+    description: "Intel Arc Pro B60 24 GB · 4-card node · vLLM XPU backend"
     gpu_count: 4
     vram_gb: 96
     multi_node: false
@@ -209,7 +209,7 @@ hardware_profiles:
     brand: Intel
     generation: xpu
     display_name: "Arc Pro B70"
-    description: "Intel Arc Pro B70 (Battlemage) 32 GB · 4-card node · vLLM XPU backend"
+    description: "Intel Arc Pro B70 32 GB · 4-card node · vLLM XPU backend"
     gpu_count: 4
     vram_gb: 128
     multi_node: false


### PR DESCRIPTION
Add 4 models(Qwen/Qwen3-32B, openai/gpt-oss-20b, deepseek-ai/DeepSeek-OCR, meta-llama/Llama-3.1-8B-Instruct) deployment recipe for Intel XPU based on the vLLM Docker release by upstream (0.26.0).