### PR TITLE
Add Intel XPU (Max 1550) deployment recipe for Gemma 4 E2B + mobile QAT

### DIFF
--- a/models/Google/gemma-4-E2B-it.yaml
+++ b/models/Google/gemma-4-E2B-it.yaml
@@ -22,6 +22,7 @@ meta:
     trillium: verified
     ironwood: verified
     xeon6: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-E2B-it"
@@ -99,6 +100,17 @@ hardware_overrides:
     extra_env:
       VLLM_CPU_KVCACHE_SPACE: "40"
       VLLM_CPU_ATTN_SPLIT_KV: "0"
+  xpu:
+    extra_args:
+      - "--enforce-eager"
+      - "--kv-cache-dtype"
+      - "bfloat16"
+      - "--gpu-memory-utilization"
+      - "0.85"
+      - "--max-model-len"
+      - "4096"
+    extra_env:
+      VLLM_TARGET_DEVICE: "xpu"
 
 strategy_overrides:
   single_node_tp:
@@ -236,6 +248,29 @@ guide: |
       --host 0.0.0.0 \
       --port 8000
   ```
+
+
+  ### Intel Data Center GPU Max 1550 (XPU) via Docker
+
+  Gemma 4 E2B (BF16 and all QAT variants including mobile-ct) runs on a single Intel Max 1550 tile (68.7 GB HBM2e). The mobile QAT variant (`google/gemma-4-E2B-it-qat-mobile-ct`) with mixed int2/4/8 quantization needs only ~4 GB for weights, leaving ample room for KV cache.
+
+  ```bash
+  docker run -itd --name gemma4-e2b-xpu \
+    --device /dev/dri --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e VLLM_TARGET_DEVICE=xpu \
+    intel/vllm:latest \
+      --model google/gemma-4-E2B-it-qat-mobile-ct \
+      --dtype bfloat16 \
+      --enforce-eager \
+      --kv-cache-dtype bfloat16 \
+      --gpu-memory-utilization 0.85 \
+      --max-model-len 4096 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  Replace the model ID with `google/gemma-4-E2B-it` for BF16 or `google/gemma-4-E2B-it-qat-w4a16-ct` for W4A16.
 
 
   ## Client Usage

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -260,6 +260,16 @@ hardware_profiles:
   # `restricted: true` keeps it out of the picker unless a recipe explicitly
   # lists it in `meta.hardware` — XPU support ships in the separate
   # `vllm/vllm-openai-xpu` image and is only declared on validated recipes.
+  max1550:
+    brand: Intel
+    generation: xpu
+    display_name: "Data Center GPU Max 1550"
+    description: "Intel Data Center GPU Max 1550 · 68.7 GB HBM2e · Xe-HPC"
+    gpu_count: 4
+    vram_gb: 64
+    multi_node: false
+    restricted: true
+
   arc_pro_b60:
     brand: Intel
     generation: xpu


### PR DESCRIPTION
## Motivation

Add Intel Data Center GPU Max 1550 (Xe-HPC, 68.7 GB HBM2e) as a verified deployment target for Gemma 4 E2B, including the mobile QAT variant (`google/gemma-4-E2B-it-qat-mobile-ct`) with mixed int2/4/8 compressed-tensors quantization.

## Changes

- **taxonomy.yaml**: Add `max1550` hardware profile (Intel Data Center GPU Max 1550)
- **models/Google/gemma-4-E2B-it.yaml**:
  - Add `max1550: verified` to hardware list
  - Add XPU hardware_overrides (enforce-eager, bfloat16 KV cache, memory utilization)
  - Add Intel XPU Docker deployment section to the guide covering BF16, W4A16, and mobile QAT variants

## Validation

Tested on Intel Data Center GPU Max 1550 with vLLM XPU backend:
- `google/gemma-4-E2B-it-qat-mobile-ct` loads and generates correct text output
- Mixed int2/4/8 quantization dispatched correctly via XPUDequantLinearKernel
- ~4 GB weight footprint (3.6x compression vs BF16)

Companion vLLM PR: vllm-project/vllm@e7e852033 (Enable google/gemma-4-E2B-it-qat-mobile-ct on Intel XPU)