### PR TITLE
[Recipe] Add IndexTTS-2.5

### DIFF
--- a/models/IndexTeam/IndexTTS-2.5.yaml
+++ b/models/IndexTeam/IndexTTS-2.5.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "IndexTeam"
   description: "Multilingual zero-shot voice-cloning TTS with native speed, emotion, and text-normalization controls, served through vLLM-Omni's OpenAI-compatible speech API."
   date_added: 2026-08-10
-  date_updated: 2026-08-10
+  date_updated: 2026-08-12
   difficulty: intermediate
   tasks:
     - omni
@@ -19,7 +19,7 @@ model:
   install:
     pip:
       command: 'uv pip install "vllm-omni[indextts2] @ git+https://github.com/vllm-project/vllm-omni.git"'
-      note: "IndexTTS-2.5 support requires vLLM-Omni PR #5957 or a later revision containing that change."
+      note: "IndexTTS-2.5 support is included in vLLM-Omni; see the upstream IndexTTS-2.5 recipe for deployment details."
     docker: false
   architecture: dense
   # IndexTeam has not published an authoritative total parameter count.
@@ -40,7 +40,7 @@ omni:
   tasks:
     - id: t2a
       label: "Text → Speech"
-      model_id: "/path/to/indextts-2.5"
+      model_id: "IndexTeam/IndexTTS-2.5"
       endpoint: "/v1/audio/speech"
       description: "Multilingual voice cloning with native speed and emotion controls (22.05 kHz mono WAV)"
       curl: |
@@ -83,22 +83,20 @@ guide: |
   text normalization, model-native speed control, and three emotion-conditioning
   modes through `/v1/audio/speech`.
 
