### PR TITLE
Remove max-num-batched-tokens from DeepSeek config

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -151,8 +151,6 @@ hardware_overrides:
       - "0.95"
       - "--max-num-seqs"
       - "16"
-      - "--max-num-batched-tokens"
-      - "16384"
       - "--no-enable-flashinfer-autotune"
       - "--compilation-config"
       - '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'


### PR DESCRIPTION
Removed the max number of batched tokens configuration.

it can not be started successful on newest image  vllm/vllm-openai:nightly 

it only 31K kvcache if add it ,so we must remove it --max-num-batched-tokens 16384 

tested h20*8

