### PR TITLE
Mark Kimi-K3 H100 unsupported

### DIFF
--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Moonshot AI"
   description: "Pre-release 2.8T-parameter native multimodal MoE with Kimi Delta Attention, Gated MLA, Attention Residuals, and a 1M-token context window"
   date_added: 2026-07-27
-  date_updated: 2026-07-25
+  date_updated: 2026-07-29
   difficulty: hard
   tasks:
     - multimodal
@@ -15,6 +15,7 @@ meta:
     - "moonshotai/Kimi-K2.5"
   default_hardware: b300
   hardware:
+    h100: unsupported
     h200: verified
     b300: verified
     gb300: verified


### PR DESCRIPTION
## Summary

- Mark H100 as unsupported for the Kimi-K3 recipe.
- This disables H100 in the Hardware picker and prevents Kimi-K3 H100 command renderings.
- Update the recipe's material-change date.

## Duplicate-work check

- Reviewed open Kimi-K3 PRs #688 and #695. They add an FP8 recipe and a B200 TP+PP profile respectively; neither marks H100 unsupported.

## Validation

- `node scripts/build-recipes-api.mjs` — passed: 151 models, 8 strategies, 2 KV-store deployments.
- Confirmed the generated Kimi-K3 data marks `meta.hardware.h100` as `unsupported` and has no H100 rendering endpoint.

## Model evaluation

- Not run. This is recipe availability metadata only; no model weights, implementation, or output behavior changed.

## AI assistance

- AI assistance was used to locate the recipe configuration, make the narrowly scoped change, and run the validation.