-  The official total parameter count has not been disclosed. The
-  `IndexTeam/IndexTTS-2.5` Hugging Face repository is not currently readable
-  through the public unauthenticated API, so this recipe intentionally uses a
-  **local native model bundle** instead of claiming automatic model download.
+  The official total parameter count has not been disclosed. The model is
+  available from [IndexTeam/IndexTTS-2.5 on Hugging Face](https://huggingface.co/IndexTeam/IndexTTS-2.5).
 
   ## Prerequisites
 
-  - Obtain an authorized IndexTTS-2.5 native bundle and place it at
-    `/path/to/indextts-2.5`. The nested upstream `checkpoints/` layout is
-    accepted.
+  - Download access to [IndexTeam/IndexTTS-2.5 on Hugging Face](https://huggingface.co/IndexTeam/IndexTTS-2.5).
+    vLLM-Omni also accepts an already-downloaded native bundle and its nested
+    upstream `checkpoints/` layout.
   - Use a CUDA GPU with enough memory for both stages. The standard deploy
     config reserves up to `0.4` GPU-memory utilization per stage on one GPU;
     lower-memory profiles have not been validated.
-  - Use vLLM-Omni PR
-    [#5957](https://github.com/vllm-project/vllm-omni/pull/5957) or a later
-    revision containing IndexTTS-2.5 support.
+  - Follow the merged
+    [vLLM-Omni IndexTTS-2.5 recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/IndexTeam/IndexTTS-2_5.md)
+    for the upstream serving requirements.
 
   ## Installation
 
@@ -112,7 +110,7 @@ guide: |
   Run this command from a vLLM-Omni checkout so the deploy YAML is available:
 
   ```bash
-  vllm-omni serve /path/to/indextts-2.5 \
+  vllm-omni serve IndexTeam/IndexTTS-2.5 \
     --omni \
     --trust-remote-code \
     --deploy-config vllm_omni/deploy/indextts2_5.yaml \
@@ -253,5 +251,5 @@ guide: |
   ## References
 
   - [IndexTTS-2.5 model page](https://huggingface.co/IndexTeam/IndexTTS-2.5)
-  - [vLLM-Omni IndexTTS-2.5 support PR](https://github.com/vllm-project/vllm-omni/pull/5957)
+  - [vLLM-Omni IndexTTS-2.5 recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/IndexTeam/IndexTTS-2_5.md)
   - [vLLM-Omni repository](https://github.com/vllm-project/vllm-omni)

--- a/models/IndexTeam/IndexTTS-2.5.yaml
+++ b/models/IndexTeam/IndexTTS-2.5.yaml
@@ -30,6 +30,8 @@ model:
     - "--trust-remote-code"
     - "--deploy-config"
     - "vllm_omni/deploy/indextts2_5.yaml"
+    - "--served-model-name"
+    - "IndexTeam/IndexTTS-2.5"
   base_env: {}
 
 omni:
@@ -45,7 +47,7 @@ omni:
         curl -X POST http://localhost:8092/v1/audio/speech \
           -H "Content-Type: application/json" \
           -d '{
-            "model": "/path/to/indextts-2.5",
+            "model": "IndexTeam/IndexTTS-2.5",
             "input": "你好，这是 IndexTTS-2.5 语音合成测试。",
             "voice": "demo_voice",
             "speed": 1.0,
@@ -114,6 +116,7 @@ guide: |
     --omni \
     --trust-remote-code \
     --deploy-config vllm_omni/deploy/indextts2_5.yaml \
+    --served-model-name IndexTeam/IndexTTS-2.5 \
     --port 8092
   ```
 
@@ -136,7 +139,7 @@ guide: |
   curl -X POST http://localhost:8092/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
-      "model": "/path/to/indextts-2.5",
+      "model": "IndexTeam/IndexTTS-2.5",
       "input": "你好，这是复用已上传音色的语音合成测试。",
       "voice": "demo_voice",
       "response_format": "wav",
@@ -177,7 +180,7 @@ guide: |
   curl -X POST http://localhost:8092/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
-      "model": "/path/to/indextts-2.5",
+      "model": "IndexTeam/IndexTTS-2.5",
       "input": "这是使用模型原生语速控制的测试。",
       "voice": "demo_voice",
       "speed": 1.5,

--- a/models/IndexTeam/IndexTTS-2.5.yaml
+++ b/models/IndexTeam/IndexTTS-2.5.yaml
@@ -1,0 +1,254 @@
+meta:
+  title: "IndexTTS-2.5"
+  slug: "indextts-2-5"
+  provider: "IndexTeam"
+  description: "Multilingual zero-shot voice-cloning TTS with native speed, emotion, and text-normalization controls, served through vLLM-Omni's OpenAI-compatible speech API."
+  date_added: 2026-08-10
+  date_updated: 2026-08-10
+  difficulty: intermediate
+  tasks:
+    - omni
+  related_recipes:
+    - Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice
+    - zai-org/GLM-TTS
+    - OpenMOSS-Team/MOSS-TTS
+
+model:
+  model_id: "IndexTeam/IndexTTS-2.5"
+  min_vllm_version: "0.26.0"
+  install:
+    pip:
+      command: 'uv pip install "vllm-omni[indextts2] @ git+https://github.com/vllm-project/vllm-omni.git"'
+      note: "IndexTTS-2.5 support requires vLLM-Omni PR #5957 or a later revision containing that change."
+    docker: false
+  architecture: dense
+  # IndexTeam has not published an authoritative total parameter count.
+  parameter_count: "Undisclosed"
+  active_parameters: "Undisclosed"
+  context_length: 0
+  base_args:
+    - "--trust-remote-code"
+    - "--deploy-config"
+    - "vllm_omni/deploy/indextts2_5.yaml"
+  base_env: {}
+
+omni:
+  serve_binary: "vllm-omni serve"
+  port: 8092
+  tasks:
+    - id: t2a
+      label: "Text → Speech"
+      model_id: "/path/to/indextts-2.5"
+      endpoint: "/v1/audio/speech"
+      description: "Multilingual voice cloning with native speed and emotion controls (22.05 kHz mono WAV)"
+      curl: |
+        curl -X POST http://localhost:8092/v1/audio/speech \
+          -H "Content-Type: application/json" \
+          -d '{
+            "model": "/path/to/indextts-2.5",
+            "input": "你好，这是 IndexTTS-2.5 语音合成测试。",
+            "voice": "demo_voice",
+            "speed": 1.0,
+            "response_format": "wav",
+            "extra_params": {
+              "lang": "zh",
+              "text_normalization": true
+            }
+          }' --output output.wav
+
+features: {}
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 96
+    description: "Native BF16 bundle using the standard two-stage single-GPU deploy profile; lower-memory configurations have not been characterized"
+
+compatible_strategies: []
+
+hardware_overrides: {}
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  IndexTTS-2.5 is a two-stage text-to-speech system: an autoregressive talker
+  produces semantic codes, then EnhancedCodec, S2Mel CFM/DiT, and BigVGAN
+  synthesize **22.05 kHz mono WAV** audio. The vLLM-Omni integration exposes
+  zero-shot voice cloning, reusable named voices, multilingual text processing,
+  text normalization, model-native speed control, and three emotion-conditioning
+  modes through `/v1/audio/speech`.
+
+  The official total parameter count has not been disclosed. The
+  `IndexTeam/IndexTTS-2.5` Hugging Face repository is not currently readable
+  through the public unauthenticated API, so this recipe intentionally uses a
+  **local native model bundle** instead of claiming automatic model download.
+
+  ## Prerequisites
+
+  - Obtain an authorized IndexTTS-2.5 native bundle and place it at
+    `/path/to/indextts-2.5`. The nested upstream `checkpoints/` layout is
+    accepted.
+  - Use a CUDA GPU with enough memory for both stages. The standard deploy
+    config reserves up to `0.4` GPU-memory utilization per stage on one GPU;
+    lower-memory profiles have not been validated.
+  - Use vLLM-Omni PR
+    [#5957](https://github.com/vllm-project/vllm-omni/pull/5957) or a later
+    revision containing IndexTTS-2.5 support.
+
+  ## Installation
+
+  ```bash
+  uv venv && source .venv/bin/activate
+  uv pip install "vllm-omni[indextts2] @ git+https://github.com/vllm-project/vllm-omni.git"
+  ```
+
+  ## Launch the server
+
+  Run this command from a vLLM-Omni checkout so the deploy YAML is available:
+
+  ```bash
+  vllm-omni serve /path/to/indextts-2.5 \
+    --omni \
+    --trust-remote-code \
+    --deploy-config vllm_omni/deploy/indextts2_5.yaml \
+    --port 8092
+  ```
+
+  ## Quick start: upload and reuse a voice
+
+  Upload a reference recording once. The voice-storage API requires a consent
+  identifier:
+
+  ```bash
+  curl -X POST http://localhost:8092/v1/audio/voices \
+    -F "audio_sample=@/path/to/reference.wav" \
+    -F "consent=user-consent-id" \
+    -F "name=demo_voice" \
+    -F "speaker_description=IndexTTS-2.5 demo voice"
+  ```
+
+  Reuse that speaker by name:
+
+  ```bash
+  curl -X POST http://localhost:8092/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "/path/to/indextts-2.5",
+      "input": "你好，这是复用已上传音色的语音合成测试。",
+      "voice": "demo_voice",
+      "response_format": "wav",
+      "extra_params": {"lang": "zh", "text_normalization": true}
+    }' --output named_voice.wav
+  ```
+
+  Use `ref_audio` instead of `voice` to clone directly from a URL, data URL, or
+  permitted `file://` URI. There are no built-in text-only preset speakers.
+
+  ## Language and text controls
+
+  `extra_params.lang` accepts `zh` (Mandarin), `en` (English), `zhen`
+  (Chinese-English mixed), `ja` (Japanese), and `yue` (Cantonese). Text
+  normalization is enabled by default:
+
+  ```json
+  {
+    "input": "Hello，欢迎使用 IndexTTS 二点五。",
+    "voice": "demo_voice",
+    "extra_params": {
+      "lang": "zhen",
+      "text_normalization": true
+    }
+  }
+  ```
+
+  For Japanese, write numbers, dates, and percentages as readable Japanese
+  text because the Japanese tokenizer does not automatically expand them.
+
+  ## Native speed control
+
+  `speed` accepts values from `0.5` to `2.0`. Values above `1.0` produce shorter,
+  faster speech. vLLM-Omni maps the public API convention to the model-native
+  `duration_factor = 1 / speed`, so the audio waveform is not post-resampled:
+
+  ```bash
+  curl -X POST http://localhost:8092/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "/path/to/indextts-2.5",
+      "input": "这是使用模型原生语速控制的测试。",
+      "voice": "demo_voice",
+      "speed": 1.5,
+      "extra_params": {"lang": "zh"}
+    }' --output speed_1_5.wav
+  ```
+
+  ## Emotion control
+
+  IndexTTS-2.5 supports an eight-value emotion vector, an emotion description,
+  or a separate emotion-reference recording. `emo_alpha` controls conditioning
+  strength from `0` to `1`.
+
+  Explicit vector order: `happy`, `angry`, `sad`, `afraid`, `disgusted`,
+  `melancholic`, `surprised`, `calm`:
+
+  ```json
+  {
+    "input": "今天真是令人开心的一天！",
+    "voice": "demo_voice",
+    "extra_params": {
+      "lang": "zh",
+      "emo_vector": [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+      "emo_alpha": 0.8
+    }
+  }
+  ```
+
+  Infer emotion from text:
+
+  ```json
+  {
+    "input": "我们终于完成了这项工作！",
+    "voice": "demo_voice",
+    "extra_params": {
+      "lang": "zh",
+      "use_emo_text": true,
+      "emo_text": "开心、兴奋而且充满活力",
+      "emo_alpha": 0.8
+    }
+  }
+  ```
+
+  Transfer expression from another recording while preserving the uploaded
+  speaker identity:
+
+  ```json
+  {
+    "input": "请用情绪参考音频中的表达方式朗读这句话。",
+    "voice": "demo_voice",
+    "extra_params": {
+      "lang": "zh",
+      "emo_audio": "file:///path/to/emotion_reference.wav",
+      "emo_alpha": 0.8
+    }
+  }
+  ```
+
+  When several emotion sources are supplied, precedence is `use_emo_text` >
+  `emo_vector` > `emo_audio` > the speaker-reference emotion.
+
+  ## Validation notes
+
+  The integration has completed end-to-end generation with voice cloning and
+  Whisper-small transcript checks. In the fixed-seed Chinese validation,
+  `speed=1.0` produced 5.503 s and `speed=2.0` produced 2.752 s; both matched
+  the requested sentence. These measurements are functional evidence, not a
+  general throughput claim.
+
+  ## References
+
+  - [IndexTTS-2.5 model page](https://huggingface.co/IndexTeam/IndexTTS-2.5)
+  - [vLLM-Omni IndexTTS-2.5 support PR](https://github.com/vllm-project/vllm-omni/pull/5957)
+  - [vLLM-Omni repository](https://github.com/vllm-project/vllm-omni)

--- a/src/lib/providers.js
+++ b/src/lib/providers.js
@@ -27,6 +27,7 @@ export const PROVIDERS = {
   "fishaudio":       { display_name: "Fish Audio",              logo: "/providers/fishaudio.png" },
   "bosonai":         { display_name: "Boson AI",                logo: "/providers/bosonai.png" },
   "OpenMOSS-Team":   { display_name: "OpenMOSS",                logo: "/providers/OpenMOSS-Team.png" },
+  "IndexTeam":       { display_name: "IndexTeam",               logo: "/providers/IndexTeam.png" },
   "OpenGVLab":       { display_name: "InternVL (OpenGVLab)",    logo: "/providers/OpenGVLab.jpeg" },
   "internlm":        { display_name: "InternLM",                logo: "/providers/internlm.png" },
   "jinaai":          { display_name: "Jina AI",                 logo: "/providers/jinaai.png" },


### PR DESCRIPTION
## Summary

Adds a vLLM Recipes entry for `IndexTeam/IndexTTS-2.5`, served through vLLM-Omni's OpenAI-compatible `/v1/audio/speech` API.

The recipe covers:

- local native-bundle installation and launch
- zero-shot voice cloning
- upload and reuse of named voices
- official Chinese, English, Japanese, Spanish, and Arabic modes, plus an additional mixed Chinese/English (`zhen`) frontend mode
- text normalization
- native `speed` / `duration_factor` control
- emotion vector, emotion-text, and emotion-reference-audio conditioning
- 22.05 kHz mono WAV output

## Upstream support

IndexTTS-2.5 support has merged in [vllm-project/vllm-omni#5957](https://github.com/vllm-project/vllm-omni/pull/5957). See the merged [vLLM-Omni IndexTTS-2.5 recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/IndexTeam/IndexTTS-2_5.md) and the [IndexTeam/IndexTTS-2.5 model page](https://huggingface.co/IndexTeam/IndexTTS-2.5).

## Metadata choices
- The recipe now uses the published `IndexTeam/IndexTTS-2.5` Hugging Face model ID for generated launch commands and links to the merged vLLM-Omni recipe.
- No H200 verification badge is claimed: the E2E host alias used during development reports `NVIDIA L20X` with 141 GiB through `nvidia-smi`, not an H200 device. Functional E2E and ASR validation are documented without mislabeling the hardware.

## Validation

- `node scripts/build-recipes-api.mjs`
  - `✓ JSON API: 155 models, 9 strategies ...`
- Generated API entry checked at `public/IndexTeam/IndexTTS-2.5.json`
- YAML parsing and repository build completed successfully

