### PR TITLE
docs(minimax-h3): add online FP8 command variant

### DIFF
--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -635,15 +635,18 @@ guide: |
   FlashAttention-4 install. Install the optional extra only when explicitly comparing FA4:
   `uv pip install -e '.[fa4]'`.
 
-  ## Optional online FP8 on B300
+  ## Optional resident online FP8 on B300
 
   vLLM-Omni [#5910](https://github.com/vllm-project/vllm-omni/pull/5910) adds one
   MiniMax-H3 online-FP8 mode. `--quantization fp8` quantizes eligible DiT and
   Qwen3-VL text-decoder linears while the vision tower, embeddings, norms, RoPE,
   VAEs, and FP32 input/output projections retain checkpoint precision.
 
-  This path is currently validated on B300 with the released `FL2VA` and `Ref2VA`
-  partitions served separately. It is documented as an opt-in command instead of a
+  Online FP8 is approximate rather than a consistency ground-truth mode. Validate
+  both video and audio quality, memory use, and latency on the target workload.
+
+  This resident path is currently validated on B300 with the released `FL2VA` and
+  `Ref2VA` partitions served separately. It is documented as an opt-in command instead of a
   recipe variant because the default recipe serves the combined root checkpoint, and
   that root-service FP8 configuration has not been validated yet:
 

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -488,7 +488,92 @@ variants:
           - "--enforce-eager"
         extra_env:
           VLLM_OMNI_VIDEO_SYNC_TIMEOUT: "14400"
-        
+
+  fp8:
+    precision: fp8
+    label: "FP8 (online)"
+    vram_minimum_gb: 202
+    description: "Online FP8 for eligible DiT and Qwen3-VL text-decoder linears. Validated on B300; other FP8-capable hardware remains selectable and should be benchmarked on the target workload."
+    extra_args:
+      - "--quantization"
+      - "fp8"
+    hardware_overrides:
+      rtx_pro_5000_4x:
+        extra_args:
+          - "--num-gpus"
+          - "4"
+          - "--tensor-parallel-size"
+          - "2"
+          - "--usp"
+          - "2"
+          - "--ring"
+          - "1"
+          - "--text-encoder-tp-size"
+          - "4"
+          - "--vae-patch-parallel-size"
+          - "4"
+          - "--diffusion-attention-backend"
+          - "CUDNN_ATTN"
+      rtx_pro_6000_2x:
+        extra_args:
+          - "--num-gpus"
+          - "2"
+          - "--tensor-parallel-size"
+          - "2"
+          - "--usp"
+          - "1"
+          - "--ring"
+          - "1"
+          - "--text-encoder-tp-size"
+          - "2"
+          - "--vae-patch-parallel-size"
+          - "2"
+      rtx_5090_2x:
+        extra_args:
+          - "--num-gpus"
+          - "2"
+          - "--tensor-parallel-size"
+          - "2"
+          - "--usp"
+          - "1"
+          - "--ring"
+          - "1"
+          - "--text-encoder-tp-size"
+          - "2"
+          - "--vae-patch-parallel-size"
+          - "2"
+          - "--diffusion-attention-backend"
+          - "CUDNN_ATTN"
+          - "--enable-distributed-layerwise-offload"
+          - "--dlo-no-use-allgather"
+          - "--dlo-resident-layers"
+          - "20"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_OMNI_VIDEO_SYNC_TIMEOUT: "14400"
+      rtx_4090_2x:
+        extra_args:
+          - "--num-gpus"
+          - "2"
+          - "--tensor-parallel-size"
+          - "2"
+          - "--usp"
+          - "1"
+          - "--ring"
+          - "1"
+          - "--text-encoder-tp-size"
+          - "2"
+          - "--vae-patch-parallel-size"
+          - "2"
+          - "--diffusion-attention-backend"
+          - "CUDNN_ATTN"
+          - "--enable-distributed-layerwise-offload"
+          - "--dlo-no-use-allgather"
+          - "--dlo-resident-layers"
+          - "12"
+          - "--enforce-eager"
+        extra_env:
+          VLLM_OMNI_VIDEO_SYNC_TIMEOUT: "14400"
 
 # Omni recipes are served through `vllm serve --omni`, which has its own
 # diffusion-parallelism flags (--usp / --ring / --vae-patch-parallel-size).
@@ -635,20 +720,23 @@ guide: |
   FlashAttention-4 install. Install the optional extra only when explicitly comparing FA4:
   `uv pip install -e '.[fa4]'`.
 
-  ## Optional resident online FP8 on B300
+  ## Optional online FP8
 
   vLLM-Omni [#5910](https://github.com/vllm-project/vllm-omni/pull/5910) adds one
   MiniMax-H3 online-FP8 mode. `--quantization fp8` quantizes eligible DiT and
   Qwen3-VL text-decoder linears while the vision tower, embeddings, norms, RoPE,
   VAEs, and FP32 input/output projections retain checkpoint precision.
 
+  Select **FP8 (online)** in the command matrix to append `--quantization fp8`.
+  The option is not restricted to B300: it remains selectable on the recipe's
+  FP8-capable hardware. Current end-to-end validation was performed on B300, so
+  benchmark and quality-check other platforms on the target workload.
+
   Online FP8 is approximate rather than a consistency ground-truth mode. Validate
   both video and audio quality, memory use, and latency on the target workload.
 
-  This resident path is currently validated on B300 with the released `FL2VA` and
-  `Ref2VA` partitions served separately. It is documented as an opt-in command instead of a
-  recipe variant because the default recipe serves the combined root checkpoint, and
-  that root-service FP8 configuration has not been validated yet:
+  The following single-partition command is the B300 validation shape used for
+  the measurements below:
 
   ```bash
   CUDA_VISIBLE_DEVICES=0 \
@@ -671,7 +759,7 @@ guide: |
     --enforce-eager
   ```
 
-  Resident B300 measurements show that FP8 is primarily a capacity optimization for
+  B300 measurements show that FP8 is primarily a capacity optimization for
   the encoder. The latency values below isolate the steady-state Qwen3-VL
   `encode_ids` call after two warmups (median of five runs; TP4 uses the slowest rank):
 
@@ -1062,9 +1150,9 @@ guide: |
   - The VAE supports the native `tile` parallel mode only.
   - A `U2 × Ring2` hybrid currently fails with an attention-mask length mismatch; use pure
     Ulysses.
-  - Online FP8 is currently validated on B300 for the separate `FL2VA` and `Ref2VA`
-    partitions. The combined root service and RTX/AMD routes are not yet validated.
-    FP8 with DLO requires `--dlo-no-use-allgather`; the sharded AllGather path cannot
+  - Online FP8 is selectable on the recipe's FP8-capable hardware. Current end-to-end
+    validation is from B300; benchmark and quality-check other platforms before production
+    use. FP8 with DLO requires `--dlo-no-use-allgather`; the sharded AllGather path cannot
     reconstruct weights quantized at runtime.
   - Pure Ulysses still replicates the 66.3 GB DiT on every rank, so 64 GB GPUs cannot use
     `--usp N --tp 1` as a resident capacity path. Use DiT TP plus DLO (the two-GPU recipes

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -635,6 +635,58 @@ guide: |
   FlashAttention-4 install. Install the optional extra only when explicitly comparing FA4:
   `uv pip install -e '.[fa4]'`.
 
+  ## Optional online FP8 on B300
+
+  vLLM-Omni [#5910](https://github.com/vllm-project/vllm-omni/pull/5910) adds one
+  MiniMax-H3 online-FP8 mode. `--quantization fp8` quantizes eligible DiT and
+  Qwen3-VL text-decoder linears while the vision tower, embeddings, norms, RoPE,
+  VAEs, and FP32 input/output projections retain checkpoint precision.
+
+  This path is currently validated on B300 with the released `FL2VA` and `Ref2VA`
+  partitions served separately. It is documented as an opt-in command instead of a
+  recipe variant because the default recipe serves the combined root checkpoint, and
+  that root-service FP8 configuration has not been validated yet:
+
+  ```bash
+  CUDA_VISIBLE_DEVICES=0 \
+  VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  vllm serve /path/to/MiniMax-H3/FL2VA \
+    --omni \
+    --quantization fp8 \
+    --trust-remote-code \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --num-gpus 1 \
+    --tensor-parallel-size 1 \
+    --usp 1 \
+    --ring 1 \
+    --text-encoder-tp-size 1 \
+    --vae-patch-parallel-size 1 \
+    --vae-parallel-mode tile \
+    --vae-use-tiling \
+    --diffusion-attention-backend CUDNN_ATTN \
+    --enforce-eager
+  ```
+
+  Resident B300 measurements show that FP8 is primarily a capacity optimization for
+  the encoder. The latency values below isolate the steady-state Qwen3-VL
+  `encode_ids` call after two warmups (median of five runs; TP4 uses the slowest rank):
+
+  | Qwen presentation | Text-encoder TP | BF16 | Online FP8 | FP8 vs BF16 |
+  |---:|---:|---:|---:|---:|
+  | 25 tokens | 1 | 18.994 ms | 32.736 ms | 0.580x (72.4% slower) |
+  | 25 tokens | 4 | 23.510 ms | 40.919 ms | 0.575x (74.1% slower) |
+  | 1,200 tokens | 1 | 65.494 ms | 64.860 ms | 1.010x (1.0% faster) |
+  | 1,200 tokens | 4 | 43.400 ms | 44.162 ms | 0.983x (1.8% slower) |
+
+  Process-scoped model memory fell from **121.10 to 90.33 GiB/GPU (25.4%)** at
+  TP1 and from **39.92 to 32.32–32.35 GiB/GPU (19.0%)** at TP4. Those figures
+  include the complete loaded pipeline rather than only the encoder.
+
+  FP8 can be combined with distributed layerwise offload, but runtime-created FP8
+  weights require the full-weight per-rank path. Always add `--dlo-no-use-allgather`;
+  the sharded DLO AllGather path is unsupported.
+
   ## Launch — two 24/32 GB GPUs with distributed layerwise offload
 
   vLLM-Omni includes a low-memory TP2 path for H3. Install the current vLLM-Omni
@@ -1007,8 +1059,10 @@ guide: |
   - The VAE supports the native `tile` parallel mode only.
   - A `U2 × Ring2` hybrid currently fails with an attention-mask length mismatch; use pure
     Ulysses.
-  - **FP8 quantization is not supported yet** — a transformer-side blocker is known and
-    deferred past the day-0 release.
+  - Online FP8 is currently validated on B300 for the separate `FL2VA` and `Ref2VA`
+    partitions. The combined root service and RTX/AMD routes are not yet validated.
+    FP8 with DLO requires `--dlo-no-use-allgather`; the sharded AllGather path cannot
+    reconstruct weights quantized at runtime.
   - Pure Ulysses still replicates the 66.3 GB DiT on every rank, so 64 GB GPUs cannot use
     `--usp N --tp 1` as a resident capacity path. Use DiT TP plus DLO (the two-GPU recipes
     above), or model-level CPU offload; text-encoder TP alone is not sufficient.


### PR DESCRIPTION
## Summary

Follow-up to #765 and dependent on vllm-project/vllm-omni#5910.

- add an **FP8 (online)** option to the MiniMax-H3 command matrix
- append `--quantization fp8` while preserving each hardware profile's existing TP, Ulysses, attention, and DLO settings
- keep the option available across the recipe's FP8-capable hardware; B300 is the current validation platform, not a hardware allowlist
- document the B300 latency/memory evidence and the DLO no-AllGather requirement

## Scope

Online FP8 quantizes eligible DiT and Qwen3-VL text-decoder linears. The vision tower, embeddings, norms, RoPE, VAEs, and FP32 input/output projections retain checkpoint precision.

The mode is approximate. Current end-to-end validation is on B300; other selectable FP8-capable platforms should be benchmarked and quality-checked on the target workload.

FP8 with DLO requires `--dlo-no-use-allgather`; runtime-created FP8 weights are incompatible with the sharded DLO AllGather path.

## B300 validation

Single-B300 resident 50-step T2VA:

| Mode | Time | Worker peak | Change |
|---|---:|---:|---:|
| BF16 | 162.30 s | 133,110 MiB | baseline |
| Online FP8 | 151.58 s | 92,146 MiB | 1.071x faster, 30.8% lower peak |

Steady-state Qwen3-VL `encode_ids` latency (median of five after two warmups; TP4 uses the slowest rank):

| Presentation | Text-encoder TP | BF16 | Online FP8 | FP8 vs BF16 |
|---:|---:|---:|---:|---:|
| 25 tokens | 1 | 18.994 ms | 32.736 ms | 0.580x |
| 25 tokens | 4 | 23.510 ms | 40.919 ms | 0.575x |
| 1,200 tokens | 1 | 65.494 ms | 64.860 ms | 1.010x |
| 1,200 tokens | 4 | 43.400 ms | 44.162 ms | 0.983x |

Process-scoped model memory fell from 121.10 to 90.33 GiB/GPU at TP1 and from 39.92 to 32.32–32.35 GiB/GPU at TP4.

## Validation

- `node scripts/build-recipes-api.mjs` — 154 models generated
- semantic command-matrix assertions — 54 FP8 renderings across 9 hardware profiles × 6 request modes
- verified FP8 adds only `--quantization fp8`; existing per-hardware command/env settings remain unchanged
- `git diff --check`

This remains draft until vllm-project/vllm-omni#5910 lands.
