### PR TITLE
Enable the Offloading options on full-attention recipes

### DIFF
--- a/models/ByteDance-Seed/Seed-OSS-36B-Instruct.yaml
+++ b/models/ByteDance-Seed/Seed-OSS-36B-Instruct.yaml
@@ -47,6 +47,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args: []

--- a/models/MiniMaxAI/MiniMax-M2.1.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.1.yaml
@@ -58,6 +58,10 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args:

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -70,6 +70,10 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   nvidia:
     extra_args:

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -83,6 +83,10 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args:

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -74,6 +74,10 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     # First launch JIT-compiles AITER kernels (CK FP8 MoE, RMSNorm, activation);

--- a/models/OpenGVLab/InternVL3_5-8B.yaml
+++ b/models/OpenGVLab/InternVL3_5-8B.yaml
@@ -52,6 +52,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 strategy_overrides: {}
 

--- a/models/PaddlePaddle/PaddleOCR-VL-1.5.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL-1.5.yaml
@@ -60,6 +60,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args: []

--- a/models/PaddlePaddle/PaddleOCR-VL-1.6.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL-1.6.yaml
@@ -62,6 +62,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args: []

--- a/models/PaddlePaddle/PaddleOCR-VL.yaml
+++ b/models/PaddlePaddle/PaddleOCR-VL.yaml
@@ -59,6 +59,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args: []

--- a/models/Qwen/Qwen2.5-32B.yaml
+++ b/models/Qwen/Qwen2.5-32B.yaml
@@ -37,6 +37,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
@@ -60,6 +60,10 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   hopper:
     extra_args:

--- a/models/Qwen/Qwen2.5-VL-7B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-7B-Instruct.yaml
@@ -57,6 +57,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -70,6 +70,10 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/Qwen/Qwen3-32B.yaml
+++ b/models/Qwen/Qwen3-32B.yaml
@@ -63,6 +63,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/Qwen/Qwen3-4B.yaml
+++ b/models/Qwen/Qwen3-4B.yaml
@@ -55,6 +55,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/Qwen/Qwen3-ASR-1.7B.yaml
+++ b/models/Qwen/Qwen3-ASR-1.7B.yaml
@@ -39,6 +39,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args: []

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -84,6 +84,10 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   hopper:
     extra_args:

--- a/models/Qwen/Qwen3Guard-Gen-8B.yaml
+++ b/models/Qwen/Qwen3Guard-Gen-8B.yaml
@@ -47,6 +47,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-21B-A3B-PT.yaml
@@ -56,6 +56,10 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args:

--- a/models/baidu/ERNIE-4.5-VL-28B-A3B-PT.yaml
+++ b/models/baidu/ERNIE-4.5-VL-28B-A3B-PT.yaml
@@ -76,6 +76,10 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 strategy_overrides: {}
 

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -62,6 +62,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args: []

--- a/models/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -63,6 +63,10 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   hopper:
     extra_args:

--- a/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
+++ b/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
@@ -84,6 +84,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args:

--- a/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
+++ b/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
@@ -83,6 +83,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args:

--- a/models/mistralai/Mistral-Medium-3.5-128B.yaml
+++ b/models/mistralai/Mistral-Medium-3.5-128B.yaml
@@ -76,6 +76,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args:

--- a/models/openbmb/MiniCPM5-1B.yaml
+++ b/models/openbmb/MiniCPM5-1B.yaml
@@ -42,6 +42,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 strategy_overrides:
   single_node_tp:
     tp: 1

--- a/models/tencent/Hunyuan-A13B-Instruct.yaml
+++ b/models/tencent/Hunyuan-A13B-Instruct.yaml
@@ -51,6 +51,10 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     # Hunyuan-A13B is an AMD-first recipe; AITER acceleration required.

--- a/models/zai-org/GLM-4.5.yaml
+++ b/models/zai-org/GLM-4.5.yaml
@@ -71,6 +71,10 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/zai-org/GLM-4.5V.yaml
+++ b/models/zai-org/GLM-4.5V.yaml
@@ -77,6 +77,10 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     # Requires transformers >= 5.0.0; see dependencies.

--- a/models/zai-org/GLM-4.6.yaml
+++ b/models/zai-org/GLM-4.6.yaml
@@ -71,6 +71,10 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/zai-org/GLM-4.6V.yaml
+++ b/models/zai-org/GLM-4.6V.yaml
@@ -77,6 +77,10 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   amd:
     extra_args:

