### PR TITLE
Add DeepSeek-V4-Flash 0731 and DSpark variants

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "deepseek-v4-flash"
   provider: "DeepSeek"
   description: "DeepSeek V4 MoE model with hybrid CSA+HCA attention, manifold-constrained hyper-connections, and three-tier reasoning (Non-think / Think High / Think Max)."
-  date_added: 2026-04-24
+  date_added: 2026-07-31
   date_updated: 2026-07-31
   difficulty: hard
   tasks:
@@ -60,8 +60,8 @@ features:
   spec_decoding:
     description: "Speculative decoding — pick a drafting method."
     # Mode = the --speculative-config method only (args); the served checkpoint is
-    # owned by the Variant row. Default is MTP; the DSpark and 0731 checkpoints
-    # flip this to dspark via their `default_modes`.
+    # owned by the Variant row. Default is MTP; the 0731 (default) and DSpark
+    # checkpoints flip this to dspark via their `default_modes`.
     default_mode: mtp
     modes:
       mtp:
@@ -70,7 +70,7 @@ features:
         # The preview FP4+FP8 and NVFP4 checkpoints ship an MTP head only — their
         # config.json carries no dspark_* block, so dspark can't be drafted there.
         variants:
-          - default
+          - fp8
           - nvfp4
         args:
           - "--speculative-config"
@@ -83,10 +83,11 @@ features:
       dspark:
         label: "DSpark"
         description: "DSpark drafting, 7 draft tokens, greedy. Requires the DSpark or 0731 checkpoint (Variant row)."
-        # Only the fused checkpoints carry the DSpark draft module.
+        # Only the fused checkpoints carry the DSpark draft module — the 0731
+        # release (default) and the DSpark re-pack of the preview weights.
         variants:
+          - default
           - dspark
-          - v0731
         args:
           - "--speculative-config"
           - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"greedy"}'
@@ -96,6 +97,22 @@ opt_in_features:
 
 variants:
   default:
+    # Official 0731 release: new weights (not a re-pack of the preview), same
+    # architecture and same fused DSpark draft module.
+    model_id: "deepseek-ai/DeepSeek-V4-Flash-0731"
+    label: "0731"
+    precision: fp8
+    vram_minimum_gb: 200
+    description: "Official DeepSeek-V4-Flash release (2026-07-31) superseding the preview — substantially stronger agentic performance, with the DSpark draft module attached."
+    min_vllm_version: "0.26.0"
+    default_modes:
+      spec_decoding: dspark
+    hardware_overrides:
+      blackwell:
+        extra_args:
+          - "--moe-backend"
+          - "deep_gemm_mega_moe"
+  fp8:
     precision: fp8
     vram_minimum_gb: 170
     description: "Native FP4+FP8 mixed checkpoint (MoE experts FP4, remaining params FP8)"
@@ -123,22 +140,6 @@ variants:
     description: "Preview FP4+FP8 weights with the DSpark draft module baked in — same base checkpoint as the default variant plus a fused speculative decoder."
     # DSpark drafting landed in 0.25.0; 0.26.0 is the first release where it also
     # works on the MI325X/MI355X pills this recipe advertises (ROCm enablement).
-    min_vllm_version: "0.26.0"
-    default_modes:
-      spec_decoding: dspark
-    hardware_overrides:
-      blackwell:
-        extra_args:
-          - "--moe-backend"
-          - "deep_gemm_mega_moe"
-  v0731:
-    # Official 0731 release: new weights (not a re-pack of the preview), same
-    # architecture and same fused DSpark draft module.
-    model_id: "deepseek-ai/DeepSeek-V4-Flash-0731"
-    label: "0731"
-    precision: fp8
-    vram_minimum_gb: 200
-    description: "Official DeepSeek-V4-Flash release (2026-07-31) superseding the preview — substantially stronger agentic performance, with the DSpark draft module attached."
     min_vllm_version: "0.26.0"
     default_modes:
       spec_decoding: dspark
@@ -272,16 +273,17 @@ guide: |
 
   | Variant | Repo | Draft | Notes |
   | :-- | :-- | :-- | :-- |
