### PR TITLE
Add MiniMax-H3 two-GPU DLO deployment recipe

### DIFF
--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -15,6 +15,8 @@ meta:
   hardware:
     gb200: verified
     b300: verified
+    rtx_4090_2x: verified
+    rtx_5090_2x: verified
     mi300x: verified
     mi325x: verified
     mi355x: verified
@@ -80,6 +82,22 @@ omni:
       vram_minimum_gb: 135
       endpoint: "/v1/videos/sync"
       description: "Text prompt → joint video + synchronized audio. Served by the FL2VA partition."
+      hardware_overrides:
+        rtx_5090_2x:
+          vram_minimum_gb: 64
+        rtx_4090_2x:
+          vram_minimum_gb: 48
+          curl: |
+            curl -sS -X POST http://localhost:8000/v1/videos/sync \
+              -F 'prompt=In a snowy blue-purple forest, Ori carefully walks past a sleeping giant; footsteps crunch in the snow while the creature breathes and softly snorts.' \
+              -F 'width=1024' \
+              -F 'height=576' \
+              -F 'fps=24' \
+              -F 'num_inference_steps=50' \
+              -F 'flow_shift=12' \
+              -F 'seed=1101' \
+              -F 'extra_params={"task":"t2va","duration":5.0,"audio_flow_shift":3.0}' \
+              -o t2va.mp4
       curl: |
         curl -sS -X POST http://localhost:8000/v1/videos/sync \
           -F 'prompt=In a snowy blue-purple forest, Ori carefully walks past a sleeping giant; footsteps crunch in the snow while the creature breathes and softly snorts.' \
@@ -97,6 +115,25 @@ omni:
       vram_minimum_gb: 135
       endpoint: "/v1/videos/sync"
       description: "First frame + prompt → video + audio, on the FL2VA partition. Omitting width/height keeps the first frame's aspect ratio at a 768 px short edge."
+      hardware_overrides:
+        rtx_5090_2x:
+          vram_minimum_gb: 64
+        rtx_4090_2x:
+          vram_minimum_gb: 48
+          curl: |
+            export FIRST_FRAME=/path/to/fl2va_first_frame.png
+
+            curl -sS -X POST http://localhost:8000/v1/videos/sync \
+              -F 'prompt=A man stands beside a yellow car at night. The car drives away; he follows it with his eyes and begins singing sadly, with synchronized voice and city ambience.' \
+              -F 'width=1024' \
+              -F 'height=576' \
+              -F 'fps=24' \
+              -F 'num_inference_steps=50' \
+              -F 'flow_shift=12' \
+              -F 'seed=2101' \
+              -F 'extra_params={"task":"fl2va","duration":5.0,"audio_flow_shift":3.0}' \
+              -F "input_reference=@${FIRST_FRAME};type=image/png" \
+              -o fl2va.mp4
       curl: |
         export FIRST_FRAME=/path/to/fl2va_first_frame.png
 
@@ -115,6 +152,47 @@ omni:
       vram_minimum_gb: 168
       endpoint: "/v1/videos/sync"
       description: "Omni reference (image+audio, or one-or-more videos) → video + audio, on the Ref2VA partition. A full 15 s two-video request peaked at 166 GB on the main rank."
