### PR TITLE
[Recipe] Rename Dots model to dots3-note-prev

### DIFF
--- a/models/dots-studio/dots3-note-prev.yaml
+++ b/models/dots-studio/dots3-note-prev.yaml
@@ -1,6 +1,6 @@
 meta:
-  title: "dots-3-note-prev"
-  slug: "dots-3-note-prev"
+  title: "dots3-note-prev"
+  slug: "dots3-note-prev"
   provider: "Dots"
   description: "Multimodal MoE model available in BF16 and native FP8, with hybrid DSA and SWA, 512K context, and MTP speculative decoding."
   date_added: 2026-08-13
@@ -21,7 +21,7 @@ meta:
     mi355x: unsupported
 
 model:
-  model_id: "dots-studio/dots-3-note-prev"
+  model_id: "dots-studio/dots3-note-prev"
   min_vllm_version: "nightly"
   nightly_required: true
   architecture: moe
@@ -30,7 +30,7 @@ model:
   context_length: 524288
   base_args:
     - "--served-model-name"
-    - "dots-3-note-prev"
+    - "dots3-note-prev"
     - "--gpu-memory-utilization"
     - "0.9"
     - "--max-model-len"
@@ -50,7 +50,7 @@ features:
       - "--reasoning-parser"
       - "qwen3"
   tool_calling:
-    description: "Parse dots-3-note-prev's native XML tool-call format with automatic tool choice."
+    description: "Parse dots3-note-prev's native XML tool-call format with automatic tool choice."
     args:
       - "--enable-auto-tool-choice"
       - "--tool-call-parser"
@@ -73,7 +73,7 @@ opt_in_features:
 
 variants:
   default:
-    model_id: "dots-studio/dots-3-note-prev-fp8"
+    model_id: "dots-studio/dots3-note-prev-fp8"
     precision: fp8
     vram_minimum_gb: 359
     description: "Native block-scaled FP8 language-model weights with BF16 multimodal encoders; verified on 8x 80GB NVIDIA GPUs."
@@ -83,7 +83,7 @@ variants:
           - "--moe-backend"
           - "deep_gemm"
   bf16:
-    model_id: "dots-studio/dots-3-note-prev"
+    model_id: "dots-studio/dots3-note-prev"
     precision: bf16
     vram_minimum_gb: 692
     description: "Full BF16 checkpoint using the Triton unquantized-MoE backend; its indexed weights total about 576.9 GB before runtime and KV-cache memory."
@@ -109,10 +109,10 @@ strategy_overrides: {}
 guide: |
   ## Overview
 
-  dots-3-note-prev is a native multimodal Mixture-of-Experts model supporting text, image,
+  dots3-note-prev is a native multimodal Mixture-of-Experts model supporting text, image,
   video, and audio inputs through one model architecture. It is published as a full
-  BF16 checkpoint (`dots-studio/dots-3-note-prev`) and a native FP8 checkpoint
-  (`dots-studio/dots-3-note-prev-fp8`). Its language backbone has 256 routed experts
+  BF16 checkpoint (`dots-studio/dots3-note-prev`) and a native FP8 checkpoint
+  (`dots-studio/dots3-note-prev-fp8`). Its language backbone has 256 routed experts
   (top-8) plus a shared expert and mixes DSA and SWA layers. Both releases expose
   MTP speculative decoding.
 
@@ -128,7 +128,7 @@ guide: |
     memory for the runtime and KV cache; the recipe budgets 692 GB aggregate VRAM.
   - A recent CUDA environment. Native FP8 uses DeepGEMM, while unquantized BF16
     uses the Triton MoE backend.
-  - A vLLM nightly containing native dots-3-note-prev support.
+  - A vLLM nightly containing native dots3-note-prev support.
 
   ## Launch commands
 
@@ -147,8 +147,8 @@ guide: |
   lower `--max-model-len` or add `--language-model-only` for text workloads.
 
   ```bash
-  vllm serve dots-studio/dots-3-note-prev \
-    --served-model-name dots-3-note-prev \
+  vllm serve dots-studio/dots3-note-prev \
+    --served-model-name dots3-note-prev \
     --host 0.0.0.0 \
     --tensor-parallel-size 8 \
     --enable-expert-parallel \
@@ -166,8 +166,8 @@ guide: |
   deployment, but it does not enable expert parallelism.
 
   ```bash
-  vllm serve dots-studio/dots-3-note-prev-fp8 \
-    --served-model-name dots-3-note-prev \
+  vllm serve dots-studio/dots3-note-prev-fp8 \
+    --served-model-name dots3-note-prev \
     --host 0.0.0.0 \
     --tensor-parallel-size 8 \
     --gpu-memory-utilization 0.9 \
