### PR TITLE
Enable the Offloading options on DeepSeek-V4-Flash

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -161,6 +161,10 @@ compatible_strategies:
 # latency-oriented alternative.
 default_strategy: single_node_tep
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   blackwell:
     # Common to every variant on Blackwell. The FP8-only deep_gemm_mega_moe MoE


### PR DESCRIPTION
Marks `kv_offload_support` verified on `deepseek-ai/DeepSeek-V4-Flash`, following #704.

**Validated** on 4×H100 (TP4, FP8, vLLM nightly `0.26.1rc1.dev77`, recipe's own `--kv-cache-dtype fp8 --block-size 256`): serve with the option's `--kv-transfer-config`, send a greedy prompt, confirm `kv_offload_store_bytes` > 0, reset the prefix cache, resend, confirm `kv_offload_load_bytes` > 0 and byte-identical output. Both configurations pass:

| config | store | load |
|---|---|---|
| `offloading_cpu` | 368,824,320 | 120,268,800 |
| `offloading_fs` | 368,824,320 | 120,268,800 |

Only `DeepSeek-V4-Flash` is enabled — the other DeepSeek recipes were not tested.