### PR TITLE
Add Intel XPU deployment for Gemma 4 E2B-it with assistant model support

### DIFF
--- a/models/Google/gemma-4-12B-it.yaml
+++ b/models/Google/gemma-4-12B-it.yaml
@@ -15,6 +15,7 @@ meta:
     - google/gemma-4-31B-it
   hardware:
     h100: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-12B-it"
@@ -73,7 +74,13 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  xpu:
+    extra_args:
+      tensor_parallel_size: 2
+      quantization: compressed-tensors
+    extra_env:
+      ZE_AFFINITY_MASK: "0,1"
 
 strategy_overrides:
   single_node_tp:
@@ -164,6 +171,23 @@ guide: |
       --host 0.0.0.0 --port 8000
   ```
   On CUDA 12.9 hosts, use the `vllm/vllm-openai:gemma4-unified-cu129` tag instead.
+
+  ### Docker (Intel XPU — Max 1550)
+  The W4A16 QAT variant fits on 2 tiles of a Max 1550 with mixed attention backends
+  (Flash Attention SYCL for sliding-window layers, Triton for full-attention layers).
+  ```bash
+  docker run -itd --name gemma4-12b-xpu \
+    --device /dev/dri --network host --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e ZE_AFFINITY_MASK="0,1" \
+    intel/vllm:latest \
+      --model google/gemma-4-12B-it-qat-w4a16-ct \
+      --dtype bfloat16 \
+      --quantization compressed-tensors \
+      --tensor-parallel-size 2 \
+      --max-model-len 16384 \
+      --host 0.0.0.0 --port 8000
+  ```
 
   ### Docker (Cloud TPU — Trillium / Ironwood)
   TPU uses the separate `vllm/vllm-tpu` image (no pip wheel). Pull the tag specified by the upstream [Trillium](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Gemma4) or [Ironwood](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/inference/ironwood/vLLM/Gemma4/) recipe, then run:

--- a/models/Google/gemma-4-E2B-it.yaml
+++ b/models/Google/gemma-4-E2B-it.yaml
@@ -21,6 +21,7 @@ meta:
     trillium: verified
     ironwood: verified
     xeon6: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-E2B-it"
@@ -94,6 +95,11 @@ compatible_strategies:
   - multi_node_tp
 
 hardware_overrides:
+  xpu:
+    extra_args:
+      enforce_eager: true
+    extra_env:
+      ZE_AFFINITY_MASK: "0"
   cpu:
     extra_env:
       VLLM_CPU_KVCACHE_SPACE: "40"
@@ -234,6 +240,31 @@ guide: |
       --model google/gemma-4-E2B-it \
       --host 0.0.0.0 \
       --port 8000
+  ```
+
+
+  ### Intel Data Center GPU Max 1550 (XPU) Deployment via Docker
+
+  The model fits on a single Max 1550 tile (~13 GB BF16). Text-only mode is recommended for XPU to avoid multimodal encoder overhead. Speculative decoding with the [assistant model](https://huggingface.co/google/gemma-4-E2B-it-assistant) is also supported on XPU.
+
+  ```bash
+  docker run -itd --name gemma4-e2b-xpu \
+    --device /dev/dri --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e ZE_AFFINITY_MASK=0 \
+    intel/vllm:latest \
+      --model google/gemma-4-E2B-it \
+      --language-model-only \
+      --dtype bfloat16 \
+      --enforce-eager \
+      --max-model-len 8192 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  To enable speculative decoding on XPU, add:
+  ```
+  --speculative-config '{"model":"google/gemma-4-E2B-it-assistant","num_speculative_tokens":2}'
   ```
 
 

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -144,6 +144,16 @@ hardware_profiles:
     restricted: true
 
   # ── Intel Xeon CPU ──
+  max1550:
+    brand: Intel
+    generation: xpu
+    display_name: "Data Center GPU Max 1550"
+    description: "Intel Data Center GPU Max 1550 · 64 GB HBM2e per tile · 2-tile OAM module"
+    gpu_count: 4
+    vram_gb: 256
+    multi_node: false
+    restricted: true
+
   xeon6:
     brand: Intel
     generation: cpu


### PR DESCRIPTION
## Motivation

Add Intel Data Center GPU Max 1550 (XPU) as a verified deployment target for Gemma 4 E2B-it, including support for speculative decoding with the gemma-4-E2B-it-assistant draft model.

## Changes

- Add `max1550: verified` to the hardware list
- Add `xpu` hardware_overrides with `enforce_eager: true` and `ZE_AFFINITY_MASK=0`
- Add Intel XPU Docker deployment section to the guide with text-only and speculative decoding instructions

## Validation

- Model loads and runs on Intel Data Center GPU Max 1550 (single tile, TP=1, BF16, ~13 GB)
- Speculative decoding with assistant model verified functional
- Corresponding vLLM changes merged: `7bc453ed9a` (architecture registration, config scaffolding, tokenizer fix, KV shared layer guard)