### PR TITLE
[AMD][Kimi-K3] Enable fused gated RMSNorm

### DIFF
--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Moonshot AI"
   description: "Pre-release 2.8T-parameter native multimodal MoE with Kimi Delta Attention, Gated MLA, Attention Residuals, and a 1M-token context window"
   date_added: 2026-07-27
-  date_updated: 2026-07-30
+  date_updated: 2026-08-03
   difficulty: hard
   tasks:
     - multimodal
@@ -209,6 +209,9 @@ hardware_overrides:
       - "kimi_k3"
       - "--max-num-batched-tokens"
       - "4096"
+      # Fuse the KDA output RMSNorm and sigmoid gate into one Triton kernel.
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY","custom_ops":["+fused_rms_norm_gated"]}'
 
 strategy_overrides:
   # Guide recommendation made concrete: deep_gemm_mega_moe for any DEP
@@ -291,8 +294,6 @@ strategy_overrides:
         - "--max-num-batched-tokens"
         - "32"
         - "--no-disable-hybrid-kv-cache-manager"
-        - "--compilation-config"
-        - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
 
 guide: |
   ## Overview


### PR DESCRIPTION
## Summary

- enable vLLM's `fused_rms_norm_gated` custom op in the AMD Kimi-K3 recipe
- consolidate the ROCm settings into one `--compilation-config` JSON object
- remove Kimi-K3's redundant PD copy of `FULL_DECODE_ONLY`; the shared PD strategy still supplies it on non-AMD hardware
- update the recipe modification date

The custom op fuses the KDA output RMSNorm and sigmoid gate into one Triton kernel. Keeping both ROCm settings in one object avoids duplicate configuration flags and last-wins replacement.

## Directional performance

Kimi-K3, TP8 MI355X, automatic `ROCM_AITER_MLA`, 63,911-token shared prefix + 4,089-token suffix, 350 output tokens, 16 warmups:

| Concurrency | Mean ITL, previous | Mean ITL, fused | Change | Output tok/s, previous | Output tok/s, fused | Change | Mean TTFT, previous | Mean TTFT, fused |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 16 | 44.97 ms | 41.28 ms | -8.2% | 269.94 | 289.91 | +7.4% | 4885.64 ms | 4711.84 ms |
| 24 | 57.67 ms | 52.48 ms | -9.0% | 328.21 | 344.59 | +5.0% | 5071.48 ms | 5667.47 ms |

These are directional comparisons using the requested existing no-flag data. The fusion run isolated `custom_ops` and resolved the non-PD default `FULL_AND_PIECEWISE` graph mode; the recipe now explicitly selects `FULL_DECODE_ONLY`. The previous and fused runs also used different AITER Gluon revisions (`3e11ac40...` and `0cbde922...` respectively), so this is not a strict full-recipe A/B test.

## Validation

- `node scripts/build-recipes-api.mjs` (`153 models`, `9 strategies`)
- checked generated MI300X/MI325X/MI355X single-node, multi-node, Docker, and PD commands; each contains one compilation-config flag
- parsed the combined object with vLLM `EngineArgs`; it resolves to both `cudagraph_mode=FULL_DECODE_ONLY` and `custom_ops=["+fused_rms_norm_gated"]`
- end-to-end C16/C24 runs completed with no request errors or output-length mismatches
