### PR TITLE
Fix Simple CPU offload boolean

### DIFF
--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -286,7 +286,7 @@ kv_offload:
     description: "Offload KV cache to CPU DRAM on each serving node via SimpleCPUOffloadConnector — one flag, no extra infrastructure. ~220 GiB of host RAM used per GPU rank."
     args:
       - "--kv-transfer-config"
-      - '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use_per_rank":236223201280,"lazy_offload":"false"}}'
+      - '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use_per_rank":236223201280,"lazy_offload":false}}'
   offloading_cpu:
     display_name: "CPU DRAM only"
     label: "CPU"


### PR DESCRIPTION
## Summary

- Encode `lazy_offload` as a JSON boolean in the shared Simple CPU offload config.

## Why

The connector expects a boolean, but the recipe emitted the string `"false"`. This fixes generated commands to emit `false` with the correct type.

## Validation

- `node scripts/build-recipes-api.mjs`
- `git diff --check`
