### PR TITLE
Add Intel XPU deployment recipe for Gemma 4 E4B IT

### DIFF
--- a/models/Google/gemma-4-12B-it.yaml
+++ b/models/Google/gemma-4-12B-it.yaml
@@ -15,6 +15,7 @@ meta:
     - google/gemma-4-31B-it
   hardware:
     h100: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-12B-it"
@@ -73,7 +74,13 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  xpu:
+    extra_args:
+      tensor_parallel_size: 2
+      quantization: compressed-tensors
+    extra_env:
+      ZE_AFFINITY_MASK: "0,1"
 
 strategy_overrides:
   single_node_tp:
@@ -164,6 +171,23 @@ guide: |
       --host 0.0.0.0 --port 8000
   ```
   On CUDA 12.9 hosts, use the `vllm/vllm-openai:gemma4-unified-cu129` tag instead.
+
+  ### Docker (Intel XPU — Max 1550)
+  The W4A16 QAT variant fits on 2 tiles of a Max 1550 with mixed attention backends
+  (Flash Attention SYCL for sliding-window layers, Triton for full-attention layers).
+  ```bash
+  docker run -itd --name gemma4-12b-xpu \
+    --device /dev/dri --network host --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e ZE_AFFINITY_MASK="0,1" \
+    intel/vllm:latest \
+      --model google/gemma-4-12B-it-qat-w4a16-ct \
+      --dtype bfloat16 \
+      --quantization compressed-tensors \
+      --tensor-parallel-size 2 \
+      --max-model-len 16384 \
+      --host 0.0.0.0 --port 8000
+  ```
 
   ### Docker (Cloud TPU — Trillium / Ironwood)
   TPU uses the separate `vllm/vllm-tpu` image (no pip wheel). Pull the tag specified by the upstream [Trillium](https://github.com/AI-Hypercomputer/tpu-recipes/tree/main/inference/trillium/vLLM/Gemma4) or [Ironwood](https://github.com/AI-Hypercomputer/tpu-recipes/blob/main/inference/ironwood/vLLM/Gemma4/) recipe, then run:

--- a/models/Google/gemma-4-E2B-it.yaml
+++ b/models/Google/gemma-4-E2B-it.yaml
@@ -21,6 +21,7 @@ meta:
     trillium: verified
     ironwood: verified
     xeon6: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-E2B-it"
@@ -94,6 +95,11 @@ compatible_strategies:
   - multi_node_tp
 
 hardware_overrides:
+  xpu:
+    extra_args:
+      enforce_eager: true
+    extra_env:
+      ZE_AFFINITY_MASK: "0"
   cpu:
     extra_env:
       VLLM_CPU_KVCACHE_SPACE: "40"
@@ -234,6 +240,31 @@ guide: |
       --model google/gemma-4-E2B-it \
       --host 0.0.0.0 \
       --port 8000
+  ```
+
+
+  ### Intel Data Center GPU Max 1550 (XPU) Deployment via Docker
+
+  The model fits on a single Max 1550 tile (~13 GB BF16). Text-only mode is recommended for XPU to avoid multimodal encoder overhead. Speculative decoding with the [assistant model](https://huggingface.co/google/gemma-4-E2B-it-assistant) is also supported on XPU.
+
+  ```bash
+  docker run -itd --name gemma4-e2b-xpu \
+    --device /dev/dri --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e ZE_AFFINITY_MASK=0 \
+    intel/vllm:latest \
+      --model google/gemma-4-E2B-it \
+      --language-model-only \
+      --dtype bfloat16 \
+      --enforce-eager \
+      --max-model-len 8192 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  To enable speculative decoding on XPU, add:
+  ```
+  --speculative-config '{"model":"google/gemma-4-E2B-it-assistant","num_speculative_tokens":2}'
   ```
 
 

--- a/models/Google/gemma-4-E4B-it.yaml
+++ b/models/Google/gemma-4-E4B-it.yaml
@@ -21,6 +21,7 @@ meta:
     trillium: verified
     ironwood: verified
     xeon6: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-E4B-it"
@@ -98,6 +99,11 @@ hardware_overrides:
     extra_env:
       VLLM_CPU_KVCACHE_SPACE: "40"
       VLLM_CPU_ATTN_SPLIT_KV: "0"
+  xpu:
+    extra_args:
+      enforce_eager: true
+    extra_env:
+      ZE_AFFINITY_MASK: "0"
 
 strategy_overrides:
   single_node_tp:
@@ -236,6 +242,26 @@ guide: |
   ```
 
   For additional Intel Xeon 6 deployment details, see the Intel Software Catalog entries for [Gemma 4 E4B IT](https://aiswcatalog.intel.com/models/google-gemma-4-e4b-it).
+
+  ### Intel XPU Deployment via Docker (Data Center GPU Max 1550)
+
+  Gemma 4 E4B fits on a single Max 1550 tile (~16 GB BF16 weights). The per-layer mixed attention backend (Flash Attention for sliding window layers, Triton for global attention layers) is selected automatically.
+
+  ```bash
+  docker run -itd --name gemma4-e4b-xpu \
+    --device /dev/dri --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e ZE_AFFINITY_MASK=0 \
+    intel/vllm:latest \
+      --model google/gemma-4-E4B-it \
+      --dtype bfloat16 \
+      --enforce-eager \
+      --max-model-len 32768 \
+      --host 0.0.0.0 --port 8000
+  ```
+
+  For text-only workloads, add `--language-model-only` to skip loading vision/audio encoders and free VRAM for KV cache.
 
   ## Client Usage
 

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -144,6 +144,16 @@ hardware_profiles:
     restricted: true
 
   # ── Intel Xeon CPU ──
+  max1550:
+    brand: Intel
+    generation: xpu
+    display_name: "Data Center GPU Max 1550"
+    description: "Intel Data Center GPU Max 1550 · 64 GB HBM2e per tile · 2-tile OAM module"
+    gpu_count: 4
+    vram_gb: 256
+    multi_node: false
+    restricted: true
+
   xeon6:
     brand: Intel
     generation: cpu


### PR DESCRIPTION
## Motivation

Add Intel Data Center GPU Max 1550 (XPU) deployment support for google/gemma-4-E4B-it.

## Changes

- Added `max1550: verified` to hardware list
- Added XPU hardware_overrides (enforce_eager, ZE_AFFINITY_MASK)
- Added Intel XPU Docker deployment section to the guide

## Key Details

Gemma 4 E4B uses heterogeneous head dimensions (256 sliding, 512 global). On XPU, vLLM automatically routes each layer to the optimal attention backend:
- Sliding window layers (head_dim=256) → Flash Attention SYCL
- Global attention layers (head_dim=512) → Triton Attention

The model fits on a single Max 1550 tile (~16 GB BF16 weights).

## Validation

- Model loads and serves correctly on Max 1550 with per-layer mixed attention backends
- Corresponding vLLM PR: vllm-project/vllm@29e44f745a