### PR TITLE
Add AMD recipes for Inkling models and fix selector deadlocks

### DIFF
--- a/models/thinkingmachines/Inkling-Small.yaml
+++ b/models/thinkingmachines/Inkling-Small.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Thinking Machines Lab"
   description: "Natively multimodal 276B-parameter MoE from Thinking Machines Lab — 12B active parameters, text/image/audio in, text out, and up to 1M context."
   date_added: 2026-07-30
-  date_updated: 2026-07-30
+  date_updated: 2026-08-04
   difficulty: intermediate
   tasks:
     - multimodal
@@ -12,9 +12,8 @@ meta:
   related_recipes:
     - "thinkingmachines/Inkling"
   hardware:
-    mi300x: unsupported
-    mi325x: unsupported
-    mi355x: unsupported
+    mi300x: verified
+    mi355x: verified
 
 model:
   model_id: "thinkingmachines/Inkling-Small-NVFP4"
@@ -31,10 +30,8 @@ model:
     - "--trust-remote-code"
     - "--tokenizer-mode"
     - "inkling"
-    - "--kernel-config.enable_flashinfer_autotune=False"
   base_env:
     VLLM_USE_V2_MODEL_RUNNER: "1"
-    FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED: "1"
 
 dependencies:
   - note: "Audio extras — only needed when serving the audio modality"
@@ -83,6 +80,65 @@ variants:
       gb300: 1
       h200: 2
     description: "NVFP4 checkpoint requiring at least 180 GB aggregated VRAM: W4A4 with TP1 on B300/GB300 or TP2 on B200/GB200, and W4A16 with TP2 on H200."
+    extra_args:
+      - "--kernel-config.enable_flashinfer_autotune=False"
+    extra_env:
+      FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED: "1"
+  mxfp4:
+    model_id: "EmbeddedLLM/Inkling-Small-MXFP4"
+    precision: mxfp4
+    precision_hardware:
+      brand: AMD
+    vram_minimum_gb: 160
+    supported_hardware:
+      - mi300x
+      - mi325x
+      - mi355x
+    tp:
+      mi300x: 2
+      mi325x: 2
+      mi355x: 1
+    description: "Quark OCP MXFP4 checkpoint for AMD Instinct. Its measured MI355X TP1 load footprint was 149.03 GiB consumed (~160.0 GB decimal); add KV-cache capacity for serving. Full 1M context is validated at TP1 on MI355X and TP2 on MI300X. MI325X uses the same gfx942 TP2 path but is not yet smoke-tested."
+    hardware_overrides:
+      mi300x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "auto"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.85"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
+          INKLING_GFX950_GLUON: "0"
+      mi325x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "auto"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.85"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
+          INKLING_GFX950_GLUON: "0"
+      mi355x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "aiter"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.95"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
+          INKLING_GFX950_GLUON: "0"
   bf16:
     model_id: "thinkingmachines/Inkling-Small"
     precision: bf16
@@ -93,13 +149,64 @@ variants:
       - gb200
       - gb300
       - h200
+      - mi300x
+      - mi325x
+      - mi355x
     tp:
       b300: 4
       b200: 8
       gb200: 4
       gb300: 4
       h200: 8
-    description: "Full BF16 checkpoint requiring at least 600 GB aggregated VRAM: TP4 on B300/GB200/GB300 or TP8 on B200/H200."
+      mi300x: 4
+      mi325x: 4
+      mi355x: 4
+    description: "Full BF16 checkpoint requiring at least 600 GB aggregated VRAM: TP4 on B300/GB200/GB300 and AMD Instinct, or TP8 on B200/H200. MI355X TP4 is smoke-tested; MI300X/MI325X use the gfx942 automatic MoE path pending direct BF16 smoke."
+    hardware_overrides:
+      nvidia:
+        extra_args:
+          - "--kernel-config.enable_flashinfer_autotune=False"
+        extra_env:
+          FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED: "1"
+      mi300x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "auto"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.90"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
+      mi325x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "auto"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.90"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
+      mi355x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "aiter"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.90"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -163,13 +270,18 @@ guide: |
   - **NVFP4 (default):** Requires at least 180 GB aggregated VRAM. Run W4A4 with TP1
     on B300/GB300 or TP2 on B200/GB200. On H200, run W4A16 with TP2; the MoE kernel
     dequantizes the NVFP4 weights to BF16 on the fly.
