### PR TITLE
Route variant HF ids when the default variant names its own checkpoint

### DIFF
--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -731,13 +731,16 @@ for (const file of findYamlFiles(modelsDir)) {
   const defaultRecommended = renderAndWriteVariant(r, "default", parentHfId, strategies, taxonomy);
   if (defaultRecommended) r.recommended_command = defaultRecommended;
 
-  // Promote each non-default variant whose `model_id` points at a distinct HF
-  // repo to its own top-level JSON endpoint, mirroring the HF URL convention.
-  // Renderings for promoted variants are gathered here and written after the
-  // parent JSON so we can store `json:` pointers in parent.variants.<v>.
+  // Promote each variant whose `model_id` points at a distinct HF repo to its
+  // own top-level JSON endpoint, mirroring the HF URL convention. `default` is
+  // included: a recipe may default to a differently-named checkpoint (this
+  // recipe's own id stays the parent path, rendered above), and that HF id
+  // needs an endpoint too — a default pointing back at the parent id is caught
+  // by the collision check below. Renderings for promoted variants are gathered
+  // here and written after the parent JSON so we can store `json:` pointers in
+  // parent.variants.<v>.
   const promotedRenderings = [];  // { variantKey, variantHfId, recommended }
   for (const [variantKey, variantCfg] of Object.entries(r.variants || {})) {
-    if (variantKey === "default") continue;
     const variantModelId = variantCfg?.model_id;
     if (!variantModelId || typeof variantModelId !== "string" || !variantModelId.includes("/")) continue;
     if (allRecipeHfIds.has(variantModelId)) {

--- a/src/app/[org]/[repo]/page.js
+++ b/src/app/[org]/[repo]/page.js
@@ -74,7 +74,12 @@ export default async function RecipePage({ params, searchParams }) {
   const recipe = getRecipeByHfId(org, repo);
   if (!recipe) {
     const v = findVariantRedirect(org, repo);
-    if (v) redirect(`/${v.parent.hf_org}/${v.parent.hf_repo}?variant=${encodeURIComponent(v.variantKey)}`);
+    // `?variant=default` is redundant — the builder already opens on the
+    // default variant, so a default-variant checkpoint lands on a clean URL.
+    if (v) {
+      const qs = v.variantKey === "default" ? "" : `?variant=${encodeURIComponent(v.variantKey)}`;
+      redirect(`/${v.parent.hf_org}/${v.parent.hf_repo}${qs}`);
+    }
     notFound();
   }
   if (org !== recipe.hf_org || repo !== recipe.hf_repo) {

--- a/src/lib/recipes.js
+++ b/src/lib/recipes.js
@@ -82,8 +82,11 @@ export function getRecipesByOrg(org) {
  * return the parent recipe + variant key so the route can redirect to
  * `/<parent.hf_org>/<parent.hf_repo>?variant=<key>`. Otherwise null.
  *
- * Skips the `default` variant and any variant whose model_id equals the
- * parent's own HF id (those are just the base recipe).
+ * Skips any variant whose model_id equals the parent's own HF id (that's
+ * just the base recipe). The `default` variant is NOT skipped: a recipe may
+ * point its default at a differently-named checkpoint (DeepSeek-V4-Flash
+ * defaults to `-0731`, GLM-5.2 to `-FP8`), and that HF id has to resolve
+ * rather than 404.
  */
 export function findVariantRedirect(org, repo) {
   const target = `${org}/${repo}`.toLowerCase();
@@ -91,8 +94,8 @@ export function findVariantRedirect(org, repo) {
     if (r.hf_id.toLowerCase() === target) return null;
     const variants = r.variants || {};
     for (const [key, v] of Object.entries(variants)) {
-      if (key === "default") continue;
-      if (v?.model_id && v.model_id.toLowerCase() === target) {
+      if (!v?.model_id || v.model_id === r.hf_id) continue;
+      if (v.model_id.toLowerCase() === target) {
         return { parent: r, variantKey: key };
       }
     }
@@ -102,7 +105,8 @@ export function findVariantRedirect(org, repo) {
 
 /**
  * All `<org>/<repo>` pairs that should route to a recipe page — base
- * recipes plus the HF ids of each non-default variant. Used by
+ * recipes plus the HF id of every variant that names its own checkpoint
+ * (`default` included — see findVariantRedirect). Used by
  * `generateStaticParams` so variant ids are prerendered and emit the
  * redirect response instead of 404.
  */
@@ -117,8 +121,7 @@ export function getAllRoutablePairs() {
   };
   for (const r of getAllRecipes()) {
     push(r.hf_org, r.hf_repo);
-    for (const [key, v] of Object.entries(r.variants || {})) {
-      if (key === "default") continue;
+    for (const [, v] of Object.entries(r.variants || {})) {
       if (!v?.model_id || v.model_id === r.hf_id) continue;
       const [vo, ...rest] = v.model_id.split("/");
       if (!vo || rest.length === 0) continue;


### PR DESCRIPTION
`https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Flash-0731` returns **404**.

A recipe can point its `default` variant at a differently-named checkpoint. Three do today:

| Recipe | Default variant serves | URL before |
| :-- | :-- | :-- |
| `deepseek-ai/DeepSeek-V4-Flash` | `…-0731` | 404 |
| `zai-org/GLM-5.2` | `…-FP8` | 404 |
| `jinaai/jina-embeddings-v5-text-small` | `…-retrieval` | 404 |

Non-default variants (`-DSpark`, `-NVFP4`, …) already resolve, so it was exactly the checkpoint users are steered toward — the default — that had no URL. DeepSeek's own model card links readers here.

## Cause

`findVariantRedirect`, `getAllRoutablePairs` (`src/lib/recipes.js`) and the JSON API promotion loop (`scripts/build-recipes-api.mjs`) each skipped `key === "default"` before looking at `model_id`.

That skip was **redundant with the guard beside it** — `!v.model_id || v.model_id === r.hf_id` already excludes an ordinary default (which names no `model_id`) and one that merely restates the parent id. Dropping it is a no-op for every recipe whose default has no `model_id`, and gives the three above a working URL plus a JSON endpoint.

A default-variant checkpoint redirects to the **bare** recipe URL rather than `?variant=default`, since the builder already opens on the default.

## Verification

Against a production build (`next start`):

```
deepseek-ai/DeepSeek-V4-Flash-0731     307 -> /deepseek-ai/DeepSeek-V4-Flash
zai-org/GLM-5.2-FP8                    307 -> /zai-org/GLM-5.2
deepseek-ai/DeepSeek-V4-Flash-DSpark   307 -> /deepseek-ai/DeepSeek-V4-Flash?variant=dspark
nvidia/DeepSeek-V4-Flash-NVFP4         307 -> /deepseek-ai/DeepSeek-V4-Flash?variant=nvfp4
deepseek-ai/DeepSeek-V4-Flash          200
deepseek-ai/Totally-Not-Real           404
```

Existing `?variant=` redirects are unchanged, the base recipe still 200s, and an unknown id still 404s. Promoted variants go 136 → 139; the two Inkling collision warnings are deliberately preserved (that pattern — a variant whose `model_id` equals the recipe's own path — is still caught by the existing collision check, not silently swallowed).

Follow-up to #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)