### PR TITLE
Enable the Offloading options on Inkling-Small

### DIFF
--- a/models/thinkingmachines/Inkling-Small.yaml
+++ b/models/thinkingmachines/Inkling-Small.yaml
@@ -121,6 +121,10 @@ strategy_hardware:
     h100: unsupported
     h200: unsupported
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides:


### PR DESCRIPTION
Marks `kv_offload_support` verified on `thinkingmachines/Inkling-Small`, following #704.

**Validated** on 8×H100 (TP8, bf16 variant, vLLM nightly `0.26.1rc1.dev77`, recipe's `--tokenizer-mode inkling` and autotune flag): serve with the option's `--kv-transfer-config`, greedy prompt, confirm `kv_offload_store_bytes` > 0, reset the prefix cache, resend, confirm `kv_offload_load_bytes` > 0 and byte-identical output. Both configurations pass:

| config | store | load |
|---|---|---|
| `offloading_cpu` | 902,823,936 | 152,305,664 |
| `offloading_fs` | 902,823,936 | 152,305,664 |

Tested on the bf16 variant because NVFP4 requires Blackwell; the default NVFP4 variant is unaffected by this change and untested here.