### PR TITLE
Enable the Offloading options on the Nemotron-3 / Nemotron-H family

### DIFF
--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -71,6 +71,10 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16.yaml
@@ -68,6 +68,10 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 strategy_overrides: {}
 

--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -114,6 +114,10 @@ compatible_strategies:
   - multi_node_tep
   - multi_node_dep
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16.yaml
@@ -80,6 +80,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}

--- a/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16.yaml
@@ -69,6 +69,10 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 strategy_overrides: {}
 

--- a/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -74,6 +74,10 @@ compatible_strategies:
   - multi_node_tp
   - multi_node_tp_pp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 strategy_overrides: {}
 

--- a/models/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16.yaml
+++ b/models/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16.yaml
@@ -79,6 +79,10 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides: {}
 
 strategy_overrides: {}


### PR DESCRIPTION
Marks `kv_offload_support` verified across the Nemotron `NemotronHForCausalLM` family, following #704.

**Validated end-to-end: `NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16`** on 16×H200 across 2 nodes (TP8 per node × PP2, bf16, vLLM nightly `0.26.1rc1.dev181`, with the recipe's `--kv-cache-dtype fp8 --mamba-backend triton --mamba-ssm-cache-dtype float32`): serve with the option's `--kv-transfer-config`, greedy prompt, confirm `kv_offload_store_bytes` > 0, reset the prefix cache, resend, confirm `kv_offload_load_bytes` > 0 and unchanged output.

| config | store | load |
|---|---|---|
| `offloading_cpu` | 2,047,082,496 | 2,484,142,080 |
| `offloading_fs` | 4,509,401,088 | 2,484,142,080 |

**The other six recipes are enabled on architectural equivalence, 
- `NVIDIA-Nemotron-3-Nano-4B-BF16`
- `NVIDIA-Nemotron-Nano-9B-v2`
- `NVIDIA-Nemotron-Nano-12B-v2-VL-BF16`
- `NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`
- `NVIDIA-Nemotron-3-Super-120B-A12B-BF16`
- `Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16`