### PR TITLE
fix deepseek-v4-flash-0731 rtx pro 6000 deploy bug 

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "DeepSeek"
   description: "DeepSeek V4 MoE model with hybrid CSA+HCA attention, manifold-constrained hyper-connections, and three-tier reasoning (Non-think / Think High / Think Max)."
   date_added: 2026-07-31
-  date_updated: 2026-07-31
+  date_updated: 2026-08-06
   difficulty: hard
   tasks:
     - text
@@ -170,12 +170,25 @@ kv_offload_support:
   offloading_cpu: verified
   offloading_fs: verified
 
+strategy_hardware:
+  # PD splits into a prefill pool and a decode pool, each sized in whole nodes
+  # (strategy_overrides.pd_cluster gives both `nodes: 1`), so the builder emits
+  # a two-node deployment. RTX Pro 6000 8x is multi_node: false / scalable:
+  # false in taxonomy.yaml — it can't be joined into a cluster, so that command
+  # has nowhere to run. The JSON API already skips pd_cluster on non-scalable
+  # hardware; this makes the Strategy row agree. multi_node_dep needs no entry:
+  # the Nodes row is pinned to 1 here, which already hides every multi_node
+  # strategy.
+  pd_cluster:
+    rtx_pro_6000_8x: unsupported
+
 hardware_overrides:
   blackwell:
     # Common to every variant on Blackwell. The FP8-only deep_gemm_mega_moe MoE
     # kernel is added per-variant (FP8 checkpoints), not here.
     extra_args:
-      - "--attention_config.use_fp4_indexer_cache=True"
+      - "--attention_config.use_fp4_indexer_cache"
+      - "True"
   amd:
     extra_args:
       - "--distributed-executor-backend"
@@ -206,8 +219,25 @@ strategy_overrides:
         # but drops --moe-backend deep_gemm_mega_moe (TP-only path uses the
         # default MoE backend).
         extra_args:
-          - "--attention_config.use_fp4_indexer_cache=True"
-          - "--no-enable-flashinfer-autotune"
+         - "--attention_config.use_fp4_indexer_cache"
+         - "True"
+         - "--no-enable-flashinfer-autotune"
+      rtx_pro_6000_8x:
+        extra_args:
+          - "--attention_config.use_fp4_indexer_cache"
+          - "False"
+    single_node_tep:
+      hardware_overrides:
+      # sm_120 has neither Blackwell kernel: the FP4 indexer cache and
+      # deep_gemm_mega_moe are SM100-only and abort at startup. Turned back off
+      # here — these are the values vLLM resolves to unaided (FP8 indexer cache,
+      # DEEPGEMM_MXFP4 MoE backend), which is the verified configuration.
+      rtx_pro_6000_8x:
+        extra_args:
+          - "--attention_config.use_fp4_indexer_cache"
+          - "False"
+          - "--moe-backend"
+          - "auto"
   single_node_dep:
     # Force DP=4 on all hardware (fills GB200's 4-GPU tray; on 8-GPU nodes use
     # half the GPUs per replica). dedupeArgs (last-wins) shadows the default
@@ -217,10 +247,26 @@ strategy_overrides:
       - "4"
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
+    hardware_overrides:
+      # Same sm_120 opt-out as single_node_tep.
+      rtx_pro_6000_8x:
+        extra_args:
+          - "--attention_config.use_fp4_indexer_cache"
+          - "False"
+          - "--moe-backend"
+          - "auto"
   multi_node_dep:
     extra_args:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
+    hardware_overrides:
+      # Same sm_120 opt-out as single_node_tep.
+      rtx_pro_6000_8x:
+        extra_args:
+          - "--attention_config.use_fp4_indexer_cache"
+          - "False"
+          - "--moe-backend"
+          - "auto"
   pd_cluster:
     env:
       VLLM_USE_NCCL_SYMM_MEM: "1"

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -215,9 +215,9 @@ strategy_overrides:
         extra_args:
           - "--no-enable-flashinfer-autotune"
       blackwell:
-        # Replaces recipe-level blackwell override: keeps the FP4 indexer cache
-        # but drops --moe-backend deep_gemm_mega_moe (TP-only path uses the
-        # default MoE backend).
+    # Replaces recipe-level blackwell override: keeps the FP4 indexer cache
+    # but drops --moe-backend deep_gemm_mega_moe (TP-only path uses the
+    # default MoE backend).
         extra_args:
          - "--attention_config.use_fp4_indexer_cache"
          - "True"
@@ -226,12 +226,12 @@ strategy_overrides:
         extra_args:
           - "--attention_config.use_fp4_indexer_cache"
           - "False"
-    single_node_tep:
-      hardware_overrides:
-      # sm_120 has neither Blackwell kernel: the FP4 indexer cache and
-      # deep_gemm_mega_moe are SM100-only and abort at startup. Turned back off
-      # here — these are the values vLLM resolves to unaided (FP8 indexer cache,
-      # DEEPGEMM_MXFP4 MoE backend), which is the verified configuration.
+  single_node_tep:
+    hardware_overrides:
+    # sm_120 has neither Blackwell kernel: the FP4 indexer cache and
+    # deep_gemm_mega_moe are SM100-only and abort at startup. Turned back off
+    # here — these are the values vLLM resolves to unaided (FP8 indexer cache,
+    # DEEPGEMM_MXFP4 MoE backend), which is the verified configuration.
       rtx_pro_6000_8x:
         extra_args:
           - "--attention_config.use_fp4_indexer_cache"


### PR DESCRIPTION
Updated the rtx pro 6000 moe-backend field and attention_config field for hardware overrides.6000 do not support both --attention_config.use_fp4_indexer_cache=True \
  --moe-backend deep_gemm_mega_moe \

error:
Worker_TP3_EP3 pid=18935) ERROR 08-06 14:55:55 [multiproc_executor.py:898] NotImplementedError: DeepGEMM MegaMoE requires SM100 GPUs.
untimeError: Worker failed with error 'use_fp4_indexer_cache requires Blackwell datacenter GPUs (sm_10x, e.g. B200/GB200); sm_120 (consumer Blackwell) and earlier architectures are not supported.', please check the stack trace above for the root cause