+      hardware_overrides:
+        rtx_5090_2x:
+          vram_minimum_gb: 64
+        rtx_4090_2x:
+          vram_minimum_gb: 48
+          curl: |
+            # A) image + audio reference. Serve local assets first:
+            #    python -m http.server 8092 --bind 127.0.0.1 \
+            #      --directory /path/to/reference_assets
+            export REF_IMAGE=/path/to/reference_assets/ref2va_image.png
+            export AUDIO_URL=http://127.0.0.1:8092/ref2va_audio.mp3
+
+            curl -sS -X POST http://localhost:8000/v1/videos/sync \
+              -F 'prompt=A white cat with black mustache and eyebrow markings sits on a beige couch, lip-syncing precisely to the complete reference audio before shifting from confusion to deadpan speechlessness.' \
+              -F 'width=1024' \
+              -F 'height=576' \
+              -F 'fps=24' \
+              -F 'num_inference_steps=50' \
+              -F 'flow_shift=12' \
+              -F 'seed=3101' \
+              -F 'extra_params={"task":"ref2va","duration":5.0,"audio_flow_shift":3.0}' \
+              -F "input_reference=@${REF_IMAGE};type=image/png" \
+              -F "audio_reference={\"audio_url\":\"${AUDIO_URL}\"}" \
+              -o ref2va_image_audio.mp4
+
+            # B) two video references. Repeat input_references in source order.
+            export SUBJECT_VIDEO=/path/to/green_screen_subject.mp4
+            export BACKGROUND_VIDEO=/path/to/fairytale_background.mov
+
+            curl -sS -X POST http://localhost:8000/v1/videos/sync \
+              -F 'prompt=Remove the green screen background of Video 1 and replace it with the fairytale environment from Video 2. Match the background motion to the character actions and relight the character to fit the scene.' \
+              -F 'width=1024' \
+              -F 'height=576' \
+              -F 'fps=24' \
+              -F 'num_inference_steps=50' \
+              -F 'flow_shift=12' \
+              -F 'seed=3101' \
+              -F 'extra_params={"task":"ref2va","duration":5.0,"audio_flow_shift":3.0}' \
+              -F "input_references=@${SUBJECT_VIDEO};type=video/mp4" \
+              -F "input_references=@${BACKGROUND_VIDEO};type=video/quicktime" \
+              -o ref2va_video_video.mp4
       curl: |
         # A) image + audio reference. `audio_reference` takes an HTTP(S) or data: URL —
         #    serve local assets first:  python -m http.server 8092 --bind 127.0.0.1 \
@@ -173,6 +251,53 @@ variants:
     precision: bf16
     vram_minimum_gb: 135
     description: "BF16 — 66.3 GB DiT + 51.5 GB Qwen3-VL encoder + ~10.6 GB VAEs. 133 GB per-GPU engine peak measured on the validated 4×B300 no-offload profile; --text-encoder-tp-size 4 brings it to 103 GB"
+    hardware_overrides:
+      rtx_5090_2x:
+        extra_args:
+          - "--num-gpus"
+          - "2"
+          - "--tensor-parallel-size"
+          - "2"
+          - "--usp"
+          - "1"
+          - "--ring"
+          - "1"
+          - "--text-encoder-tp-size"
+          - "2"
+          - "--vae-patch-parallel-size"
+          - "2"
+          - "--diffusion-attention-backend"
+          - "CUDNN_ATTN"
+          - "--enable-distributed-layerwise-offload"
+          - "--dlo-no-use-allgather"
+          - "--dlo-resident-layers"
+          - "20"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_OMNI_VIDEO_SYNC_TIMEOUT: "14400"
+      rtx_4090_2x:
+        extra_args:
+          - "--num-gpus"
+          - "2"
+          - "--tensor-parallel-size"
+          - "2"
+          - "--usp"
+          - "1"
+          - "--ring"
+          - "1"
+          - "--text-encoder-tp-size"
+          - "2"
+          - "--vae-patch-parallel-size"
+          - "2"
+          - "--diffusion-attention-backend"
+          - "CUDNN_ATTN"
+          - "--enable-distributed-layerwise-offload"
+          - "--dlo-no-use-allgather"
+          - "--dlo-resident-layers"
+          - "12"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_OMNI_VIDEO_SYNC_TIMEOUT: "14400"
 
 # Omni recipes are served through `vllm serve --omni`, which has its own
 # diffusion-parallelism flags (--usp / --ring / --vae-patch-parallel-size).
@@ -312,15 +437,8 @@ guide: |
 
   ## Launch — two 24/32 GB GPUs with distributed layerwise offload
 
