### PR TITLE
Update deepseek-v4-flash-0731 Docker image version to v0.25.0 to fix unStablize bug 

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -105,6 +105,7 @@ variants:
     vram_minimum_gb: 200
     description: "Official DeepSeek-V4-Flash release (2026-07-31) superseding the preview — substantially stronger agentic performance, with the DSpark draft module attached."
     min_vllm_version: "0.25.0"
+    docker_image: "vllm/vllm-openai:v0.25.0"
     default_modes:
       spec_decoding: dspark
     hardware_overrides:

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -142,7 +142,6 @@ variants:
     # DSpark drafting landed in 0.25.0; 0.26.0 is the first release where it also
     # works on the MI325X/MI355X pills this recipe advertises (ROCm enablement).
     min_vllm_version: "0.25.0"
-    docker_image: "vllm/vllm-openai:v0.25.0"
     default_modes:
       spec_decoding: dspark
     hardware_overrides:

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -488,7 +488,7 @@ guide: |
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_MOONCAKE_BOOTSTRAP_PORT=8998 \
     -e CUDA_VISIBLE_DEVICES=0,1,2,3 \
-    vllm/vllm-openai:latest \
+    vllm/vllm-openai:v0.25.0 \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
@@ -522,7 +522,7 @@ guide: |
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_MOONCAKE_BOOTSTRAP_PORT=9889 \
     -e CUDA_VISIBLE_DEVICES=4,5,6,7 \
-    vllm/vllm-openai:latest \
+    vllm/vllm-openai:v0.25.0 \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
@@ -576,7 +576,7 @@ guide: |
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_NIXL_SIDE_CHANNEL_PORT=5557 \
     -e CUDA_VISIBLE_DEVICES=0,1,2,3 \
-    vllm/vllm-openai:latest \
+    vllm/vllm-openai:v0.25.0 \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
@@ -610,7 +610,7 @@ guide: |
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_NIXL_SIDE_CHANNEL_PORT=5558 \
     -e CUDA_VISIBLE_DEVICES=4,5,6,7 \
-    vllm/vllm-openai:latest \
+    vllm/vllm-openai:v0.25.0 \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -141,6 +141,7 @@ variants:
     # DSpark drafting landed in 0.25.0; 0.26.0 is the first release where it also
     # works on the MI325X/MI355X pills this recipe advertises (ROCm enablement).
     min_vllm_version: "0.25.0"
+    docker_image: "vllm/vllm-openai:v0.25.0"
     default_modes:
       spec_decoding: dspark
     hardware_overrides:

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -104,7 +104,7 @@ variants:
     precision: fp8
     vram_minimum_gb: 200
     description: "Official DeepSeek-V4-Flash release (2026-07-31) superseding the preview — substantially stronger agentic performance, with the DSpark draft module attached."
-    min_vllm_version: "0.26.0"
+    min_vllm_version: "0.25.0"
     default_modes:
       spec_decoding: dspark
     hardware_overrides:
@@ -140,7 +140,7 @@ variants:
     description: "Preview FP4+FP8 weights with the DSpark draft module baked in — same base checkpoint as the default variant plus a fused speculative decoder."
     # DSpark drafting landed in 0.25.0; 0.26.0 is the first release where it also
     # works on the MI325X/MI355X pills this recipe advertises (ROCm enablement).
-    min_vllm_version: "0.26.0"
+    min_vllm_version: "0.25.0"
     default_modes:
       spec_decoding: dspark
     hardware_overrides:
@@ -297,7 +297,7 @@ guide: |
   ```
 
   The fused checkpoints are ~167 GB on disk versus ~160 GB for the preview — the draft
-  module is the difference. Both require **vLLM 0.26.0**: DSpark drafting itself landed
+  module is the difference. Both require **vLLM 0.25.0**: DSpark drafting itself landed
   in 0.25.0, but ROCm support for it (MI325X / MI355X) only shipped in 0.26.0. On
   NVIDIA-only deployments 0.25.0 is sufficient.
 


### PR DESCRIPTION
fix crash and crash bug in 30 minutes "assert self.topk_indices_buffer is not None" ,"Worker_TP7 pid=345) ERROR 08-01 14:43:38 [multiproc_executor.py:1007] RuntimeError: Assertion error (/workspace/.deps/flashmla-src/csrc/sm90/prefill/sparse/instantiations/../phase1.cuh:614): Assertion res == CUresult::CUDA_SUCCESS failed."