@@ -184,8 +184,8 @@ guide: |
   experts are distributed across the eight expert-parallel ranks.
 
   ```bash
-  vllm serve dots-studio/dots-3-note-prev-fp8 \
-    --served-model-name dots-3-note-prev \
+  vllm serve dots-studio/dots3-note-prev-fp8 \
+    --served-model-name dots3-note-prev \
     --host 0.0.0.0 \
     --tensor-parallel-size 8 \
     --enable-expert-parallel \
@@ -204,8 +204,8 @@ guide: |
   It therefore needs more GPU memory than TP+EP.
 
   ```bash
-  vllm serve dots-studio/dots-3-note-prev-fp8 \
-    --served-model-name dots-3-note-prev \
+  vllm serve dots-studio/dots3-note-prev-fp8 \
+    --served-model-name dots3-note-prev \
     --host 0.0.0.0 \
     --data-parallel-size 8 \
     --enable-expert-parallel \
@@ -224,8 +224,8 @@ guide: |
   The option can be combined with TP, TP+EP, or DP+EP.
 
   ```bash
-  vllm serve dots-studio/dots-3-note-prev-fp8 \
-    --served-model-name dots-3-note-prev \
+  vllm serve dots-studio/dots3-note-prev-fp8 \
+    --served-model-name dots3-note-prev \
     --host 0.0.0.0 \
     --tensor-parallel-size 8 \
     --enable-expert-parallel \
@@ -245,8 +245,8 @@ guide: |
   loading a separate draft model. The example uses TP+EP with the native FP8 checkpoint.
 
   ```bash
-  vllm serve dots-studio/dots-3-note-prev-fp8 \
-    --served-model-name dots-3-note-prev \
+  vllm serve dots-studio/dots3-note-prev-fp8 \
+    --served-model-name dots3-note-prev \
     --host 0.0.0.0 \
     --tensor-parallel-size 8 \
     --enable-expert-parallel \
@@ -261,13 +261,13 @@ guide: |
 
   ### Tool calling
 
-  dots-3-note-prev emits tool calls inside `<dots_function_call>` XML wrappers. Enable
+  dots3-note-prev emits tool calls inside `<dots_function_call>` XML wrappers. Enable
   automatic tool choice with the native `dots` parser. These options can be combined
   with any parallel strategy, `--language-model-only`, and MTP speculative decoding.
 
   ```bash
-  vllm serve dots-studio/dots-3-note-prev-fp8 \
-    --served-model-name dots-3-note-prev \
+  vllm serve dots-studio/dots3-note-prev-fp8 \
+    --served-model-name dots3-note-prev \
     --host 0.0.0.0 \
     --tensor-parallel-size 8 \
     --enable-expert-parallel \
@@ -287,7 +287,7 @@ guide: |
   curl http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
-      "model": "dots-3-note-prev",
+      "model": "dots3-note-prev",
       "messages": [{"role": "user", "content": "Explain sparse attention briefly."}],
       "temperature": 0.7
     }'
@@ -314,7 +314,7 @@ guide: |
 
   ## References
 
-  - [dots-3-note-prev FP8 on Hugging Face](https://huggingface.co/dots-studio/dots-3-note-prev-fp8)
-  - [dots-3-note-prev BF16 on Hugging Face](https://huggingface.co/dots-studio/dots-3-note-prev)
-  - [vLLM dots-3-note-prev support PR](https://github.com/vllm-project/vllm/pull/51255)
+  - [dots3-note-prev FP8 on Hugging Face](https://huggingface.co/dots-studio/dots3-note-prev-fp8)
+  - [dots3-note-prev BF16 on Hugging Face](https://huggingface.co/dots-studio/dots3-note-prev)
+  - [vLLM dots3-note-prev support PR](https://github.com/vllm-project/vllm/pull/51255)
   - [vLLM parallelism and scaling guide](https://docs.vllm.ai/en/latest/serving/parallelism_scaling.html)


### PR DESCRIPTION
## Summary

Rename the Dots model’s technical name from `dots-3-note-prev` to `dots3-note-prev` to match the updated Hugging Face repository names.

## Changes

- Rename the recipe path to `models/dots-studio/dots3-note-prev.yaml`.
- Update the recipe title, slug, served model name, documentation, and client examples.
- Update the checkpoint IDs:
  - BF16: `dots-studio/dots3-note-prev`
  - FP8: `dots-studio/dots3-note-prev-fp8`
- Update all Hugging Face links and launch commands.

## Validation

- Confirmed both updated Hugging Face model IDs resolve successfully.
- Verified command synthesis for both the FP8 and BF16 variants.
- Confirmed no stale `dots-3-note-prev` references remain in the recipe.