### PR TITLE
Verify Muse-Glimmer-30B on RTX 5090 (1x and 2x) and document the fp8_block DeepGEMM workaround

### DIFF
--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -273,18 +273,33 @@ guide: |
     and vision both work. `vram_minimum_gb: 31` is accurate — the margin is real
     but thin.
 
-    Two things are worth knowing before you plan around it.
-
     **Speculative decoding needs a second card.** The draft head is 5.11 GB and the
     nvfp4 weights are 25.42 GB, so on one 32 GB card vLLM OOMs during init with
-    roughly 400 MiB free. On 2x 5090 with `--tensor-parallel-size 2` it runs, and
-    it is worth the second card: 184 tok/s versus 66 without the drafter.
+    roughly 400 MiB free. On 2x 5090 with `--tensor-parallel-size 2` it is well
+    worth the second card — decode roughly triples.
 
-    **Lower `--gpu-memory-utilization` when speculating.** At the default 0.92 with
-    TP=2, vLLM sizes a 2,594,229-token KV cache and then fails to allocate 396 MiB
-    for the speculator. At 0.80 the cache is still 1,631,689 tokens (6.22x
-    concurrency at 262K) and initialisation completes. Counter-intuitively, a
-    *lower* utilisation is what makes speculative decoding start at all here.
+    On 2x 5090 the default `--gpu-memory-utilization 0.92` works with the drafter;
+    utilisation only sizes the KV cache, it does not gate initialisation. Measured
+    across the range, base recipe (131,072 ctx, bf16 KV) plus DFlash:
+
+    | `--gpu-memory-utilization` | KV cache | concurrency @131K |
+    |---|---|---|
+    | 0.92 | 1,202,076 | 9.17x |
+    | 0.88 | 1,054,407 | 8.04x |
+    | 0.84 | 906,720 | 6.92x |
+    | 0.80 | 759,051 | 5.79x |
+
+    All seven steps from 0.92 down to 0.80 initialised cleanly. Decode measured
+    212-261 tok/s across them with no trend attributable to utilisation — the
+    spread is run-to-run noise (a second model was sharing the host during the
+    early steps), so treat ~240 tok/s as the figure and pick utilisation purely
+    for the cache size you want.
+
+    If you *extend* beyond the recipe — a longer `--max-model-len` via rope
+    scaling, or `--kv-cache-dtype fp8` — the arithmetic changes and 0.92 can OOM:
+    at 262,144 with fp8 KV, vLLM sized a 2,594,229-token cache and then failed to
+    allocate 396 MiB for the speculator. Lowering to 0.80 fixed it. That is a
+    consequence of the extension, not of the recipe as written.
 
     A note on `max_tokens`: the channel-scoped output means a tight budget can
     truncate before the final channel closes, returning empty `content` with

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -23,6 +23,7 @@ meta:
     mi300x: verified
     mi325x: verified
     mi355x: verified
+    rtx_5090: verified
 
 model:
   model_id: "meta-models/Muse-Glimmer-30B"

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -24,6 +24,7 @@ meta:
     mi325x: verified
     mi355x: verified
     rtx_5090: verified
+    rtx_5090_2x: verified
 
 model:
   model_id: "meta-models/Muse-Glimmer-30B"
@@ -74,7 +75,8 @@ features:
   spec_decoding:
     # The 5.11 GB draft head does not fit beside the 25.42 GB nvfp4 weights on a
     # single 32 GB RTX 5090: vLLM OOMs during init with ~400 MiB free. Verified,
-    # not inferred. Two cards are required — see the guide's RTX 5090 section.
+    # not inferred. On 2x RTX 5090 it works and is verified — see the guide's
+    # RTX 5090 section for measurements.
     hardware:
       rtx_5090: unsupported
     description: "DFlash block-diffusion draft head — predicts a whole block in one forward, verified in parallel by the target. `num_speculative_tokens: 15` is not a tuning knob: the head has `block_size: 16` and slot 0 re-presents the last accepted token, so 15 is what remains."
