### PR TITLE
Update MiniMax M3 for B300 NVFP4

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -168,6 +168,8 @@ variants:
     description: "NVIDIA-quantized NVFP4 weights (ModelOpt) for Blackwell (B200/B300) — native FP4 tensor cores, ~half the VRAM of MXFP8."
     extra_args:
       - "--trust-remote-code"
+      - "--kv-cache-dtype"
+      - "fp8"
       # FlashInfer TRT-LLM attention kernels with an FP8 indexer KV cache.
       - "--attention_config.backend"
       - "FLASHINFER"

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -73,6 +73,11 @@ features:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
       - "--language-model-only"
+  thinking_always_on:
+    description: "Pin `thinking_mode: enabled` server-side — every turn reasons before answering, including after tool results. Recommended for agentic workflows."
+    args:
+      - "--default-chat-template-kwargs"
+      - '{"thinking_mode": "enabled"}'
   encoder_parallel:
     description: "Run the vision encoder data-parallel instead of tensor-parallel — avoids TP comm overhead on the small encoder. Also enables the host-shared-memory multimodal processor cache and the per-brand encoder attention backend (FlashInfer on NVIDIA, AITER FlashAttention on AMD). Mutually exclusive with text_only."
     # No platform-agnostic `args`: this recipe targets only NVIDIA + AMD, both
@@ -101,6 +106,7 @@ features:
 opt_in_features:
   - spec_decoding
   - text_only
+  - thinking_always_on
   - encoder_parallel
 
 variants:
@@ -171,6 +177,7 @@ variants:
       - "fp8"
     extra_env:
       VLLM_FLOAT32_MATMUL_PRECISION: "high"
+      VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
   mxfp4:
     model_id: "amd/MiniMax-M3-MXFP4"
     precision: mxfp4
@@ -652,28 +659,6 @@ guide: |
     --trust-remote-code \
     --block-size 128 \
     --language-model-only \
-    --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
-  ```
-
-  ### Agentic coding on B300
-
-  The validated B300 agentic-coding lane runs the GQA draft head at TP4 with
-  thinking always on, and pins thinking server-side so every turn — including
-  turns after tool results — reasons before answering:
-
-  ```bash
-  VLLM_FLOAT32_MATMUL_PRECISION=high \
-    vllm serve nvidia/MiniMax-M3-NVFP4 \
-    --tensor-parallel-size 4 \
-    --trust-remote-code \
-    --block-size 128 \
-    --language-model-only \
-    --enable-prefix-caching \
-    --attention-config '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}' \
-    --reasoning-parser minimax_m3 \
-    --tool-call-parser minimax_m3 \
-    --enable-auto-tool-choice \
-    --default-chat-template-kwargs '{"thinking_mode": "enabled"}' \
     --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
   ```
 

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "MiniMax"
   description: "MiniMax M3 vision-language MoE (427B total / 26B active) for frontier coding, agent toolchains, and 1M-token reasoning via MSA sparse attention — native multimodal (image + video + computer use); BF16 plus MXFP8, NVIDIA Blackwell NVFP4, and AMD MI355X MXFP4 variants. Runs on NVIDIA (Hopper/Blackwell) and AMD CDNA4/CDNA3."
   date_added: 2026-06-12
-  date_updated: 2026-07-15
+  date_updated: 2026-08-03
   difficulty: advanced
   tasks:
     - text
@@ -14,6 +14,7 @@ meta:
   hardware:
     h200: verified
     b200: verified
+    b300: verified
     mi300x: verified
     mi355x: verified
 
@@ -161,6 +162,11 @@ variants:
     description: "NVIDIA-quantized NVFP4 weights (ModelOpt) for Blackwell (B200/B300) — native FP4 tensor cores, ~half the VRAM of MXFP8."
     extra_args:
       - "--trust-remote-code"
+      # FlashInfer TRT-LLM attention kernels with an FP8 indexer KV cache.
+      - "--attention_config.backend"
+      - "FLASHINFER"
+      - "--attention_config.use_trtllm_attention"
+      - "true"
       - "--attention_config.indexer_kv_dtype"
       - "fp8"
     extra_env:
@@ -646,6 +652,28 @@ guide: |
     --trust-remote-code \
     --block-size 128 \
     --language-model-only \
+    --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
+  ```
+
+  ### Agentic coding on B300
+
+  The validated B300 agentic-coding lane runs the GQA draft head at TP4 with
+  thinking always on, and pins thinking server-side so every turn — including
+  turns after tool results — reasons before answering:
+
+  ```bash
+  VLLM_FLOAT32_MATMUL_PRECISION=high \
+    vllm serve nvidia/MiniMax-M3-NVFP4 \
+    --tensor-parallel-size 4 \
+    --trust-remote-code \
+    --block-size 128 \
+    --language-model-only \
+    --enable-prefix-caching \
+    --attention-config '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}' \
+    --reasoning-parser minimax_m3 \
+    --tool-call-parser minimax_m3 \
+    --enable-auto-tool-choice \
+    --default-chat-template-kwargs '{"thinking_mode": "enabled"}' \
     --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
   ```
 


### PR DESCRIPTION
Mark B300 as verified for MiniMax-M3, run the NVFP4 variant on FlashInfer TRT-LLM attention with the FP8 indexer KV cache, and document the B300 agentic-coding launch with the EAGLE3-GQA draft head. Best configs based on https://github.com/SemiAnalysisAI/InferenceX/pull/2328.