### PR TITLE
Add FP8_BLOCK variant for Muse-Glimmer-30B

### DIFF
--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -82,6 +82,12 @@ variants:
     # 29.78B x 2 bytes x 1.2
     vram_minimum_gb: 72
     description: "BF16 weights, the reference precision."
+  fp8_block:
+    precision: fp8
+    model_id: "RedHatAI/Muse-Glimmer-30B-FP8-block"
+    # 33 GB on disk x 1.2 overhead
+    vram_minimum_gb: 40
+    description: "FP8_BLOCK (E4M3) weights with 128x128 block scaling, dynamic activations. 33 GB on disk, fits one GPU."
   nvfp4:
     precision: nvfp4
     model_id: "Inferact/Muse-Glimmer-30B-NVFP4-W4A4"
@@ -132,6 +138,7 @@ guide: |
   | variant | repo | size | notes |
   |---|---|---|---|
   | BF16 | [`meta-models/Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B) | 59.58 GB | reference precision |
+  | FP8 | [`RedHatAI/Muse-Glimmer-30B-FP8-block`](https://huggingface.co/RedHatAI/Muse-Glimmer-30B-FP8-block) | 32.78 GB | FP8 block-scaled weights, dynamic activations (vision tower + embeddings BF16) |
   | NVFP4 | [`Inferact/Muse-Glimmer-30B-NVFP4-W4A4`](https://huggingface.co/Inferact/Muse-Glimmer-30B-NVFP4-W4A4) | 25.42 GB | ModelOpt NVFP4, **W4A4**, group size 16 |
   | draft | [`meta-models/Muse-Glimmer-30B-assistant`](https://huggingface.co/meta-models/Muse-Glimmer-30B-assistant) | 5.11 GB | DFlash draft head for speculative decoding |
 


### PR DESCRIPTION
Add RedHatAI/Muse-Glimmer-30B-FP8-block as an FP8 variant with 128x128 block scaling. 
Checkpoint: https://huggingface.co/RedHatAI/Muse-Glimmer-30B-FP8-block