### PR TITLE
[ROCm] Fix MiniMax-M3 EAGLE draft backend recipe

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -62,12 +62,22 @@ features:
         args:
           - "--speculative-config"
           - '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
+        hardware_overrides:
+          amd:
+            args:
+              - "--speculative-config"
+              - '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3", "num_speculative_tokens": 3, "attention_backend": "TRITON_ATTN"}'
       eagle3_gqa:
         label: "GQA"
         description: "GQA Eagle3 draft head (Grouped Query Attention, 4 KV heads vs 64) — 16× smaller draft KV cache. Prefer for long-context or large-batch deployments where draft KV memory is the constraint."
         args:
           - "--speculative-config"
           - '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
+        hardware_overrides:
+          amd:
+            args:
+              - "--speculative-config"
+              - '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "TRITON_ATTN"}'
   text_only:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:


### PR DESCRIPTION
Fix MiniMax-M3 ROCm EAGLE draft attention backend recipe.

Update the MiniMax-M3 recipe so AMD ROCm EAGLE3 speculative decoding uses `TRITON_ATTN` for the draft model attention backend. Keep the default CUDA/NVIDIA EAGLE3 draft backend as `FLASH_ATTN`.

AI assistance was used for this PR.

## Motivation

The MI355X MiniMax-M3 MXFP8 recipe already selects `TRITON_ATTN` for the target model on ROCm, but the EAGLE3 `speculative_config` still selected `FLASH_ATTN` for the draft model:

```bash
vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
  --block-size 128 \
  --attention-backend TRITON_ATTN \
  --tensor-parallel-size 8 \
  --tool-call-parser minimax_m3 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m3 \
  --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3", "num_speculative_tokens": 3, "attention_backend": "FLASH_ATTN"}'
```

On ROCm, that draft backend selection failed during EAGLE/drafter startup:

```text
AssertionError: FlashAttention version not detected.
```

Using `TRITON_ATTN` for the EAGLE draft backend allowed the same ROCm setup to start successfully:

```bash
vllm serve MiniMaxAI/MiniMax-M3-MXFP8 \
  --block-size 128 \
  --attention-backend TRITON_ATTN \
  --tensor-parallel-size 8 \
  --tool-call-parser minimax_m3 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m3 \
  --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3", "num_speculative_tokens": 3, "attention_backend": "TRITON_ATTN"}'
```

## Validation

- Runtime startup probes on MI355X with `vllm/vllm-openai-rocm:nightly-cb8104839c141609d99f1254459ef3a4f1bd4263`
- Ran the documented recipe generator:

```bash
docker run --rm -v "$PWD":/work -w /work node:24-bookworm bash -lc 'corepack enable && pnpm install --frozen-lockfile && node scripts/build-recipes-api.mjs'
```

Result:

```text
✓ JSON API: 153 models (130 with recommended_command, 670 default-hw alternatives, 1206 per-hw renderings), 139 promoted variants, 9 strategies, 2 kv-store deployments, 2 platforms (2 variant collisions skipped)
```

- Synthesized the MI355X + MXFP8 + EAGLE3 command and confirmed the draft `speculative_config` now uses `TRITON_ATTN`.
- Synthesized the B200 + NVFP4 + EAGLE3 command and confirmed the draft `speculative_config` still uses `FLASH_ATTN`.