@@ -278,7 +280,15 @@ guide: |
     roughly 400 MiB free. On 2x 5090 with `--tensor-parallel-size 2` it is well
     worth the second card — decode roughly triples.
 
-    On 2x 5090 the default `--gpu-memory-utilization 0.92` works with the drafter;
+    ### 2x RTX 5090
+
+    Verified with the drafter enabled. Sweeping `--gpu-memory-utilization` from
+    0.92 to 0.80 on the base recipe (131,072 ctx, bf16 KV) plus DFlash, every step
+    initialised and served, 212-261 tok/s. Utilisation only sizes the KV cache.
+
+    Not tested at 2x: vision, and concurrent load at `--max-num-seqs 64`.
+
+        On 2x 5090 the default `--gpu-memory-utilization 0.92` works with the drafter;
     utilisation only sizes the KV cache, it does not gate initialisation. Measured
     across the range, base recipe (131,072 ctx, bf16 KV) plus DFlash:
 

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -72,6 +72,11 @@ features:
       - "--reasoning-parser"
       - "muse_glimmer"
   spec_decoding:
+    # The 5.11 GB draft head does not fit beside the 25.42 GB nvfp4 weights on a
+    # single 32 GB RTX 5090: vLLM OOMs during init with ~400 MiB free. Verified,
+    # not inferred. Two cards are required — see the guide's RTX 5090 section.
+    hardware:
+      rtx_5090: unsupported
     description: "DFlash block-diffusion draft head — predicts a whole block in one forward, verified in parallel by the target. `num_speculative_tokens: 15` is not a tuning knob: the head has `block_size: 16` and slot 0 re-presents the last accepted token, so 15 is what remains."
     args:
       - "--speculative-config"
@@ -259,6 +264,31 @@ guide: |
   **Reasoning strength.** Effort is set with a `Reasoning strength: <value>` line
   in the system prompt, one of `low` / `medium` / `high` / `xhigh`. Use `high` or
   `xhigh` for coding and agentic tasks.
+
+  ## RTX 5090 (32 GB, consumer Blackwell)
+
+    The `nvfp4` variant runs on a **single** RTX 5090 with no overrides: 131,072
+    context, a 179,647-token KV cache (1.37x concurrency at full length), 28.8 GB
+    of 32.6 GB used, and 68.8 tok/s on a 600-token greedy generation. Tool calling
+    and vision both work. `vram_minimum_gb: 31` is accurate — the margin is real
+    but thin.
+
+    Two things are worth knowing before you plan around it.
+
+    **Speculative decoding needs a second card.** The draft head is 5.11 GB and the
+    nvfp4 weights are 25.42 GB, so on one 32 GB card vLLM OOMs during init with
+    roughly 400 MiB free. On 2x 5090 with `--tensor-parallel-size 2` it runs, and
+    it is worth the second card: 184 tok/s versus 66 without the drafter.
+
+    **Lower `--gpu-memory-utilization` when speculating.** At the default 0.92 with
+    TP=2, vLLM sizes a 2,594,229-token KV cache and then fails to allocate 396 MiB
+    for the speculator. At 0.80 the cache is still 1,631,689 tokens (6.22x
+    concurrency at 262K) and initialisation completes. Counter-intuitively, a
+    *lower* utilisation is what makes speculative decoding start at all here.
+
+    A note on `max_tokens`: the channel-scoped output means a tight budget can
+    truncate before the final channel closes, returning empty `content` with
+    `finish_reason: stop`. Give it room.
 
   ## Speculative decoding
 

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -282,15 +282,12 @@ guide: |
 
     ### 2x RTX 5090
 
