### PR TITLE
added Xeon support for gpt-oss-20b.yaml

### DIFF
--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -54,13 +54,10 @@ compatible_strategies:
 hardware_overrides:
   cpu:
     extra_args:
-      - "--no-enable-prefix-caching"
       - "--max-num-batched-tokens"
       - "16384"
       - "--gpu-memory-utilization"
       - "0.8"
-    extra_env:
-      VLLM_ENGINE_ITERATION_TIMEOUT_S: "600"
   blackwell:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: "1"
@@ -151,10 +148,8 @@ guide: |
   not prescribe a Xeon 6 TP value or hard-code NUMA node IDs.
 
   ```bash
-  export VLLM_ENGINE_ITERATION_TIMEOUT_S=600
 
   vllm serve openai/gpt-oss-20b \
-    --no-enable-prefix-caching \
     --max-num-batched-tokens 16384 \
     --gpu-memory-utilization 0.8
   ```
@@ -166,10 +161,8 @@ guide: |
     --network host \
     --shm-size 16g \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    -e VLLM_ENGINE_ITERATION_TIMEOUT_S=600 \
     vllm/vllm-openai-cpu:latest-x86_64 \
       --model openai/gpt-oss-20b \
-      --no-enable-prefix-caching \
       --max-num-batched-tokens 16384 \
       --gpu-memory-utilization 0.8 \
       --host 0.0.0.0 \

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -2,7 +2,7 @@ meta:
   title: "GPT-OSS 20B"
   slug: "gpt-oss-20b"
   provider: "OpenAI"
-  description: "OpenAI's gpt-oss-20b — 21B-total / 3.6B-active MoE reasoning model with native MXFP4 quant; fits in 16GB VRAM"
+  description: "OpenAI's gpt-oss-20b — 21B-total / 3.6B-active MoE reasoning model with native MXFP4 quant; supports GPU, XPU, and Xeon 6 CPU serving"
   date_added: 2025-08-05
   date_updated: 2026-05-08
   difficulty: beginner
@@ -20,6 +20,7 @@ meta:
     mi355x: verified
     arc_pro_b60: verified
     arc_pro_b70: verified
+    xeon6: verified
 
 model:
   model_id: "openai/gpt-oss-20b"
@@ -51,6 +52,15 @@ compatible_strategies:
   - single_node_tp
 
 hardware_overrides:
+  cpu:
+    extra_args:
+      - "--no-enable-prefix-caching"
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--gpu-memory-utilization"
+      - "0.8"
+    extra_env:
+      VLLM_ENGINE_ITERATION_TIMEOUT_S: "600"
   blackwell:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: "1"
@@ -85,9 +95,9 @@ guide: |
 
   ## Prerequisites
 
-  - Hardware: NVIDIA H100/H200/B200 or AMD MI300X/MI325X/MI355X or Intel XPU B60/B70 (also runs on Ada/Ampere consumer cards with sufficient VRAM).
+  - Hardware: NVIDIA H100/H200/B200, AMD MI300X/MI325X/MI355X, Intel XPU B60/B70, or 4x Xeon 6 CPUs.
   - vLLM >= 0.10.0.
-  - CUDA >= 12.8 if building from source (must match between install and serving).
+  - CUDA >= 12.8 if building from source for NVIDIA GPUs (must match between install and serving).
 
   ### Install vLLM
 
@@ -95,6 +105,18 @@ guide: |
   uv venv
   source .venv/bin/activate
   uv pip install vllm --torch-backend=auto
+  ```
+
+  ### pip (Intel Xeon 6 CPUs)
+
+  For Intel and AMD x86 CPUs, follow the
+  [CPU pre-built wheels](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/#pre-built-wheels)
+  installation instructions.
+
+  ### Docker (Intel Xeon 6 CPUs)
+
+  ```bash
+  docker pull vllm/vllm-openai-cpu:latest-x86_64
   ```
 
   Docker quickstart:
@@ -120,6 +142,38 @@ guide: |
 
   ```bash
   vllm serve openai/gpt-oss-20b
+  ```
+
+  ### Intel Xeon 6
+
+  Choose the tensor parallel size based on the system topology and deployment
+  requirements. Add `--tensor-parallel-size <N>` when needed; the recipe does
+  not prescribe a Xeon 6 TP value or hard-code NUMA node IDs.
+
+  ```bash
+  export VLLM_ENGINE_ITERATION_TIMEOUT_S=600
+
+  vllm serve openai/gpt-oss-20b \
+    --no-enable-prefix-caching \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.8
+  ```
+
+  Docker:
+
+  ```bash
+  docker run -itd --name gpt-oss-20b-cpu \
+    --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e VLLM_ENGINE_ITERATION_TIMEOUT_S=600 \
+    vllm/vllm-openai-cpu:latest-x86_64 \
+      --model openai/gpt-oss-20b \
+      --no-enable-prefix-caching \
+      --max-num-batched-tokens 16384 \
+      --gpu-memory-utilization 0.8 \
+      --host 0.0.0.0 \
+      --port 8000
   ```
 
   Blackwell (B200) with FlashInfer MXFP4+MXFP8 MoE:


### PR DESCRIPTION
## Summary

Add Intel Xeon 6 support for `openai/gpt-oss-20b`, following the CPU recipe patterns from PR #518 and PR #519.

The configuration is based on a validated Xeon 6 serving

This PR adds:

* `xeon6: verified`
* CPU install and Docker guidance
* CPU tuning:

  * `--no-enable-prefix-caching`
  * `--max-num-batched-tokens 16384`
  * `--gpu-memory-utilization 0.8`
  * `VLLM_ENGINE_ITERATION_TIMEOUT_S=600`

## Differences from the validation Excel

Some benchmark settings are intentionally not carried into the portable recipe:

* `--dtype bfloat16`: removed because vLLM `dtype=auto` resolves GPT-OSS to BF16 runtime dtype.
* `--max-num-seqs=256`: removed because it matches the current default.
* `--trust-remote-code`: removed because GPT-OSS has native vLLM support.
* `TP=2`: not fixed; users choose TP based on their CPU topology.
* `DP=2` / router DP: out of scope for this model recipe.
* `CPU_VISIBLE_MEMORY_NODES` and explicit CPU binding: removed because they are host/topology specific.
* Legacy launcher settings such as `VLLM_USE_V1`, `VLLM_RPC_TIMEOUT`, and `VLLM_ALLOW_LONG_MAX_MODEL_LEN` are not needed.
* --no-enable-prefix-caching: removed because it was part of the performance benchmark configuration and is not required for the general deployment recipe.
* VLLM_ENGINE_ITERATION_TIMEOUT_S=600: removed because it was part of the performance benchmark/repro configuration and is not required for the general deployment recipe.

The model remains `precision: mxfp4`; BF16 in the validation run is the runtime dtype, not a separate BF16 checkpoint variant.