-  - **BF16:** Requires at least 600 GB aggregated VRAM. Run TP4 on B300/GB200/GB300 or
-    TP8 on B200/H200.
+  - **BF16:** Requires at least 600 GB aggregated VRAM. Run TP4 on B300/GB200/GB300
+    or AMD MI300X/MI325X/MI355X, and TP8 on B200/H200. MI355X TP4 is validated;
+    direct MI300X/MI325X BF16 smoke is pending.
+  - **MXFP4 (AMD):** `EmbeddedLLM/Inkling-Small-MXFP4` keeps the full 1M-token
+    context at TP1 on MI355X or TP2 on MI300X. MI355X runs native AITER MXFP4
+    MoE; MI300X uses the supported Triton on-the-fly MXFP4 emulation path.
 
   ## Prerequisites
 
   - **Hardware:** B300/GB300 TP1 or B200/GB200/H200 TP2 for NVFP4;
-    B300/GB200/GB300 TP4 or B200/H200 TP8 for BF16.
+    B300/GB200/GB300/MI300X/MI325X/MI355X TP4 or B200/H200 TP8 for BF16;
+    MI355X TP1 or MI300X/MI325X TP2 for AMD MXFP4.
   - **vLLM:** A nightly build with Inkling support.
   - **Audio:** Install the optional `vllm[audio]` extra only when serving audio inputs.
 
@@ -194,8 +306,30 @@ guide: |
   On H200, the builder emits TP2 and vLLM runs W4A16 with on-the-fly
   dequantization.
 
