### PR TITLE
MiniMax-M3 spec decoding Blackwell

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -57,7 +57,14 @@ features:
       - "--speculative-config"
       - '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
     hardware_overrides:
-      # On ROCm the Eagle3 draft head prefers the TRITON_ATTN attn backend as it has better performance than the default.
+      blackwell:
+        args:
+          - "--speculative-config"
+          - '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
+          - "--attention_config.backend"
+          - "FLASHINFER"
+          - "--attention_config.use_trtllm_attention"
+          - "true"
       amd:
         args:
           - "--speculative-config"


### PR DESCRIPTION
Use Eagle3-GQA draft head and enable FLASHINFER + TRT-LLM attention for spec_decoding on Blackwell (B200/B300/GB200/GB300). Non-Blackwell NVIDIA stays on the standard Eagle3 head; AMD stays on TRITON_ATTN. Based on https://github.com/SemiAnalysisAI/InferenceX/pull/2328 and https://github.com/SemiAnalysisAI/InferenceX/pull/2337.