### PR TITLE
[ROCm] [New-Model] Add muse glimmer 30b mi300x/mi355x recipes

### DIFF
--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -85,6 +85,19 @@ variants:
     # 29.78B x 2 bytes x 1.2
     vram_minimum_gb: 72
     description: "BF16 weights, the reference precision."
+    hardware_overrides:
+      mi300x:
+        extra_args:
+          - "--attention-backend"
+          - "ROCM_AITER_FA"
+      mi325x:
+        extra_args:
+          - "--attention-backend"
+          - "ROCM_AITER_FA"
+      mi355x:
+        extra_args:
+          - "--attention-backend"
+          - "ROCM_AITER_FA"
   nvfp4:
     precision: nvfp4
     model_id: "Inferact/Muse-Glimmer-30B-NVFP4-W4A4"
@@ -97,6 +110,12 @@ variants:
 
 compatible_strategies:
   - single_node_tp
+
+hardware_overrides:
+  amd:
+    extra_args: []
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
 
 guide: |
   ## Overview

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -20,6 +20,7 @@ meta:
     # Single GB10 with 128 GB unified memory. gpu_count is 1, so autoFitTp caps
     # TP at 1 — this is a plain single-card deployment, no sharding.
     dgx_spark_gb10: verified
+    mi355x: verified
 
 model:
   model_id: "meta-models/Muse-Glimmer-30B"
@@ -35,7 +36,7 @@ model:
   nightly_required: true
   install:
     docker:
-      note: "Docker is the supported path — the model code and the muse_glimmer parsers are not in any released vLLM wheel."
+      note: "Docker is the supported path — the model code and the muse_glimmer parsers are not in any released vLLM wheel. On ROCm, please install the code from https://github.com/vllm-project/vllm/pull/51655 ."
     pip: false
   architecture: dense
   # Model card states ~29.6B total including the perception encoder. Measured from
@@ -181,6 +182,28 @@ guide: |
   the KV cache and the perception encoder. The **NVFP4** checkpoint is 25.42 GB,
   which leaves considerably more of that shared pool for KV and the host — the
   better fit of the two on this hardware.
+
+  ## Running on MI355X
+
+  As of now, please install the code from https://github.com/vllm-project/vllm/pull/51655
+  if it hasn't been merged yet. After the PR is merged use `vllm/vllm-openai-rocm:nightly` image.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve /model \
+    --served-model-name muse-glimmer \
+    --tensor-parallel-size 4 \
+    --max-model-len 131072 \
+    --enable-auto-tool-choice \
+    --tool-call-parser muse_glimmer \
+    --reasoning-parser muse_glimmer \
+    --generation-config auto
+  ```
+
+  At TP=1 on MI355X this reports an 11.65M-token KV pool and ~88.9x max concurrency
+  at the full 128K context.
+  At TP=4 on MI355X this reports an 27.68M-token KV pool and ~211.22x max concurrency
+  at the full 128K context.
 
   ## Sampling
 

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -21,6 +21,7 @@ meta:
     # TP at 1 — this is a plain single-card deployment, no sharding.
     dgx_spark_gb10: verified
     mi300x: verified
+    mi325x: verified
     mi355x: verified
 
 model:
@@ -184,7 +185,7 @@ guide: |
   which leaves considerably more of that shared pool for KV and the host — the
   better fit of the two on this hardware.
 
-  ## Running on MI300X/MI355X
+  ## Running on MI300X/MI325X/MI355X
 
   As of now, please install the code from https://github.com/vllm-project/vllm/pull/51655
   if it hasn't been merged yet. After the PR is merged use `vllm/vllm-openai-rocm:nightly` image.

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -197,10 +197,11 @@ guide: |
     --enable-auto-tool-choice \
     --tool-call-parser muse_glimmer \
     --reasoning-parser muse_glimmer \
-    --generation-config auto
+    --generation-config auto \
+    --attention-backend ROCM_AITER_FA
   ```
 
-  At TP=1 on MI355X this reports an 11.65M-token KV pool and ~88.9x max concurrency
+  At TP=1 on MI355X this reports an 11.64M-token KV pool and ~88.86x max concurrency
   at the full 128K context.
   At TP=4 on MI355X this reports an 27.68M-token KV pool and ~211.22x max concurrency
   at the full 128K context.

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -20,6 +20,7 @@ meta:
     # Single GB10 with 128 GB unified memory. gpu_count is 1, so autoFitTp caps
     # TP at 1 — this is a plain single-card deployment, no sharding.
     dgx_spark_gb10: verified
+    mi300x: verified
     mi355x: verified
 
 model:
@@ -183,7 +184,7 @@ guide: |
   which leaves considerably more of that shared pool for KV and the host — the
   better fit of the two on this hardware.
 
-  ## Running on MI355X
+  ## Running on MI300X/MI355X
 
   As of now, please install the code from https://github.com/vllm-project/vllm/pull/51655
   if it hasn't been merged yet. After the PR is merged use `vllm/vllm-openai-rocm:nightly` image.
@@ -201,6 +202,10 @@ guide: |
     --attention-backend ROCM_AITER_FA
   ```
 
+  At TP=1 on MI300X this reports an 6.66M-token KV pool and ~50.82x max concurrency
+  at the full 128K context.
+  At TP=4 on MI300X this reports an 17.79M-token KV pool and ~135.73x max concurrency
+  at the full 128K context.
   At TP=1 on MI355X this reports an 11.64M-token KV pool and ~88.86x max concurrency
   at the full 128K context.
   At TP=4 on MI355X this reports an 27.68M-token KV pool and ~211.22x max concurrency

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -224,10 +224,13 @@ guide: |
 
   At TP=1 on MI300X this reports an 6.66M-token KV pool and ~50.82x max concurrency
   at the full 128K context.
+
   At TP=4 on MI300X this reports an 17.79M-token KV pool and ~135.73x max concurrency
   at the full 128K context.
+
   At TP=1 on MI355X this reports an 11.64M-token KV pool and ~88.86x max concurrency
   at the full 128K context.
+  
   At TP=4 on MI355X this reports an 27.68M-token KV pool and ~211.22x max concurrency
   at the full 128K context.
 


### PR DESCRIPTION
This PR validated the https://huggingface.co/meta-models/Muse-Glimmer-30B on mi300x/mi355x . It depends on the code from the PR https://github.com/vllm-project/vllm/pull/51655

The model is verified on mi300x and mi355x for TP1 and TP2 with AITER enabled and rocm_aiter_fa

The lm_eval score of all four configurations are validated with 256 concurrency gsm8k full dataset, at numshot 20.
All configurations have a score of `0.93x`