### PR TITLE
Verify Qwen3.8-27B on RTX 5090 (1x and 2x, sm120)

### DIFF
--- a/models/Qwen/Qwen3.8-27B.yaml
+++ b/models/Qwen/Qwen3.8-27B.yaml
@@ -17,10 +17,12 @@ meta:
   # and working tool calls. Everything else stays absent — the honest silent default.
   hardware:
     gb300: verified
-    # 2x RTX 5090 (consumer Blackwell, sm120), verified 2026-08-15 on vLLM
-    # 0.26.1rc1.dev608+g99a10304d: FP8 and both NVFP4 builds at TP2, each booted,
-    # served and answered a verifiable prompt, with MTP acceptance read from
-    # /metrics rather than inferred from throughput.
+    # Consumer Blackwell (sm120), verified 2026-08-15 on vLLM
+    # 0.26.1rc1.dev608+g99a10304d. Each entry was booted, served and answered a
+    # verifiable prompt, with MTP acceptance read from /metrics rather than
+    # inferred from throughput. rtx_5090 is NVFP4 on one card and requires
+    # --enforce-eager; rtx_5090_2x covers FP8 and both NVFP4 builds at TP2.
+    rtx_5090: verified
     rtx_5090_2x: verified
 
 model:
@@ -123,7 +125,7 @@ variants:
     label: "NVFP4 (W4A4)"
     # 26,381,249,312 B = 26.4 GB. quant_method `modelopt`, quant_algo `NVFP4`.
     vram_minimum_gb: 32
-    supported_hardware: [b200, b300, gb200, gb300, rtx_5090_2x]
+    supported_hardware: [b200, b300, gb200, gb300, rtx_5090, rtx_5090_2x]
     description: "NVFP4 build for NVIDIA Blackwell — 24.6 GiB, the smallest footprint: 1 GPU."
 
 # Dense model: no routed experts, so none of the expert-parallel or PD strategies apply.
@@ -222,6 +224,30 @@ guide: |
   The in-checkpoint MTP head works in every precision above. Acceptance is measured from
   `vllm:spec_decode_num_{accepted,draft}_tokens_total`, since throughput alone cannot
   distinguish a working drafter from one that loaded and was ignored.
+
+  ### 1x RTX 5090 — NVFP4 needs `--enforce-eager`
+
+  One card has **31.4 GiB usable**, not 32, and NVFP4 fits only with CUDA graphs off:
+
+  ```bash
+  vllm serve Inferact/Qwen3.8-27B-NVFP4 \
+    --tensor-parallel-size 1 \
+    --max-model-len 32768 \
+    --kv-cache-dtype fp8 \
+    --enforce-eager \
+    --reasoning-parser qwen3
+  ```
+
+  Without `--enforce-eager`, startup dies in CUDA graph capture with
+  `torch.OutOfMemoryError: Tried to allocate 784.00 MiB`. **Raising or lowering
+  `--gpu-memory-utilization` does not help** — 0.80 and 0.93 both leave the same 47.06 MiB
+  free, because that budget covers weights and KV while graph capture allocates outside it.
+
+  KV pool at 32K context: 91,022 tokens with `--enforce-eager` alone; 135,926 adding
+  `--language-model-only`; 152,917 also capping `--max-num-seqs 8`; 76,458 with bf16 KV
+  instead of fp8 — so fp8 KV is a choice here, not a requirement. The MTP head still fits
+  (90,112 tokens, 0.754 acceptance). Those two flags are levers for a bigger pool, not fixes
+  for the OOM: only `--enforce-eager` decides whether the server starts.
 
   ## Client usage
 

--- a/models/Qwen/Qwen3.8-27B.yaml
+++ b/models/Qwen/Qwen3.8-27B.yaml
@@ -17,6 +17,11 @@ meta:
   # and working tool calls. Everything else stays absent — the honest silent default.
   hardware:
     gb300: verified
+    # 2x RTX 5090 (consumer Blackwell, sm120), verified 2026-08-15 on vLLM
+    # 0.26.1rc1.dev608+g99a10304d: FP8 and both NVFP4 builds at TP2, each booted,
+    # served and answered a verifiable prompt, with MTP acceptance read from
+    # /metrics rather than inferred from throughput.
+    rtx_5090_2x: verified
 
 model:
   model_id: "Qwen/Qwen3.8-27B"
@@ -118,7 +123,7 @@ variants:
     label: "NVFP4 (W4A4)"
     # 26,381,249,312 B = 26.4 GB. quant_method `modelopt`, quant_algo `NVFP4`.
     vram_minimum_gb: 32
-    supported_hardware: [b200, b300, gb200, gb300]
+    supported_hardware: [b200, b300, gb200, gb300, rtx_5090_2x]
     description: "NVFP4 build for NVIDIA Blackwell — 24.6 GiB, the smallest footprint: 1 GPU."
 
 # Dense model: no routed experts, so none of the expert-parallel or PD strategies apply.
