### PR TITLE
Add inclusionAI/Ling-3.0-flash recipe

### DIFF
--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -1,0 +1,120 @@
+meta:
+  title: "Ling-3.0-flash"
+  slug: "ling-3-0-flash"
+  provider: "inclusionAI"
+  description: "Ling-3.0-flash MoE model with 124B total / 5.5B active parameters and a 3.1B MTP layer"
+  date_updated: 2026-08-14
+  difficulty: advanced
+  tasks:
+    - text
+  performance_headline: "Validated on 4x NVIDIA H20 with FlashMLA, MTP, and CUDA graphs"
+  hardware:
+    h20: verified
+
+model:
+  model_id: "inclusionAI/Ling-3.0-flash"
+  min_vllm_version: "0.25.0"
+  nightly_required: true
+  architecture: moe
+  parameter_count: "124B"
+  active_parameters: "5.5B"
+  context_length: 131072
+  base_args:
+    - "--trust-remote-code"
+    - "--dtype"
+    - "bfloat16"
+    - "--gpu-memory-utilization"
+    - "0.9"
+    - "--enable-chunked-prefill"
+    - "--compilation-config"
+    - '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+    - "--enable-prefix-caching"
+
+features:
+  tool_calling:
+    description: "Enable Ling 3 automatic tool calling"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "ling3"
+  reasoning:
+    description: "Split Ling 3 thinking traces into reasoning_content"
+    args:
+      - "--reasoning-parser"
+      - "ling3"
+  spec_decoding:
+    description: "Use the model's native MTP head with three speculative tokens"
+    args:
+      - "--speculative-config"
+      - '{"method":"mtp","num_speculative_tokens":3}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 300
+    description: "Provisional BF16 checkpoint; validated with TP=4 on NVIDIA H20"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+
+strategy_overrides:
+  single_node_tp:
+    tp: 4
+
+guide: |
+  ## Overview
+
+  `inclusionAI/Ling-3.0-flash` uses the `BailingMoeV3ForCausalLM` architecture
+  with a hybrid MLA/KDA attention stack, 512 routed experts (8 active per token),
+  one shared expert, and a native multi-token prediction head. The 42-layer base
+  model has 124.4B total and 5.5B active parameters. The checkpoint also contains
+  a 3.1B MTP layer, bringing the complete checkpoint to 127.5B parameters.
+
+  ## Prerequisites
+
+  - **vLLM:** a build containing native Bailing V3 support
+  - **Validated hardware:** 4x NVIDIA H20-3e
+  - **Precision:** BF16
+  - **Context length:** 131,072 tokens
+
+  ## Launching the Server
+
+  ```bash
+  NCCL_DEBUG=WARN vllm serve inclusionAI/Ling-3.0-flash \
+    --trust-remote-code \
+    --dtype bfloat16 \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.9 \
+    --enable-chunked-prefill \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser ling3 \
+    --reasoning-parser ling3 \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+  ```
+
+  ## Thinking Mode
+
+  Thinking is selected per request through the chat template rather than by a
+  server flag:
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="inclusionAI/Ling-3.0-flash",
+      messages=[{"role": "user", "content": "Solve the problem step by step."}],
+      temperature=0.0,
+      max_tokens=128000,
+      extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+  )
+  print(response.choices[0].message.reasoning_content)
+  print(response.choices[0].message.content)
+  ```


### PR DESCRIPTION
## Summary

Adds a serving recipe for [inclusionAI/Ling-3.0-Flash](https://huggingface.co/inclusionAI/Ling-3.0-flash).

- Architecture: `BailingMoeV3ForCausalLM`, a hybrid MLA/KDA MoE model.
- Size: 124B total / 5.5B active parameters, with 512 routed experts
  (8 active per token), one shared expert, and a 3.1B MTP layer.
- Context: 131K tokens.
- Precision: BF16.
- Features: CUDA graphs, prefix caching, Mamba cache alignment, Ling3
  reasoning/tool-call parsing, and opt-in MTP speculative decoding.
- Validated deployment: single-node TP=4 on NVIDIA H20.

The recipe requires a vLLM build containing Ling-3.0-Flash model support.
The MTP configuration is opt-in because it trades additional model-side work
for higher decode throughput.

## Test Plan

- [x] `node scripts/build-recipes-api.mjs`
- [x] Verify the generated model metadata and launch commands in the local
  recipes preview.
- [x] Start the TP=4 BF16 recipe on NVIDIA GPUs.
- [x] Verify base generation, `ling3` reasoning parsing, automatic tool calls,
  and opt-in MTP decoding.