-  For BF16, select the **BF16** variant. The command builder emits TP4 on
-  B300/GB200/GB300 and TP8 on B200/H200.
+  On AMD, select the **MXFP4** variant. To fit 1M context, MI300X TP2 and MI355X TP1.
+  MI355X uses `--moe-backend aiter`; MI300X uses `--moe-backend auto`
+  because native AITER W4A4 is gated to gfx950, while gfx942 falls back to
+  `OCP_MXQuantizationEmulationTritonExperts`. Inkling relative attention remains
+  on its model-specific Triton path (`INKLING_GFX950_GLUON=0`), which was faster
+  than the optional gfx950 Gluon path in the serving benchmark.
+
+  Equivalent MI355X launch:
+  ```bash
+  export VLLM_USE_V2_MODEL_RUNNER=1
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_USE_AITER_MOE=1
+  export INKLING_GFX950_GLUON=0
+
+  vllm serve EmbeddedLLM/Inkling-Small-MXFP4 \
+    --tensor-parallel-size 1 \
+    --tokenizer-mode inkling \
+    --reasoning-parser inkling \
+    --tool-call-parser inkling \
+    --enable-auto-tool-choice \
+    --moe-backend aiter \
+    --block-size 128 \
+    --trust-remote-code
+  ```
 
   Query the server with the OpenAI SDK:
   ```python
@@ -219,4 +353,5 @@ guide: |
   ## References
 
   - [TML Inkling announcement](https://thinkingmachines.ai/news/introducing-inkling/#inkling-small)
+  - [Inkling-Small MXFP4 for AMD](https://huggingface.co/EmbeddedLLM/Inkling-Small-MXFP4)
   - [TML Inkling recipe](https://docs.vllm.ai/projects/recipes/en/latest/thinkingmachines/Inkling.html)

--- a/models/thinkingmachines/Inkling.yaml
+++ b/models/thinkingmachines/Inkling.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Thinking Machines Lab"
   description: "Natively multimodal 1T-parameter MoE from Thinking Machines Lab — text/image/audio in, text out, up to 1M context — with relative attention, short convolution, and shared expert sinks."
   date_added: 2026-07-15
-  date_updated: 2026-07-30
+  date_updated: 2026-08-04
   difficulty: intermediate
   tasks:
     - multimodal
@@ -14,9 +14,8 @@ meta:
     gb200: verified
     b200: verified
     h200: verified
-    mi300x: unsupported
-    mi325x: unsupported
-    mi355x: unsupported
+    mi300x: verified
+    mi355x: verified
 
 model:
   model_id: "thinkingmachines/Inkling-NVFP4"
@@ -33,10 +32,8 @@ model:
     - "--trust-remote-code"
     - "--tokenizer-mode"
     - "inkling"
-    - "--kernel-config.enable_flashinfer_autotune=False"
   base_env:
     VLLM_USE_V2_MODEL_RUNNER: "1"
-    FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED: "1"
 
 dependencies:
   - note: "Audio extras — only needed when serving the audio modality"
@@ -78,11 +75,78 @@ variants:
       brand: NVIDIA
     vram_minimum_gb: 651
     description: "Weight-only NVFP4 (group size 16) on the routed MoE expert matmuls only; attention, norms, sconv, shared experts, routers, embeddings, and the layer 0-1 dense MLPs stay BF16. ~542 GB on disk. On Hopper, the MoE kernel dequantizes the NVFP4 expert weights to BF16 on the fly."
+    extra_args:
+      - "--kernel-config.enable_flashinfer_autotune=False"
+    extra_env:
+      FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED: "1"
+  mxfp4:
+    model_id: "lightseekorg/Inkling-MXFP4"
+    precision: mxfp4
+    precision_hardware:
+      brand: AMD
+    vram_minimum_gb: 540
+    supported_hardware:
+      - mi300x
+      - mi325x
+      - mi355x
+    tp:
+      mi300x: 4
+      mi325x: 4
+      mi355x: 4
+    description: "Quark OCP MXFP4 checkpoint for AMD Instinct: TP4 on MI355X with native AITER MXFP4 MoE, or TP4 on MI300X/MI325X with Triton MXFP4 emulation. Full 1M context is validated on MI300X and MI355X; MI325X uses the same gfx942 path but is not yet smoke-tested."
+    hardware_overrides:
+      mi300x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "auto"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.95"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
+          INKLING_GFX950_GLUON: "0"
+      mi325x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "auto"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.95"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
+          INKLING_GFX950_GLUON: "0"
+      mi355x:
+        docker_image: "vllm/vllm-openai-rocm:nightly"
+        extra_args:
+          - "--moe-backend"
+          - "aiter"
+          - "--block-size"
+          - "128"
+          - "--gpu-memory-utilization"
+          - "0.90"
+        extra_env:
+          VLLM_ROCM_USE_AITER: "1"
+          VLLM_ROCM_USE_AITER_MOE: "1"
+          INKLING_GFX950_GLUON: "0"
   bf16:
     model_id: "thinkingmachines/Inkling"
     precision: bf16
+    precision_hardware:
+      brand: NVIDIA
     vram_minimum_gb: 2400
     description: "Full BF16 checkpoint (~1.8 TB on disk). Runs on Hopper and Blackwell."
+    extra_args:
+      - "--kernel-config.enable_flashinfer_autotune=False"
+    extra_env:
+      FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -170,11 +234,14 @@ guide: |
     on the fly.
   - **BF16:** Full BF16 weights (`thinkingmachines/Inkling`). Runs on both **Hopper**
     (H200&H20) and Blackwell, at the cost of substantially more VRAM.
+  - **MXFP4 (AMD):** `lightseekorg/Inkling-MXFP4` keeps the full 1M-token context
+    at TP4 on MI355X and MI300X. MI355X runs native AITER MXFP4 MoE; MI300X uses
+    Triton on-the-fly MXFP4 emulation.
 
   ## Prerequisites
 
-  - **Hardware:** NVIDIA Hopper (H200/H20) or Blackwell for both NVFP4 and BF16. Broader
-    hardware support is in progress.
+  - **Hardware:** NVIDIA Hopper (H200/H20) or Blackwell for NVFP4 and BF16;
+    AMD MI300X, MI325X, or MI355X with TP4 for MXFP4.
   - **vLLM:** Nightly wheels (Day-0 support just landed).
   - **Parallelism:** 1T parameters requires multi-GPU. The featured configuration is 4x GB200
     (`--tensor-parallel-size 4`) for the NVFP4 variant. On Hopper, NVFP4 uses TP8 on H200;
@@ -200,6 +267,27 @@ guide: |
   For a multi-node BF16 deployment on Hopper (H200/H20), select the **DEP**
   strategy with **Nodes = 2** in the command builder above — it renders the
   per-node `vllm serve` commands (TP within each node, DP across nodes).
+
+  On AMD, select the **MXFP4** variant. TP4 is validated with the native
+  1M context on both GPU families.
+
+  Equivalent MI355X launch:
+  ```bash
+  export VLLM_USE_V2_MODEL_RUNNER=1
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ROCM_USE_AITER_MOE=1
+  export INKLING_GFX950_GLUON=0
+
+  vllm serve lightseekorg/Inkling-MXFP4 \
+    --tensor-parallel-size 4 \
+    --tokenizer-mode inkling \
+    --reasoning-parser inkling \
+    --tool-call-parser inkling \
+    --enable-auto-tool-choice \
+    --moe-backend aiter \
+    --block-size 128 \
+    --trust-remote-code
+  ```
 
   Query the server with the OpenAI SDK, including an image input:
   ```python