@@ -179,6 +184,44 @@ guide: |
   ```
 
   Add `--speculative-config '{"method":"mtp","num_speculative_tokens":3}'` for MTP.
+
+  ### 2x RTX 5090 (consumer Blackwell, sm120)
+
+  Verified on vLLM `0.26.1rc1.dev608+g99a10304d`, TP2 across two cards.
+
+  **NVFP4 uses the real kernel here.** vLLM selects
+  `FlashInferCutlassNvFp4LinearKernel for NVFP4 GEMM` on sm120 — a cutlass path, not an
+  emulation fallback — for both the `Inferact` build above and `unsloth/Qwen3.8-27B-NVFP4`.
+
+  **The block-scaled FP8 checkpoint needs no workaround.** vLLM auto-disables DeepGemm for
+  `model_type=qwen3_5_text` on Blackwell and falls back to CUTLASS, so it loads unaided.
+  Verified by running *without* `VLLM_USE_DEEP_GEMM=0`: identical 377,456-token KV pool.
+
+  ```bash
+  vllm serve unsloth/Qwen3.8-27B-NVFP4 \
+    --tensor-parallel-size 2 \
+    --max-model-len 262144 \
+    --kv-cache-dtype fp8 \
+    --reasoning-parser qwen3 \
+    --enable-auto-tool-choice --tool-call-parser qwen3_coder
+  ```
+
+  At 262,144 context, GPU KV cache size as reported at startup:
+
+  | precision | KV tokens | weights/GPU | MTP acceptance |
+  |---|---|---|---|
+  | FP8 | 377,456 | 14.28 GiB | 0.771 |
+  | NVFP4 (Inferact) | 445,875 | 12.02 GiB | 0.897 |
+  | NVFP4 (unsloth) | 920,517 | 10.64 GiB | 0.788 |
+
+  The two NVFP4 builds are not interchangeable on 32 GB cards: `unsloth` is
+  mixed-precision (FP8 channel-wise alongside the 4-bit groups) and leaves room for roughly
+  twice the KV cache, while the uniform-W4A4 `Inferact` build drafts better. Both serve
+  correctly.
+
+  The in-checkpoint MTP head works in every precision above. Acceptance is measured from
+  `vllm:spec_decode_num_{accepted,draft}_tokens_total`, since throughput alone cannot
+  distinguish a working drafter from one that loaded and was ignored.
 
   ## Client usage
 


### PR DESCRIPTION
Marks `rtx_5090` and `rtx_5090_2x` verified for Qwen3.8-27B, adds both to the `nvfp4` variant's `supported_hardware`, and documents the two deployments in the guide. Every configuration listed was booted, served and answered a verifiable prompt on vLLM `0.26.1rc1.dev608+g99a10304d`.

### NVFP4 runs on sm120 with a real kernel

vLLM selects `FlashInferCutlassNvFp4LinearKernel for NVFP4 GEMM` — a cutlass path, not an emulation fallback — for both the `Inferact` build this recipe names and `unsloth/Qwen3.8-27B-NVFP4`. The variant's `supported_hardware` was `[b200, b300, gb200, gb300]`, so it was excluding hardware the checkpoint works on.

### The block-scaled FP8 checkpoint needs no workaround

vLLM auto-disables DeepGemm for `model_type=qwen3_5_text` on Blackwell and falls back to CUTLASS, so it loads unaided on consumer Blackwell. Verified by running *without* `VLLM_USE_DEEP_GEMM=0`: identical 377,456-token KV pool either way. (Worth stating explicitly because other fp8-block models on sm120 do need that env var — the auto-disable is keyed on model_type.)

### 2x RTX 5090, TP2, at 262,144 context

GPU KV cache size as reported at startup:

| precision | KV tokens | weights/GPU | MTP acceptance |
|---|---|---|---|
| FP8 | 377,456 | 14.28 GiB | 0.771 |
| NVFP4 (Inferact) | 445,875 | 12.02 GiB | 0.897 |
| NVFP4 (unsloth) | 920,517 | 10.64 GiB | 0.788 |

The two NVFP4 builds are not interchangeable on 32 GB cards: the mixed-precision `unsloth` build leaves room for roughly twice the KV cache, while the uniform-W4A4 `Inferact` build drafts better. Both serve correctly, so the guide reports both rather than recommending one.

### 1x RTX 5090 needs `--enforce-eager`

One card has 31.4 GiB usable, not 32, and NVFP4 fits only with CUDA graphs off. Without `--enforce-eager`, startup dies in CUDA graph capture with `torch.OutOfMemoryError: Tried to allocate 784.00 MiB`.

Tuning `--gpu-memory-utilization` does **not** help — 0.80 and 0.93 leave the same 47.06 MiB free, because that budget covers weights and KV while graph capture allocates outside it. That negative result is in the guide too, since it is the obvious thing to reach for first.

KV pool at 32K context: 91,022 tokens with `--enforce-eager` alone, 135,926 adding `--language-model-only`, 152,917 also capping `--max-num-seqs 8`, and 76,458 with bf16 KV instead of fp8 — fp8 KV is a choice, not a requirement. The MTP head still fits on one card (90,112 tokens, 0.754 acceptance).

### Speculative decoding

The in-checkpoint MTP head works in every precision above, tested with and without `--speculative-config`. Acceptance is measured by diffing `vllm:spec_decode_num_{accepted,draft}_tokens_total` around a request rather than inferred from throughput, which cannot distinguish a working drafter from one that loaded and was ignored.

### Scope

Additive only — the existing prose, the `gb300` entry and all other fields are unchanged. BF16 and TP4 results are left out: this documents the 1- and 2-card deployments that were validated end to end.