-    Verified with the drafter enabled. Sweeping `--gpu-memory-utilization` from
-    0.92 to 0.80 on the base recipe (131,072 ctx, bf16 KV) plus DFlash, every step
-    initialised and served, 212-261 tok/s. Utilisation only sizes the KV cache.
+    Verified with the drafter enabled, and worth the second card: decode goes from
+    68.8 tok/s to ~240 tok/s.
 
-    Not tested at 2x: vision, and concurrent load at `--max-num-seqs 64`.
-
-        On 2x 5090 the default `--gpu-memory-utilization 0.92` works with the drafter;
-    utilisation only sizes the KV cache, it does not gate initialisation. Measured
-    across the range, base recipe (131,072 ctx, bf16 KV) plus DFlash:
+    `--gpu-memory-utilization` only sizes the KV cache; it does not gate
+    initialisation. Measured across the range on the base recipe (131,072 ctx,
+    bf16 KV) plus DFlash:
 
     | `--gpu-memory-utilization` | KV cache | concurrency @131K |
     |---|---|---|
@@ -299,17 +296,41 @@ guide: |
     | 0.84 | 906,720 | 6.92x |
     | 0.80 | 759,051 | 5.79x |
 
-    All seven steps from 0.92 down to 0.80 initialised cleanly. Decode measured
-    212-261 tok/s across them with no trend attributable to utilisation — the
-    spread is run-to-run noise (a second model was sharing the host during the
-    early steps), so treat ~240 tok/s as the figure and pick utilisation purely
-    for the cache size you want.
+    All seven steps from 0.92 down to 0.80 initialised cleanly, including the
+    default 0.92. Decode was 212-261 tok/s with no trend attributable to
+    utilisation — the spread is run-to-run noise (another model shared the host
+    during the early steps) — so treat ~240 tok/s as the figure and pick
+    utilisation purely for the cache size you want.
 
     If you *extend* beyond the recipe — a longer `--max-model-len` via rope
     scaling, or `--kv-cache-dtype fp8` — the arithmetic changes and 0.92 can OOM:
     at 262,144 with fp8 KV, vLLM sized a 2,594,229-token cache and then failed to
     allocate 396 MiB for the speculator. Lowering to 0.80 fixed it. That is a
     consequence of the extension, not of the recipe as written.
+
+    Not tested at 2x: vision, and concurrent load at `--max-num-seqs 64`.
+
+    ### fp8_block on sm120 needs DeepGEMM off
+
+    The `fp8_block` variant does not load on RTX 5090 with DeepGEMM enabled. It
+    fails in `process_weights_after_loading`, before the engine starts:
+
+    ```
+    RuntimeError: Assertion error (deepgemm/csrc/apis/layout.hpp:60): Unknown SF transformation
+    ```
+
+    vLLM treats capability family 120 as a supported DeepGEMM target, so the path
+    is selected and then DeepGEMM rejects the scale-factor layout. Filed as
+    vllm-project/vllm#51884. Set both to work around it:
+
+    ```bash
+    VLLM_USE_DEEP_GEMM=0 VLLM_MOE_USE_DEEP_GEMM=0
+    ```
+
+    With that, fp8_block serves fine on 2x 5090 and is the better choice than
+    nvfp4 if you have the second card — 8-bit weights instead of W4A4, and faster:
+    177.6 tok/s with the drafter at 262,144 context (rope-extended, so outside the
+    recipe as written). nvfp4 is unaffected and loads with DeepGEMM at its default.
 
     A note on `max_tokens`: the channel-scoped output means a tight budget can
     truncate before the final channel closes, returning empty `content` with


### PR DESCRIPTION
Verified Muse-Glimmer-30B on consumer Blackwell — a single RTX 5090 (32 GB, sm120) and 2x 5090 — and added `rtx_5090: verified` / `rtx_5090_2x: verified` plus an RTX 5090 section to the guide. Consumer Blackwell wasn't represented, which seemed worth closing since the nvfp4 variant requires Blackwell.

## Single card, nvfp4