--- a/models/zai-org/GLM-4.7.yaml
+++ b/models/zai-org/GLM-4.7.yaml
@@ -87,6 +87,10 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/zai-org/GLM-ASR-Nano-2512.yaml
+++ b/models/zai-org/GLM-ASR-Nano-2512.yaml
@@ -41,6 +41,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/zai-org/GLM-OCR.yaml
+++ b/models/zai-org/GLM-OCR.yaml
@@ -59,6 +59,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/zai-org/Glyph.yaml
+++ b/models/zai-org/Glyph.yaml
@@ -60,6 +60,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}


### PR DESCRIPTION
Stacked on #704 (first commits; review the last commit here).

Enables the Offloading pill (`kv_offload_support: { offloading_cpu: verified, offloading_fs: verified }`) on the recipes below — models with a single standard full-attention KV cache (no MLA, no sliding-window/chunked layers, no linear-attention/SSM hybrids; omni and embedding recipes excluded).

**Validation** — each recipe is exercised on H100s (current vLLM nightly, `0.26.1rc1.dev77`): serve the smallest Hopper-compatible variant with the recipe's `--kv-transfer-config`, send a ~2.7k-token greedy prompt, require `kv_offload_store_bytes` > 0, reset the GPU prefix cache, resend, require `kv_offload_load_bytes` > 0 and byte-identical output — for **both** the CPU and CPU+filesystem configurations. Runs use `--enforce-eager`, capped `--max-model-len`, and a test-scaled `cpu_bytes_to_use`; recipes that could not be validated are excluded from this PR (see below).

All **35** recipes below are validated.

Three candidates were **excluded** rather than claimed: `internlm/Intern-S1` (does not serve on current vLLM — its remote tokenizer is incompatible with the bundled transformers), `inclusionAI/Ring-1T-FP8` (~1.2 TB weights; not servable on a single 8×H100 node), and `Qwen/Qwen3-Coder-480B-A35B-Instruct` (no GPU capacity for an 8-GPU run during this campaign — untested, not failed).

Note: `baidu/ERNIE-4.5-VL-28B-A3B-PT` serves only with `decord` installed (its remote code imports it); the recipe lacks a `dependencies:` entry for it today — follow-up outside this PR.

