### PR TITLE
Let Kimi recipes auto-select MLA prefill backend

### DIFF
--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Moonshot AI"
   description: "Open-source native multimodal agentic MoE model with vision-language understanding, tool calling, and thinking modes"
   date_added: 2026-01-27
-  date_updated: 2026-05-14
+  date_updated: 2026-07-29
   difficulty: intermediate
   tasks:
     - multimodal
@@ -127,9 +127,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  blackwell:
-    extra_args:
-      - "--attention-config.use_trtllm_ragged_deepseek_prefill=True"
   amd:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
     extra_env:

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Moonshot AI"
   description: "Open-source native multimodal agentic MoE model with vision-language understanding, tool calling, and thinking modes"
   date_added: 2026-04-20
-  date_updated: 2026-07-13
+  date_updated: 2026-07-29
   difficulty: intermediate
   tasks:
     - multimodal
@@ -102,7 +102,7 @@ hardware_overrides:
   blackwell:
     extra_args:
       - "--attention-config"
-      - '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}'
+      - '{"use_prefill_query_quantization":true}'
   amd:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
     extra_env:
@@ -165,7 +165,7 @@ guide: |
     --block-size 64 \
     --gpu-memory-utilization 0.90 \
     --attention-backend TOKENSPEED_MLA \
-    --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}' \
+    --attention-config '{"use_prefill_query_quantization":true}' \
     --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
     --max-cudagraph-capture-size 2048 \
     --speculative-config '{"method":"eagle3","model":"lightseekorg/kimi-k2.6-eagle3-mla","num_speculative_tokens":4}'
@@ -188,7 +188,7 @@ guide: |
     --block-size 64 \
     --gpu-memory-utilization 0.90 \
     --attention-backend TOKENSPEED_MLA \
-    --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}' \
+    --attention-config '{"use_prefill_query_quantization":true}' \
     --disable-hybrid-kv-cache-manager \
     --kv-transfer-config "{\"kv_connector\":\"SimpleCPUOffloadConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use_per_rank\":${CPU_OFFLOAD_BYTES_PER_RANK},\"lazy_offload\":false}}"
   ```

--- a/models/moonshotai/Kimi-K2.7-Code.yaml
+++ b/models/moonshotai/Kimi-K2.7-Code.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Moonshot AI"
   description: "Coding-focused agentic MoE built on Kimi-K2.6, tuned for long-horizon software-engineering tasks with thinking-only reasoning, tool calling, and vision-language input"
   date_added: 2026-06-12
-  date_updated: 2026-06-12
+  date_updated: 2026-07-29
   difficulty: intermediate
   tasks:
     - multimodal
@@ -83,9 +83,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  blackwell:
-    extra_args:
-      - "--attention-config.use_trtllm_ragged_deepseek_prefill=True"
   amd:
     # Verified on 8× MI300X / MI355X (MI325X listed as supported but not verified).
     extra_env:

--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Moonshot AI"
   description: "Pre-release 2.8T-parameter native multimodal MoE with Kimi Delta Attention, Gated MLA, Attention Residuals, and a 1M-token context window"
   date_added: 2026-07-27
-  date_updated: 2026-07-25
+  date_updated: 2026-07-29
   difficulty: hard
   tasks:
     - multimodal
@@ -147,7 +147,7 @@ hardware_overrides:
       - "--kv-cache-dtype"
       - "fp8"
       - "--attention-config"
-      - '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}'
+      - '{"use_prefill_query_quantization":true}'
       - "--enable-prefix-caching"
     extra_env:
       VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION: "1"
@@ -193,9 +193,6 @@ strategy_overrides:
     # Blackwell only (cuda_copy is CUDA-only); replaces the recipe-level nvidia block.
     hardware_overrides:
       blackwell:
-        extra_args:
-          - "--attention-config"
-          - '{"mla_prefill_backend":"TRTLLM_RAGGED"}'
         extra_env:
           VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION: "1"
           UCX_TLS: "rc,cuda_copy"


### PR DESCRIPTION
## Summary

- remove forced TRTLLM ragged MLA prefill settings from the Kimi K2.5, K2.6, K2.7-Code, and K3 recipes
- https://github.com/flashinfer-ai/flashinfer/pull/3779 
- retain `use_prefill_query_quantization` where FP8 KV cache is explicitly enabled
- update the K2.6 guide examples and recipe update dates

## Why

The runtime backend selector should choose the compatible MLA prefill backend. Pinning the ragged backend bypasses that selection and can expose backend-specific output failures.

## Validation

- `node scripts/build-recipes-api.mjs`
- verified generated Kimi API output contains no `TRTLLM_RAGGED`, `use_trtllm_ragged`, or `mla_prefill_backend` settings
- verified K2.6 and K3 generated commands retain `use_prefill_query_quantization`