Ran the recipe unmodified — the pinned `vllm/vllm-openai:muse-glimmer` image, `Inferact/Muse-Glimmer-30B-NVFP4-W4A4` (25.42 GB), and the recipe's own base args at `--max-model-len 131072`. `autoFitTp` gives TP=1 on a single card. **No `hardware_overrides` were needed.**

| | |
|---|---|
| GPU KV cache | 179,647 tokens |
| max concurrency @ 131,072 ctx | 1.37x |
| VRAM | 28.8 GB of 32.6 GB (declared `vram_minimum_gb: 31` is accurate) |
| quantization | `modelopt_fp` via `FlashInferCutlassNvFp4LinearKernel` |
| decode | 68.8 tok/s (600-token generation, greedy, three runs within 0.1) |
| tool calling | parsed `tool_calls` array via the `muse_glimmer` parser |
| vision | verified with a real image (`prompt_tokens` 30 → 378) |
| startup | ~285 s |

**Speculative decoding does not fit on one card** — the draft head is 5.11 GB on top of 25.42 GB of weights, and init OOMs with ~400 MiB free. Marked `spec_decoding.hardware.rtx_5090: unsupported`; that is measured, not inferred.

## 2x RTX 5090

Speculative decoding works here, and is worth the second card: **68.8 → ~240 tok/s.**

`--gpu-memory-utilization` only sizes the KV cache; it does not gate initialisation. Swept the full range on the base recipe (131,072 ctx, bf16 KV) plus DFlash:

| `--gpu-memory-utilization` | KV cache | concurrency @131K |
|---|---|---|
| 0.92 | 1,202,076 | 9.17x |
| 0.88 | 1,054,407 | 8.04x |
| 0.84 | 906,720 | 6.92x |
| 0.80 | 759,051 | 5.79x |

All seven steps from 0.92 down to 0.80 initialised cleanly, the recipe default included. Decode was 212-261 tok/s with no trend attributable to utilisation — that spread is run-to-run noise (another model shared the host during the early steps).

An earlier revision of this branch claimed 0.92 OOMs with the drafter and recommended 0.80. That was wrong and is corrected in a commit here: I had generalised from a *rope-extended* 262K + fp8-KV config, where 0.92 genuinely does fail (vLLM sizes a 2,594,229-token cache, then can't find 396 MiB for the speculator). The recipe as written is fine at its default.

## fp8_block hits a DeepGEMM bug on sm120

The `fp8_block` variant does not load on RTX 5090 with DeepGEMM enabled. It fails in `process_weights_after_loading` — during weight loading, before the engine starts:

```
RuntimeError: Assertion error (deepgemm-src/csrc/apis/layout.hpp:60): Unknown SF transformation
```

`vllm/utils/deep_gemm.py` gates on device capability family 100 **or** 120, so consumer Blackwell selects the DeepGEMM path and then DeepGEMM's own scale-factor layout transform rejects the layout it is handed. Filed upstream as vllm-project/vllm#51884. `VLLM_USE_DEEP_GEMM=0 VLLM_MOE_USE_DEEP_GEMM=0` works around it, and I've documented that in the guide.

Worth knowing because with the workaround, fp8_block is the better choice than nvfp4 on 2x 5090 — 8-bit weights rather than W4A4, and faster. nvfp4 is unaffected and loads with DeepGEMM at its default.

## Also folded into the guide

On a card this tight it's easy to under-budget `max_tokens`. Because the model writes channel-scoped output, a small budget can truncate before the final channel closes and `content` comes back empty with `finish_reason: stop` — the same request at a larger budget answers normally in 584 completion tokens.

## Scope of the claim

Tested: nvfp4 at 1x and 2x, fp8_block at 2x. Not tested: bf16; vision and `--max-num-seqs 64` concurrency at 2x; anything beyond single-stream decode. The 177.6 tok/s fp8_block figure quoted in the guide is at a rope-extended 262K, outside the recipe as written, and labelled as such.