| Recipe | Tested checkpoint | TP | Status |
|---|---|---|---|
| PaddlePaddle/PaddleOCR-VL | `PaddlePaddle/PaddleOCR-VL` | 1 | ✅ cpu+fs (store=load=48,365,568 B) |
| PaddlePaddle/PaddleOCR-VL-1.5 | `PaddlePaddle/PaddleOCR-VL-1.5` | 1 | ✅ cpu+fs (store=load=48,365,568 B) |
| PaddlePaddle/PaddleOCR-VL-1.6 | `PaddlePaddle/PaddleOCR-VL-1.6` | 1 | ✅ cpu+fs (store=load=48,365,568 B) |
| zai-org/GLM-OCR | `zai-org/GLM-OCR` | 1 | ✅ cpu+fs (store=load=205,520,896 B) |
| openbmb/MiniCPM5-1B | `openbmb/MiniCPM5-1B` | 1 | ✅ cpu+fs (store=load=64,487,424 B) |
| Qwen/Qwen3-ASR-1.7B | `Qwen/Qwen3-ASR-1.7B` | 1 | ✅ cpu+fs (store=load=300,941,312 B) |
| Qwen/Qwen3Guard-Gen-8B | `Qwen/Qwen3Guard-Gen-0.6B` | 1 | ✅ cpu+fs (store=load=300,941,312 B) |
| Qwen/Qwen2.5-VL-7B-Instruct | `Qwen/Qwen2.5-VL-7B-Instruct-AWQ` | 1 | ✅ cpu+fs (store=load=150,470,656 B) |
| Qwen/Qwen3-4B | `Qwen/Qwen3-4B-FP8` | 1 | ✅ cpu+fs (store=load=386,924,544 B) |
| mistralai/Ministral-3-14B-Instruct-2512 | `mistralai/Ministral-3-3B-Instruct-2512` | 1 | ✅ cpu+fs (store=load=279,445,504 B) |
| mistralai/Ministral-3-8B-Reasoning-2512 | `mistralai/Ministral-3-3B-Reasoning-2512` | 1 | ✅ cpu+fs (store=load=279,445,504 B) |
| meta-llama/Llama-3.1-8B-Instruct | `nvidia/Llama-3.1-8B-Instruct-FP8` | 1 | ✅ cpu+fs (store=load=171,966,464 B) |
| zai-org/GLM-ASR-Nano-2512 | `zai-org/GLM-ASR-Nano-2512` | 1 | ✅ cpu+fs (store=load=179,830,784 B) |
| OpenGVLab/InternVL3_5-8B | `OpenGVLab/InternVL3_5-8B` | 1 | ✅ cpu+fs (store=load=386,924,544 B) |
| Qwen/Qwen3-32B | `Qwen/Qwen3-32B-AWQ` | 1 | ✅ cpu+fs (store=load=687,865,856 B) |
| zai-org/Glyph | `zai-org/Glyph` | 1 | ✅ cpu+fs (store=load=107,479,040 B) |
| Qwen/Qwen2.5-VL-72B-Instruct | `Qwen/Qwen2.5-VL-72B-Instruct-AWQ` | 1 | ✅ cpu+fs (store=load=859,832,320 B) |
| baidu/ERNIE-4.5-VL-28B-A3B-PT | `baidu/ERNIE-4.5-VL-28B-A3B-PT` | 1 | ✅ cpu+fs (store=load=150,470,656 B) |
| Qwen/Qwen2.5-32B | `Qwen/Qwen2.5-32B` | 2 | ✅ cpu+fs (store=load=687,865,856 B) |
| meta-llama/Llama-3.3-70B-Instruct | `nvidia/Llama-3.3-70B-Instruct-FP8` | 2 | ✅ cpu+fs (store=load=429,916,160 B) |
| ByteDance-Seed/Seed-OSS-36B-Instruct | `ByteDance-Seed/Seed-OSS-36B-Instruct` | 2 | ✅ cpu+fs (store=load=687,865,856 B) |
| tencent/Hunyuan-A13B-Instruct | `tencent/Hunyuan-A13B-Instruct-FP8` | 2 | ✅ cpu+fs (store=load=343,932,928 B) |
| baidu/ERNIE-4.5-21B-A3B-PT | `baidu/ERNIE-4.5-21B-A3B-PT` | 2 | ✅ cpu+fs (store=load=150,470,656 B) |
| zai-org/GLM-4.5V | `zai-org/GLM-4.5V-FP8` | 2 | ✅ cpu+fs (store=load=494,403,584 B) |
| zai-org/GLM-4.6V | `zai-org/GLM-4.6V-FP8` | 2 | ✅ cpu+fs (store=load=494,403,584 B) |
| mistralai/Mistral-Medium-3.5-128B | `mistralai/Mistral-Medium-3.5-128B` | 4 | ✅ cpu+fs (store=load=945,815,552 B) |
| Qwen/Qwen3-235B-A22B-Instruct-2507 | `Qwen/Qwen3-235B-A22B-FP8` | 4 | ✅ cpu+fs (store=load=505,151,488 B) |
| MiniMaxAI/MiniMax-M2 | `MiniMaxAI/MiniMax-M2` | 4 | ✅ cpu+fs (store=load=666,370,048 B) |
| MiniMaxAI/MiniMax-M2.1 | `MiniMaxAI/MiniMax-M2.1` | 4 | ✅ cpu+fs (store=load=666,370,048 B) |
| MiniMaxAI/MiniMax-M2.5 | `MiniMaxAI/MiniMax-M2.5` | 4 | ✅ cpu+fs (store=load=666,370,048 B) |
| MiniMaxAI/MiniMax-M2.7 | `MiniMaxAI/MiniMax-M2.7` | 4 | ✅ cpu+fs (store=load=666,370,048 B) |
| Qwen/Qwen3-VL-235B-A22B-Instruct | `Qwen/Qwen3-VL-235B-A22B-Instruct-FP8` | 4 | ✅ cpu+fs (store=load=505,151,488 B) |
| zai-org/GLM-4.6 | `zai-org/GLM-4.6-FP8` | 8 | ✅ cpu+fs (store=load=988,807,168 B) |
| zai-org/GLM-4.5 | `zai-org/GLM-4.5-FP8` | 8 | ✅ cpu+fs (store=load=988,807,168 B) |
| zai-org/GLM-4.7 | `zai-org/GLM-4.7-FP8` | 8 | ✅ cpu+fs (store=load=988,807,168 B) |