@@ -232,4 +320,5 @@ guide: |
 
   - [TML Inkling (NVFP4)](https://huggingface.co/thinkingmachines/Inkling-NVFP4)
   - [TML Inkling (BF16)](https://huggingface.co/thinkingmachines/Inkling)
+  - [Inkling MXFP4](https://huggingface.co/lightseekorg/Inkling-MXFP4)
   - [vLLM integration PR](https://github.com/Inferact/mlj/pull/16)

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -1990,20 +1990,30 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                       // `unsupported` = author opt-out for this model; disables the pill.
                       const status = recipe.meta?.hardware?.[id];
                       const isUnsupported = status === "unsupported";
+                      // Hardware and variant selectors must not deadlock when
+                      // checkpoint families have disjoint targets (for
+                      // example NVIDIA NVFP4 and AMD MXFP4). selectHardware
+                      // already switches to a fitting variant, so keep this
+                      // hardware clickable whenever any recipe variant runs
+                      // on it.
+                      const fittingVariantKey = pickFittingVariant(recipe, p, id);
+                      const fittingVariant = recipe.variants?.[fittingVariantKey];
                       // Per-role PD now sizes each pool independently, so hardware
                       // only needs to fit 1× model per node (standard precision
                       // check is enough). The old co-located single-node check
                       // (2× model on one node) is no longer the default UX.
-                      const disabled = !precisionOk || !variantHardwareOk || isUnsupported;
+                      const disabled = isUnsupported || !fittingVariantKey;
                       const verifiedNote = status === "verified"
                         ? "\n\nVerified — author has tested this hardware end-to-end"
                         : "";
-                      const reason = !variantHardwareOk
-                        ? `${currentVariant.precision?.toUpperCase()} is only supported on ${(currentVariant.supported_hardware || []).map((hw) => taxonomy.hardware_profiles?.[hw]?.display_name || hw).join(", ")}`
-                        : !precisionOk
-                        ? `${currentVariant.precision?.toUpperCase()} requires NVIDIA Blackwell`
-                        : isUnsupported
+                      const currentVariantRunsHere = precisionOk && variantHardwareOk;
+                      const fittingVariantLabel = (fittingVariant?.label || fittingVariant?.precision || fittingVariantKey)?.toUpperCase();
+                      const reason = isUnsupported
                           ? `Not yet supported on ${p.display_name} — this model doesn't run here today, may be enabled in a future release`
+                        : !fittingVariantKey
+                          ? `No variant of this model currently runs on ${p.display_name}`
+                        : !currentVariantRunsHere
+                          ? `${p.description}\n\nSelecting ${p.display_name} also switches Variant to ${fittingVariantLabel}.${verifiedNote}`
                           : `${p.description}${verifiedNote}`;
                       return (
                         <Pill
@@ -2043,10 +2053,21 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
           >
             <PillGroup>
               {Object.entries(recipe.variants || {}).map(([key, v]) => {
-                // Disable variants excluded by an exact hardware allowlist,
-                // incompatible precision, or a non-scalable VRAM shortfall.
-                const disabled = !variantRunsOnHardware(hwProfile, v, hwId);
-                const hardwareRestricted = !isVariantHardwareSupported(v, hwId);
+                // selectVariant already moves to compatible hardware. Disable
+                // only variants that have no runnable hardware anywhere;
+                // otherwise a disjoint hardware allowlist would make both the
+                // variant and its hardware mutually unselectable.
+                const currentHardwareOk = variantRunsOnHardware(hwProfile, v, hwId);
+                const hasRunnableHardware = Object.entries(taxonomy.hardware_profiles || {}).some(
+                  ([candidateId, candidateProfile]) =>
+                    isHardwareSupported(recipe, candidateId)
+                    && variantRunsOnHardware(candidateProfile, v, candidateId)
+                );
+                const disabled = !hasRunnableHardware;
+                const fallbackHwId = currentHardwareOk
+                  ? hwId
+                  : pickDefaultHardware(taxonomy.hardware_profiles, v, recipe);
+                const fallbackHw = taxonomy.hardware_profiles?.[fallbackHwId];
                 return (
                   <Pill
                     key={key}
@@ -2055,9 +2076,13 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                     onClick={() => !disabled && selectVariant(key)}
                     title={
                       disabled
-                        ? hardwareRestricted
-                          ? `${(v.label || v.precision)?.toUpperCase()} is only supported on ${(v.supported_hardware || []).map((hw) => taxonomy.hardware_profiles?.[hw]?.display_name || hw).join(", ")}`
-                          : `${(v.label || v.precision)?.toUpperCase()} needs ${v.vram_minimum_gb} GB but ${hwProfile.display_name || "this hardware"} has ${hwProfile.vram_gb} GB and can't scale out — pick a smaller-footprint variant`
+                        ? `No currently supported hardware can run ${(v.label || v.precision)?.toUpperCase()}`
+                        : !currentHardwareOk
+                          ? [
+                              v.description,
+                              `Selecting this variant also switches Hardware to ${fallbackHw?.display_name || fallbackHwId}.`,
+                              `Min ${v.vram_minimum_gb} GB to load — add KV cache for serving. Scale out via multi-node if needed.`,
+                            ].filter(Boolean).join("\n\n")
                         : [
                             v.description,
                             `Min ${v.vram_minimum_gb} GB to load — add KV cache for serving. Scale out via multi-node if needed.`,


### PR DESCRIPTION
## Summary

Add AMD serving configurations for: Inkling and Inkling-Small

This also fixes a command-builder deadlock where an AMD-only variant could not be selected while NVIDIA hardware was active, and AMD hardware could not be selected while the NVIDIA variant was active. This occurs because Inkling MXFP4 is AMD-only while NVFP4 is NVIDIA-only. The old builder disabled both the incompatible variant and its required hardware, creating a circular selector deadlock.

## Changes

- Add AMD MXFP4, BF16 support for Inkling and Inkling-Small.
- Keep CUDA-specific FlashInfer settings under NVIDIA-only overrides.
- Allow hardware and variant selectors to switch compatible pairs atomically.

## Hardware validation

| Model | Hardware | Topology | Correctness | 1M context |
|---|---|---:|---:|---:|
| Inkling-Small MXFP4 | MI355X | TP1 | Pass | Pass |
| Inkling-Small MXFP4 | MI300X | TP2 | Pass | Pass |
| Inkling MXFP4 | MI355X | TP4 | Pass | Pass |
| Inkling MXFP4 | MI300X | TP4 | Pass | Pass |

The native-context tests used a 1,048,000-token prompt plus one generated token.

## Benchmark evidence

Benchmark workload:

```bash
vllm bench serve \
  --dataset-name random \
  --random-input-len 8000 \
  --random-output-len 1024 \
  --request-rate 64 \
  --num-prompts 320 \
  --ignore-eos
```

</pre><p>Prefix caching was disabled on the server for clean measurements.</p><div><div>
Model and hardware | Selected backend | Output throughput | Comparison
-- | -- | -- | --
Inkling-Small MI355X TP1 | Triton attention + native AITER MoE | 490.872 tok/s | +39.9% vs Gluon + AITER
Inkling MI355X TP4 | Triton attention + native AITER MoE | 525.423 tok/s | +46.3% vs Gluon + AITER
Inkling-Small MI300X TP2 | AITER + Triton MXFP4 emulation | 369.562 tok/s | 369.052 tok/s without AITER
Inkling MI300X TP4 | AITER + Triton MXFP4 emulation | 212.338 tok/s | 211.962 tok/s without AITER

</div></div><p>The MI300X results are practical ties, but the mixed AITER/emulation path won consistently and is used by the recipes.</p>