### PR TITLE
fix: isolate tooltip provider state

### DIFF
--- a/src/components/ui/tooltip.jsx
+++ b/src/components/ui/tooltip.jsx
@@ -41,12 +41,14 @@ const TooltipContent = React.forwardRef(function TooltipContent(
 function InfoTip({ content, children, side, align, sideOffset, asChild = true }) {
   if (!content) return children;
   return (
-    <Tooltip>
-      <TooltipTrigger asChild={asChild}>{children}</TooltipTrigger>
-      <TooltipContent side={side} align={align} sideOffset={sideOffset}>
-        {content}
-      </TooltipContent>
-    </Tooltip>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild={asChild}>{children}</TooltipTrigger>
+        <TooltipContent side={side} align={align} sideOffset={sideOffset}>
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 


### PR DESCRIPTION
When moving quickly between buttons, Radix reused the shared tooltip provider’s “instant open” state. The next tooltip could render before Popper recalculated its position, briefly appearing in the previous tooltip’s location.
The fix gives each InfoTip its own provider, preventing state from being carried between buttons.