### PR TITLE
[ROCm] Fix AITER MoE SITU v2 A8W4 env var name for Kimi-K3

### DIFF
--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -194,7 +194,7 @@ hardware_overrides:
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       SAFETENSORS_FAST_GPU: "1"
-      AITER_SITUV2_A8W4: "1"
+      VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: "1"
       AITER_BF16_FP8_MOE_BOUND: "0"
       VLLM_USE_BREAKABLE_CUDAGRAPH: "0" # REQUIRED on ROCm: the build auto-enables =1
     extra_args:


### PR DESCRIPTION
## Summary
- Rename `AITER_SITUV2_A8W4` to `VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4` in the Kimi-K3 AMD hardware override, matching the env flag vLLM's ROCm AITER MoE path actually reads.

## Test plan
- [ ] Serve Kimi-K3 on MI355X with the AMD override and confirm the AITER MoE SITU v2 A8W4 kernel is engaged.