-  [vLLM-Omni PR #5764](https://github.com/vllm-project/vllm-omni/pull/5764) adds a
-  low-memory TP2 path for H3. Until that PR lands in a release, fetch its branch before the
-  editable install:
-
-  ```bash
-  git fetch origin pull/5764/head:minimax-h3-2gpu-dlo
-  git switch minimax-h3-2gpu-dlo
-  uv pip install -e .
-  ```
+  vLLM-Omni includes a low-memory TP2 path for H3. Install the current vLLM-Omni
+  source checkout as shown above; no feature branch is required.
 
   The two-GPU profile combines TP2 with distributed layerwise offload (DLO). Each rank
   keeps its rank-local TP shard in pinned host memory; `--dlo-no-use-allgather` streams

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -438,7 +438,7 @@ guide: |
   ## Launch — two 24/32 GB GPUs with distributed layerwise offload
 
   vLLM-Omni includes a low-memory TP2 path for H3. Install the current vLLM-Omni
-  source checkout as shown above; no feature branch is required.
+  source checkout as shown above.
 
   The two-GPU profile combines TP2 with distributed layerwise offload (DLO). Each rank
   keeps its rank-local TP shard in pinned host memory; `--dlo-no-use-allgather` streams
@@ -797,6 +797,4 @@ guide: |
   - [vLLM-Omni diffusion attention backends](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/)
   - [vLLM-Omni supported models](https://docs.vllm.ai/projects/vllm-omni/en/latest/models/supported_models/)
   - [vLLM-Omni GPU installation](https://docs.vllm.ai/projects/vllm-omni/en/latest/getting_started/installation/gpu/)
-  - [Two-GPU distributed layerwise offload PR](https://github.com/vllm-project/vllm-omni/pull/5764)
   - [ROCm H3 tracking issue](https://github.com/vllm-project/vllm-omni/issues/5697)
-  - [H3 soundfile fallback](https://github.com/vllm-project/vllm-omni/pull/5699)

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -310,6 +310,112 @@ guide: |
   The `[fa4]` extra installs the CuTe-DSL FlashAttention-4 kernels — CUDA-only, and used on
   Blackwell. Drop the extra and the `FLASH_ATTN` backend falls back to FA3/FA2.
 
+  ## Launch — two 24/32 GB GPUs with distributed layerwise offload
+
+  [vLLM-Omni PR #5764](https://github.com/vllm-project/vllm-omni/pull/5764) adds a
+  low-memory TP2 path for H3. Until that PR lands in a release, fetch its branch before the
+  editable install:
+
+  ```bash
+  git fetch origin pull/5764/head:minimax-h3-2gpu-dlo
+  git switch minimax-h3-2gpu-dlo
+  uv pip install -e .
+  ```
+
+  The two-GPU profile combines TP2 with distributed layerwise offload (DLO). Each rank
+  keeps its rank-local TP shard in pinned host memory; `--dlo-no-use-allgather` streams
+  those shards directly instead of reconstructing full DiT blocks on every rank. A
+  configurable prefix of DiT blocks stays resident for the complete denoise stage, then
+  releases its HBM before VAE decode.
+
+  Select the profile first. RTX 5090 uses 20 resident DiT layers at the released
+  1344×768 shape; RTX 4090 keeps more HBM headroom with 12 resident layers and a
+  1024×576 starting shape:
+
+  ```bash
+  # 2× RTX 5090 (32 GB)
+  export DLO_RESIDENT_LAYERS=20 WIDTH=1344 HEIGHT=768
+
+  # Or, 2× RTX 4090 (24 GB)
+  # export DLO_RESIDENT_LAYERS=12 WIDTH=1024 HEIGHT=576
+  ```
+
+  Start the FL2VA partition for T2VA and FL2VA:
+
+  ```bash
+  CUDA_VISIBLE_DEVICES=0,1 \
+  VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  VLLM_OMNI_VIDEO_SYNC_TIMEOUT=14400 \
+  vllm serve /path/to/MiniMax-H3/FL2VA \
+    --omni \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --trust-remote-code \
+    --num-gpus 2 \
+    --tensor-parallel-size 2 \
+    --usp 1 \
+    --ring 1 \
+    --text-encoder-tp-size 2 \
+    --vae-patch-parallel-size 2 \
+    --vae-parallel-mode tile \
+    --vae-use-tiling \
+    --enable-distributed-layerwise-offload \
+    --dlo-no-use-allgather \
+    --dlo-resident-layers "${DLO_RESIDENT_LAYERS}" \
+    --enforce-eager \
+    --diffusion-attention-backend CUDNN_ATTN
+  ```
+
+  The resident count changes placement and transfer frequency only; it does not quantize
+  or change the BF16/FP32 denoise math. Use a **384 GiB-class host** for the pinned model
+  shards and offload buffers.
+
+  Wait for `Application startup complete`, then verify health and run one full 50-step
+  T2VA request:
+
+  ```bash
+  curl --fail http://127.0.0.1:8000/health
+
+  curl --fail-with-body -sS \
+    -X POST http://127.0.0.1:8000/v1/videos/sync \
+    -F 'prompt=At night, three cats march into a bedroom playing tiny brass instruments, then abruptly file out, with synchronized room ambience.' \
+    -F "width=${WIDTH}" \
+    -F "height=${HEIGHT}" \
+    -F 'fps=24' \
+    -F 'num_inference_steps=50' \
+    -F 'flow_shift=12' \
+    -F 'seed=1101' \
+    -F 'extra_params={"task":"t2va","duration":5.0,"audio_flow_shift":3.0}' \
+    -o minimax-h3-t2va.mp4
+
+  ffprobe -v error -show_entries \
+    stream=index,codec_name,width,height,r_frame_rate,sample_rate,channels \
+    -of json minimax-h3-t2va.mp4
+  ffmpeg -v error -i minimax-h3-t2va.mp4 \
+    -map 0:v:0 -map 0:a:0 -f null -
+  ```
+
+  A successful output has H.264 video at 24 FPS and stereo AAC audio at 32 kHz, and the
+  final `ffmpeg` command exits with status 0. One server loads one checkpoint partition;
+  stop it and restart the same command with `/path/to/MiniMax-H3/Ref2VA` before Ref2VA
+  requests.
+
+  The PR includes an all-task runner that starts both partitions in sequence, exercises
+  T2VA, FL2VA, image+audio Ref2VA, and two-video Ref2VA, validates every output stream, and
+  records live server and GPU-memory logs:
+
+  ```bash
+  RUN_ROOT=/path/to/run-root \
+  MODEL_ROOT=/path/to/MiniMax-H3 \
+  GPU_IDS=0,1 \
+  PROFILE=rtx5090 \
+  bash recipes/MiniMaxAI/scripts/run_h3_2gpu_all_tasks.sh
+  ```
+
+  Use `PROFILE=rtx4090` for the 24 GB defaults. The script fails before inference when a
+  checkpoint partition, idle GPU, host-RAM budget, or shared FFmpeg/TorchCodec dependency
+  is missing.
+
   ## Launch — four GPUs (validated best practice)
 
   Measured on 4× NVIDIA B300: no CPU or layerwise offload, Ulysses SP degree 4, native
@@ -569,5 +675,6 @@ guide: |
   - [vLLM-Omni diffusion attention backends](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/)
   - [vLLM-Omni supported models](https://docs.vllm.ai/projects/vllm-omni/en/latest/models/supported_models/)
   - [vLLM-Omni GPU installation](https://docs.vllm.ai/projects/vllm-omni/en/latest/getting_started/installation/gpu/)
+  - [Two-GPU distributed layerwise offload PR](https://github.com/vllm-project/vllm-omni/pull/5764)
   - [ROCm H3 tracking issue](https://github.com/vllm-project/vllm-omni/issues/5697)
   - [H3 soundfile fallback](https://github.com/vllm-project/vllm-omni/pull/5699)

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -649,23 +649,27 @@ guide: |
 
   - Each server process loads exactly **one** checkpoint partition.
   - H3 executes **one generation request per diffusion batch** today.
-  - The first regional-compile request is a warmup — exclude it from steady-state numbers.
+  - The first request is a compile warmup only on the resident regional-compile profiles.
+    The two-GPU DLO recipes use `--enforce-eager` and do not compile the DiT.
   - **The serving path accepts fewer references than the model supports.** H3 documents up
     to 9 images, 3 video clips, and 3 audio clips (12 files) per Omni Reference request;
     the current vLLM-Omni path takes exactly one image plus one audio reference, **or** one
     or more videos with **no** separate `audio_reference` (it uses the source soundtracks).
-  - 768p T2VA and FL2VA are validated on MI300X; use the documented 1344×768 shape.
+  - The 768 px short-edge mode is available for T2VA and FL2VA; 1344×768 is the documented
+    16:9 request shape. The 24 GB DLO recipe uses 1024×576 as its lower-memory starting
+    point.
   - `--cfg-parallel-size > 1` is rejected by design (CFG-distilled, no negative branch).
   - The VAE supports the native `tile` parallel mode only.
   - A `U2 × Ring2` hybrid currently fails with an attention-mask length mismatch; use pure
     Ulysses.
   - **FP8 quantization is not supported yet** — a transformer-side blocker is known and
     deferred past the day-0 release.
-  - **8×64 GB will OOM.** Under `--usp 8 --ring 1 --tp 1` the 66.3 GB DiT is *replicated*
-    per rank, so even `--text-encoder-tp-size 8` leaves ~83.3 GB/rank before activations.
-    Encoder TP is necessary but not sufficient — you also need DiT TP ≥ 2, HSDP, or CPU
-    offload. (Analytical extrapolation from the 4-GPU measurements, not measured on
-    64 GB hardware.)
+  - Pure Ulysses still replicates the 66.3 GB DiT on every rank, so 64 GB GPUs cannot use
+    `--usp N --tp 1` as a resident capacity path. Use DiT TP plus DLO (the two-GPU recipes
+    above), or model-level CPU offload; text-encoder TP alone is not sufficient.
+  - DLO is a capacity path, not a free speedup: it needs substantial host RAM and streams
+    weights over PCIe on every denoise step. Increase `--dlo-resident-layers` only after
+    checking peak HBM on the exact request shape.
 
   ## References
 

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package, Info, Zap, Globe, Wrench, Brain } from "lucide-react";
 import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, isVariantHardwareSupported, fitsSingleNode, isHardwareScalable, isKvStoreBrandSupported, variantRunsOnHardware, pickFittingVariant, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun, resolveOmniCommand, pdPoolModes, defaultModeFor, isModeSupported, isModeAllowedForVariant, resolveModeKey, isFeatureAllowedForStrategy, isKvOffloadAllowedForStrategy, isKvOffloadSupportedForRecipe, isKvOffloadBrandSupported, MAX_NODES, nodesForStrategy, isStrategyReachable } from "@/lib/command-synthesis";
-import { resolveOmniTasks } from "@/lib/omni-tasks";
+import { resolveOmniTasks, resolveOmniTaskForHardware } from "@/lib/omni-tasks";
 import { TooltipProvider, InfoTip } from "@/components/ui/tooltip";
 import { detectPlaceholdersAll, substitute, substituteEnv, loadEndpoints, saveEndpoint, clearEndpoints } from "@/lib/cluster-endpoints";
 
@@ -788,7 +788,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   // All hardware profiles grouped by brand, sorted by architectural generation
   // within brand (oldest → newest; matches the semianalysis GPU timeline).
   const hwByBrand = useMemo(() => {
-    const NVIDIA_ORDER = ["h100", "h200", "b200", "gb200", "b300", "gb300", "dgx_station_gb300"];
+    const NVIDIA_ORDER = ["h100", "h200", "b200", "gb200", "b300", "gb300", "rtx_4090_2x", "rtx_5090_2x", "dgx_station_gb300"];
     const AMD_ORDER = ["mi300x", "mi325x", "mi355x"];
     const rankIn = (list, id) => {
       const i = list.indexOf(id);
@@ -1713,13 +1713,14 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     const omniVariants = Object.entries(recipe.variants || {});
     const showOmniVariants = omniVariants.length > 1;
     const showOmniTaskRow = omniTasks.length > 1;
-    const activeTask = omniTasks.find((t) => t.id === omniTask) || omniTasks[0] || null;
+    const activeTaskBase = omniTasks.find((t) => t.id === omniTask) || omniTasks[0] || null;
+    const activeTask = resolveOmniTaskForHardware(activeTaskBase, hwId);
 
     // Render the `vllm serve --omni` command via the shared omni resolver.
     // Falls back to a stub when the recipe has no omni.tasks declared yet
     // (legacy omni-tagged recipes that haven't been migrated).
     const omniRendered = activeTask
-      ? resolveOmniCommand(recipe, variant, activeTask, hwProfile)
+      ? resolveOmniCommand(recipe, variant, activeTask, hwProfile, hwId)
       : {
           command: `${recipe.omni?.serve_binary || "vllm serve"} ${currentVariant.model_id || recipe.model?.model_id || "model"} --omni`,
           env: {},
@@ -1858,19 +1859,22 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                 hint="Each task picks a vllm-omni handler endpoint and example payload. For multi-checkpoint families (Wan2.2 T2V/I2V/TI2V) the task also swaps the served model_id."
               >
                 <PillGroup>
-                  {omniTasks.map((t) => (
-                    <Pill
-                      key={t.id}
-                      active={activeTask?.id === t.id}
-                      onClick={() => selectOmniTask(t.id)}
-                      title={[t.description, `Endpoint: ${t.endpoint}`].filter(Boolean).join("\n\n")}
-                    >
-                      <span className="font-semibold">{t.label}</span>
-                      {t.vramMinimumGb && (
-                        <span className="text-muted-foreground ml-1.5 font-mono">{t.vramMinimumGb} GB</span>
-                      )}
-                    </Pill>
-                  ))}
+                  {omniTasks.map((task) => {
+                    const t = resolveOmniTaskForHardware(task, hwId);
+                    return (
+                      <Pill
+                        key={t.id}
+                        active={activeTask?.id === t.id}
+                        onClick={() => selectOmniTask(t.id)}
+                        title={[t.description, `Endpoint: ${t.endpoint}`].filter(Boolean).join("\n\n")}
+                      >
+                        <span className="font-semibold">{t.label}</span>
+                        {t.vramMinimumGb && (
+                          <span className="text-muted-foreground ml-1.5 font-mono">{t.vramMinimumGb} GB</span>
+                        )}
+                      </Pill>
+                    );
+                  })}
                 </PillGroup>
                 {activeTask?.description && (
                   <p className="text-[11px] text-muted-foreground mt-2 leading-snug">

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -767,7 +767,7 @@ function shellQuote(s) {
  *     only user is stable-audio-open, whose handler doesn't ship in `vllm`).
  *   - `recipe.omni.port` overrides the rendered `--port` flag (default 8000).
  */
-export function resolveOmniCommand(recipe, variantKey, task, hwProfile) {
+export function resolveOmniCommand(recipe, variantKey, task, hwProfile, hwProfileId = null) {
   const variant = recipe.variants?.[variantKey] || recipe.variants?.default || {};
   const modelId = task?.modelId || variant.model_id || recipe.model?.model_id || "unknown";
   const gen = normalizeGeneration(hwProfile?.generation || hwProfile?.gpu_generation);
@@ -779,12 +779,21 @@ export function resolveOmniCommand(recipe, variantKey, task, hwProfile) {
   const ho = recipe.hardware_overrides?.[gen]
     || (isNvidia ? recipe.hardware_overrides?.nvidia : null);
   if (ho?.extra_env) Object.assign(env, ho.extra_env);
+  const variantGenHo = variant?.hardware_overrides?.[gen]
+    || (isNvidia ? variant?.hardware_overrides?.nvidia : null);
+  if (variantGenHo?.extra_env) Object.assign(env, variantGenHo.extra_env);
+  const variantExactHo = hwProfileId
+    ? variant?.hardware_overrides?.[hwProfileId]
+    : null;
+  if (variantExactHo?.extra_env) Object.assign(env, variantExactHo.extra_env);
 
   const args = [];
   if (recipe.model?.base_args) args.push(...recipe.model.base_args);
   if (variantKey !== "default" && variant.extra_args) args.push(...variant.extra_args);
   if (task?.extraArgs?.length) args.push(...task.extraArgs);
   if (ho?.extra_args) args.push(...ho.extra_args);
+  if (variantGenHo?.extra_args) args.push(...variantGenHo.extra_args);
+  if (variantExactHo?.extra_args) args.push(...variantExactHo.extra_args);
   // --omni is the toggle that puts vllm into omni-handler mode. Always emit it
   // last — dedupeArgs's last-wins rule keeps it idempotent if the recipe also
   // declares it in base_args.

--- a/src/lib/omni-tasks.js
+++ b/src/lib/omni-tasks.js
@@ -208,7 +208,7 @@ export const OMNI_TASKS = {
  *                       interpolates host/port/modelId into a sample request)
  *
  * Returns: [{ id, label, endpoint, method, modelId?, vramMinimumGb?,
- *             description?, extraArgs?, example }]
+ *             description?, extraArgs?, hardwareOverrides?, example }]
  */
 export function resolveOmniTasks(recipe) {
   const decl = recipe?.omni?.tasks;
@@ -230,10 +230,29 @@ export function resolveOmniTasks(recipe) {
       vramMinimumGb: override.vram_minimum_gb,
       description: override.description,
       extraArgs: override.extra_args || [],
+      hardwareOverrides: override.hardware_overrides || {},
       example: customCurl ? () => customCurl : base.example,
     });
   }
   return out;
+}
+
+/** Apply an exact hardware override to one resolved omni task. */
+export function resolveOmniTaskForHardware(task, hwProfileId) {
+  if (!task || !hwProfileId) return task;
+  const override = task.hardwareOverrides?.[hwProfileId];
+  if (!override) return task;
+  const customCurl = override.curl;
+  return {
+    ...task,
+    label: override.label || task.label,
+    endpoint: override.endpoint || task.endpoint,
+    modelId: override.model_id || task.modelId,
+    vramMinimumGb: override.vram_minimum_gb ?? task.vramMinimumGb,
+    description: override.description || task.description,
+    extraArgs: [...(task.extraArgs || []), ...(override.extra_args || [])],
+    example: customCurl ? () => customCurl : task.example,
+  };
 }
 
 /**

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -118,6 +118,30 @@ hardware_profiles:
     scalable: false
     restricted: true
 
+  # Exact two-card consumer profiles. Kept restricted so they only appear for
+  # recipes with an end-to-end validated multi-GPU deployment.
+  rtx_4090_2x:
+    brand: NVIDIA
+    generation: ada
+    display_name: "RTX 4090"
+    description: "NVIDIA RTX 4090 · 2× RTX 4090 GPU · 24 GB VRAM/GPU"
+    gpu_count: 2
+    vram_gb: 48
+    multi_node: false
+    scalable: false
+    restricted: true
+
+  rtx_5090_2x:
+    brand: NVIDIA
+    generation: blackwell
+    display_name: "RTX 5090"
+    description: "NVIDIA RTX 5090 · 2× RTX 5090 GPU · 32 GB VRAM/GPU"
+    gpu_count: 2
+    vram_gb: 64
+    multi_node: false
+    scalable: false
+    restricted: true
+
   # ── AMD Instinct ──
   mi300x:
     brand: AMD


### PR DESCRIPTION
Wait until https://github.com/vllm-project/vllm-omni/pull/5764 is merged

## Summary

- add selectable, verified 2× RTX 5090 and 2× RTX 4090 MiniMax-H3 hardware profiles
- render the exact TP2 + distributed layerwise offload server command for each profile
- switch task VRAM hints and 50-step cURL examples with the selected hardware
- cover T2VA, FL2VA, image+audio Ref2VA, and two-video Ref2VA
- document install, launch, health checks, and H.264/AAC full-decode validation as integrated vLLM-Omni functionality

## Validation

- `node scripts/build-recipes-api.mjs`
- JS syntax checks for both shared resolvers
- SWC JSX syntax check for `CommandBuilder.jsx`
- exact command/task assertions for both two-GPU profiles and all MiniMax-H3 tasks
- Next.js dev render: `/MiniMaxAI/MiniMax-H3` returned HTTP 200 and exposed both verified hardware choices
- `git diff --check`