### PR TITLE
[ROCm] Promote tuned Kimi-K2.5 MXFP4 MoE env vars into extra_env

### DIFF
--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -107,6 +107,13 @@ variants:
     extra_env:
       VLLM_ROCM_USE_AITER_MOE: "1"
       VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
+      # Kernel-selection env vars for the tuned AITER MXFP4 MoE path documented
+      # in the guide below. AITER_MXFP4_INTERMEDIATE=1 is what selects the
+      # RadeonFlow MXFP4 intermediate GEMM path; without it (with AITER on) the
+      # MoE oracle falls back to a slower kernel. VLLM_ROCM_USE_SKINNY_GEMM
+      # defaults to on, so it must be disabled explicitly here.
+      VLLM_ROCM_USE_SKINNY_GEMM: "0"
+      AITER_MXFP4_INTERMEDIATE: "1"
     # AITER RMSNorm is left at its default (on when AITER is enabled): a local
     # TP4 GSM8K check measured identical accuracy on vs off (0.9697), so there is
     # no reason to disable it the way the single-node TP<8 guard used to.

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -107,11 +107,6 @@ variants:
     extra_env:
       VLLM_ROCM_USE_AITER_MOE: "1"
       VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: "1"
-      # Kernel-selection env vars for the tuned AITER MXFP4 MoE path documented
-      # in the guide below. AITER_MXFP4_INTERMEDIATE=1 is what selects the
-      # RadeonFlow MXFP4 intermediate GEMM path; without it (with AITER on) the
-      # MoE oracle falls back to a slower kernel. VLLM_ROCM_USE_SKINNY_GEMM
-      # defaults to on, so it must be disabled explicitly here.
       VLLM_ROCM_USE_SKINNY_GEMM: "0"
       AITER_MXFP4_INTERMEDIATE: "1"
     # AITER RMSNorm is left at its default (on when AITER is enabled): a local


### PR DESCRIPTION
## Summary

The tuned AITER MXFP4 MoE configuration for `amd/Kimi-K2.5-MXFP4` on MI355X was documented as prose in the `guide` block by #661, but the machine-readable `extra_env` for the `mxfp4` variant only carries the two vars added by #680 (`VLLM_ROCM_USE_AITER_MOE`, `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS`).

The two **behavior-changing** kernel-selection vars from that guide were never promoted into the structured `extra_env`, so anything consuming the structured recipe (rather than reading the guide by hand) silently gets a different, slower MoE kernel than the validated configuration:

- `AITER_MXFP4_INTERMEDIATE=1` — selects the RadeonFlow MXFP4 intermediate GEMM path. Default is `"0"`; without it (with `VLLM_ROCM_USE_AITER=1`) the MoE oracle falls back to a different kernel. This is the var the guide itself calls out as the one that selects the path.
- `VLLM_ROCM_USE_SKINNY_GEMM=0` — disables skinny GEMM. Default is `True`.

This PR adds those two to the `mxfp4` `extra_env` so the applied config matches the documented tuned path.

Intentionally **not** added, because their guide values already equal the upstream defaults (so they'd be no-ops):

- `AITER_BYPASS_TUNE_CONFIG` — aiter default is `0`.
- `AITER_MOE_SORT_BACKEND` — aiter default is `auto`.

`VLLM_ROCM_USE_AITER_RMSNORM=0` is guide-documented as TP<8-only; the `mxfp4` variant runs `tp: 8` (RMSNorm left at its default on), so it is not added as a static env. `OMP_NUM_THREADS=1` is a host/CPU-threading knob rather than a model kernel-selection var and is left to the guide.

## Test plan

- [x] `models/moonshotai/Kimi-K2.5.yaml` parses as YAML.
- [x] `git diff --check` clean (no whitespace errors).
- [x] Env values cross-checked against vLLM `envs.py` defaults (`VLLM_ROCM_USE_SKINNY_GEMM` default `True`) and aiter `fused_moe.py` defaults (`AITER_MXFP4_INTERMEDIATE` default `"0"`).

Made with [Cursor](https://cursor.com)