### PR TITLE
Enable the Offloading options on GLM-5.2

### DIFF
--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -108,6 +108,10 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   hopper:
     # H100/H200 use plain fp8 KV cache; Blackwell keeps base_args' fp8_e4m3,H20 do not use kvcache fp8 


### PR DESCRIPTION
Marks `kv_offload_support` verified on `zai-org/GLM-5.2`, following #704.

**Validated** on 8×H200 (TP8, FP8 checkpoint, vLLM nightly `0.26.1rc1.dev181`, the recipe's own Hopper command including its `hardware_overrides.hopper` `--kv-cache-dtype fp8`): serve with the option's `--kv-transfer-config`, send a greedy prompt, confirm `kv_offload_store_bytes` > 0, reset the prefix cache, resend, confirm `kv_offload_load_bytes` > 0 and byte-identical output. Both configurations pass, with a fully symmetric round-trip:

| config | store | load |
|---|---|---|
| `offloading_cpu` | 1,104,691,200 | 1,104,691,200 |
| `offloading_fs` | 1,104,691,200 | 1,104,691,200 |