### PR TITLE
Remove source oneapi for xpu

### DIFF
--- a/models/Qwen/Qwen3-32B.yaml
+++ b/models/Qwen/Qwen3-32B.yaml
@@ -167,11 +167,11 @@ guide: |
     -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g \
     --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    --entrypoint bash vllm/vllm-openai-xpu:latest \
-    -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve Qwen/Qwen3-32B \
+    vllm/vllm-openai-xpu:latest \
+    Qwen/Qwen3-32B \
     --gpu-memory-utilization 0.90 \
     --tensor-parallel-size 4 \
-    --max-model-len 8192"
+    --max-model-len 8192
   ```
 
   ## Configuration Tips

--- a/models/deepseek-ai/DeepSeek-OCR.yaml
+++ b/models/deepseek-ai/DeepSeek-OCR.yaml
@@ -168,10 +168,10 @@ guide: |
     -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g \
     --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    --entrypoint bash vllm/vllm-openai-xpu:latest \
-    -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve deepseek-ai/DeepSeek-OCR \
+    vllm/vllm-openai-xpu:latest \
+    deepseek-ai/DeepSeek-OCR \
     --logits-processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor \
-    --mm-processor-cache-gb 0"
+    --mm-processor-cache-gb 0
   ```
 
   Query the running server with the OpenAI client (same for CUDA / ROCm / XPU):

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -146,9 +146,9 @@ guide: |
     -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g \
     --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    --entrypoint bash vllm/vllm-openai-xpu:latest \
-    -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve meta-llama/Llama-3.1-8B-Instruct \
-    --max-model-len 8192"
+    vllm/vllm-openai-xpu:latest \
+    meta-llama/Llama-3.1-8B-Instruct \
+    --max-model-len 8192
   ```
 
   ## Client Usage

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -156,9 +156,9 @@ guide: |
     -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g \
     --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    --entrypoint bash vllm/vllm-openai-xpu:latest \
-    -c "source /opt/intel/oneapi/setvars.sh && exec vllm serve openai/gpt-oss-20b \
-    --max-model-len 8192"
+    vllm/vllm-openai-xpu:latest \
+    openai/gpt-oss-20b \
+    --max-model-len 8192
   ```
 
   ## Tool use


### PR DESCRIPTION
Remove source oneapi for xpu after the vllm 0.27 release.