-  | **FP8** (default) | `deepseek-ai/DeepSeek-V4-Flash` | MTP | Preview FP4+FP8 mixed weights |
+  | **0731** (default) | `deepseek-ai/DeepSeek-V4-Flash-0731` | DSpark | Official release, new weights + DSpark |
+  | **FP8** | `deepseek-ai/DeepSeek-V4-Flash` | MTP | Preview FP4+FP8 mixed weights |
   | **NVFP4** | `nvidia/DeepSeek-V4-Flash-NVFP4` | MTP | modelopt re-quant, Blackwell |
   | **DSpark** | `deepseek-ai/DeepSeek-V4-Flash-DSpark` | DSpark | Preview weights + fused DSpark module |
-  | **0731** | `deepseek-ai/DeepSeek-V4-Flash-0731` | DSpark | Official release, new weights + DSpark |
 
-  **0731 is the official DeepSeek-V4-Flash release**, superseding the preview with
-  substantially stronger agentic capability — 82.7 on Terminal Bench 2.1 and 54.4 on
-  DeepSWE, versus 61.8 and 7.3 for the preview. It beats DeepSeek-V4-Pro (Preview) on
-  every agentic benchmark DeepSeek published despite its far smaller activated
-  parameter count. **If you are standing up a new deployment, start here.**
+  **0731 is the official DeepSeek-V4-Flash release** and the default here, superseding
+  the preview with substantially stronger agentic capability — 82.7 on Terminal Bench
+  2.1 and 54.4 on DeepSWE, versus 61.8 and 7.3 for the preview. It beats
+  DeepSeek-V4-Pro (Preview) on every agentic benchmark DeepSeek published despite its
+  far smaller activated parameter count. The preview weights remain available as the
+  **FP8** variant for reproducing earlier results.
 
   **DSpark** is *not* new weights — it is the preview checkpoint with a speculative
   decoding module attached (see [DeepSpec](https://github.com/deepseek-ai/DeepSpec)).

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -4,11 +4,11 @@ meta:
   provider: "DeepSeek"
   description: "DeepSeek V4 MoE model with hybrid CSA+HCA attention, manifold-constrained hyper-connections, and three-tier reasoning (Non-think / Think High / Think Max)."
   date_added: 2026-04-24
-  date_updated: 2026-07-16
+  date_updated: 2026-07-31
   difficulty: hard
   tasks:
     - text
-  performance_headline: "Compact 284B/13B V4 sibling — single-node 1M-context serving with FP4+FP8 weights and MTP"
+  performance_headline: "Compact 284B/13B V4 sibling — single-node 1M-context serving with FP4+FP8 weights, MTP, and DSpark speculative decoding"
   related_recipes: []
   hardware:
     h200: verified
@@ -58,15 +58,38 @@ features:
       - "--reasoning-parser"
       - "deepseek_v4"
   spec_decoding:
-    description: "Multi-Token Prediction speculative decoding with 2 speculative tokens (1 on Hopper)."
-    args:
-      - "--speculative-config"
-      - '{"method":"mtp","num_speculative_tokens":2}'
-    hardware_overrides:
-      hopper:
+    description: "Speculative decoding — pick a drafting method."
+    # Mode = the --speculative-config method only (args); the served checkpoint is
+    # owned by the Variant row. Default is MTP; the DSpark and 0731 checkpoints
+    # flip this to dspark via their `default_modes`.
+    default_mode: mtp
+    modes:
+      mtp:
+        label: "MTP"
+        description: "Built-in Multi-Token Prediction, 2 draft tokens (1 on Hopper)."
+        # The preview FP4+FP8 and NVFP4 checkpoints ship an MTP head only — their
+        # config.json carries no dspark_* block, so dspark can't be drafted there.
+        variants:
+          - default
+          - nvfp4
         args:
           - "--speculative-config"
-          - '{"method":"mtp","num_speculative_tokens":1}'
+          - '{"method":"mtp","num_speculative_tokens":2}'
+        hardware_overrides:
+          hopper:
+            args:
+              - "--speculative-config"
+              - '{"method":"mtp","num_speculative_tokens":1}'
+      dspark:
+        label: "DSpark"
+        description: "DSpark drafting, 7 draft tokens, greedy. Requires the DSpark or 0731 checkpoint (Variant row)."
+        # Only the fused checkpoints carry the DSpark draft module.
+        variants:
+          - dspark
+          - v0731
+        args:
+          - "--speculative-config"
+          - '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"greedy"}'
 
 opt_in_features:
   - spec_decoding
@@ -88,6 +111,42 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 170
     description: "NVIDIA modelopt NVFP4 checkpoint (MoE experts NVFP4; attention, shared experts, router head, and MTP stay FP8) for Blackwell GPUs."
+  dspark:
+    # Official fused DSpark checkpoint — the preview weights with the DSpark draft
+    # module attached (config.json gains the dspark_* block). A distinct served
+    # repo, so it lives on the Variant axis; selecting it defaults the
+    # spec-decoding method to dspark (see features.spec_decoding.modes).
+    model_id: "deepseek-ai/DeepSeek-V4-Flash-DSpark"
+    label: "DSpark"
+    precision: fp8
+    vram_minimum_gb: 200
+    description: "Preview FP4+FP8 weights with the DSpark draft module baked in — same base checkpoint as the default variant plus a fused speculative decoder."
+    # DSpark drafting landed in 0.25.0; 0.26.0 is the first release where it also
+    # works on the MI325X/MI355X pills this recipe advertises (ROCm enablement).
+    min_vllm_version: "0.26.0"
+    default_modes:
+      spec_decoding: dspark
+    hardware_overrides:
+      blackwell:
+        extra_args:
+          - "--moe-backend"
+          - "deep_gemm_mega_moe"
+  v0731:
+    # Official 0731 release: new weights (not a re-pack of the preview), same
+    # architecture and same fused DSpark draft module.
+    model_id: "deepseek-ai/DeepSeek-V4-Flash-0731"
+    label: "0731"
+    precision: fp8
+    vram_minimum_gb: 200
+    description: "Official DeepSeek-V4-Flash release (2026-07-31) superseding the preview — substantially stronger agentic performance, with the DSpark draft module attached."
+    min_vllm_version: "0.26.0"
+    default_modes:
+      spec_decoding: dspark
+    hardware_overrides:
+      blackwell:
+        extra_args:
+          - "--moe-backend"
+          - "deep_gemm_mega_moe"
 
 compatible_strategies:
   - single_node_tp
@@ -205,6 +264,41 @@ guide: |
   NVFP4 experts don't support the `deep_gemm_mega_moe` MoE kernel (FP8-only), so it
   runs on the default MoE backend.
 
+  ## Checkpoints
+
+  Four checkpoints are on the **Variant** row. They differ in *which weights you serve*
+  and *which draft module ships with them* — the speculative method itself is picked on
+  the **Spec Decoding** row.
+
+  | Variant | Repo | Draft | Notes |
+  | :-- | :-- | :-- | :-- |
+  | **FP8** (default) | `deepseek-ai/DeepSeek-V4-Flash` | MTP | Preview FP4+FP8 mixed weights |
+  | **NVFP4** | `nvidia/DeepSeek-V4-Flash-NVFP4` | MTP | modelopt re-quant, Blackwell |
+  | **DSpark** | `deepseek-ai/DeepSeek-V4-Flash-DSpark` | DSpark | Preview weights + fused DSpark module |
+  | **0731** | `deepseek-ai/DeepSeek-V4-Flash-0731` | DSpark | Official release, new weights + DSpark |
+
+  **0731 is the official DeepSeek-V4-Flash release**, superseding the preview with
+  substantially stronger agentic capability — 82.7 on Terminal Bench 2.1 and 54.4 on
+  DeepSWE, versus 61.8 and 7.3 for the preview. It beats DeepSeek-V4-Pro (Preview) on
+  every agentic benchmark DeepSeek published despite its far smaller activated
+  parameter count. **If you are standing up a new deployment, start here.**
+
+  **DSpark** is *not* new weights — it is the preview checkpoint with a speculative
+  decoding module attached (see [DeepSpec](https://github.com/deepseek-ai/DeepSpec)).
+  Both fused checkpoints add a `dspark_*` block to `config.json`; the preview and NVFP4
+  checkpoints have no such block, which is why the DSpark method is offered only on the
+  two variants that carry the draft. Selecting either one auto-enables **Spec Decoding**
+  with `method: dspark`, emitting:
+
+  ```
+  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"greedy"}'
+  ```
+
+  The fused checkpoints are ~167 GB on disk versus ~160 GB for the preview — the draft
+  module is the difference. Both require **vLLM 0.26.0**: DSpark drafting itself landed
+  in 0.25.0, but ROCm support for it (MI325X / MI355X) only shipped in 0.26.0. On
+  NVIDIA-only deployments 0.25.0 is sufficient.
+
   ## Reasoning modes
 
   The chat template exposes three reasoning-effort modes:
@@ -215,6 +309,17 @@ guide: |
     (384K tokens) to avoid truncation.
 
   Recommended sampling: `temperature = 1.0`, `top_p = 1.0`.
+
+  On the **0731** variant the effort levels are named `low` / `high` / `max`, and
+  DeepSeek recommends `top_p = 0.95` for agentic scenarios (`1.0` otherwise) with
+  `temperature = 1.0`. Allow up to **384K output tokens** at the `high` and `max`
+  levels.
+
+  Note that neither fused checkpoint ships a Jinja chat template — the repos provide an
+  `encoding/` folder with `encode_messages` / `parse_message_from_completion_text`
+  helpers instead. Serving through vLLM with `--tokenizer-mode deepseek_v4` (the
+  **Tool Calling** pill) applies the built-in DeepSeek-V4 encoding, so the OpenAI-
+  compatible endpoint works without the helper scripts.
 
   ### OpenAI Client Example
 


### PR DESCRIPTION
Adds the two fused-draft **DeepSeek-V4-Flash** checkpoints to the existing recipe as entries on the **Variant** row:

| Variant | Repo | Draft |
| :-- | :-- | :-- |
| **0731** | [`deepseek-ai/DeepSeek-V4-Flash-0731`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) | DSpark |
| **DSpark** | [`deepseek-ai/DeepSeek-V4-Flash-DSpark`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-DSpark) | DSpark |

`0731` is the official release superseding the preview (82.7 Terminal Bench 2.1 / 54.4 DeepSWE vs 61.8 / 7.3), beating DeepSeek-V4-Pro (Preview) on every published agentic benchmark at a far smaller activated parameter count. `DSpark` is not new weights — it is the preview checkpoint with the draft module attached.

They stay variants of `DeepSeek-V4-Flash` rather than separate recipes: same architecture, params, flags and strategies, and both model cards link readers to `recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Flash`. This follows the existing DeepSeek-V4-Pro DSpark precedent.

## spec_decoding becomes single-select modes

Both fused checkpoints ship a DSpark decoder, so `spec_decoding` moves from a flat `args[]` to `modes` (`mtp` / `dspark`). The preview and NVFP4 `config.json` carry no `dspark_*` block, so they keep MTP only; the fused checkpoints declare `default_modes` to auto-enable spec decoding with `method: dspark`. The existing Hopper 1-token MTP override moves into the `mtp` mode unchanged.

## vLLM 0.26.0, not 0.25.0

DSpark drafting landed in 0.25.0 (vllm-project/vllm#46995), but ROCm support only shipped in 0.26.0 (vllm-project/vllm#47419) and this recipe advertises MI325X/MI355X as verified. 0.26.0 is the floor where the recipe works on every hardware pill it offers; the guide notes NVIDIA-only deployments can run 0.25.0.

## Validation

`node scripts/build-recipes-api.mjs` passes. The GB300 DP+EP rendering reproduces DeepSeek's published launch command flag-for-flag:

```bash
vllm serve deepseek-ai/DeepSeek-V4-Flash-0731 \
  --trust-remote-code --kv-cache-dtype fp8 --block-size 256 \
  --enable-expert-parallel --data-parallel-size 4 \
  --attention_config.use_fp4_indexer_cache=True \
  --moe-backend deep_gemm_mega_moe \
  --speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"greedy"}'
```

Also confirmed across the variant × hardware cross-product that NVFP4 still excludes `deep_gemm_mega_moe` (preserving #656) and Hopper still emits MTP with 1 speculative token.

## Notes for reviewers

- VRAM for the new variants is sized from the real checkpoint (166.9 GB × 1.2 = 200) per the mixed-precision rule, so it sits alongside the existing `170` on the preview/NVFP4 variants, which came from the uniform `params × 0.5 × 1.2` formula. Happy to correct those in this PR or a follow-up.
- MTP is deliberately **not** offered on the fused checkpoints. Their configs do carry `num_nextn_predict_layers: 1`, but neither model card documents MTP there and I could not verify it works alongside the DSpark module.

Related to #600 (that issue asks specifically for an 8×RTX Pro 6000 / SM120 profile, which this PR does not add).

🤖 Generated with [Claude Code](https://claude.com/claude-code)