### PR TITLE
Add Intel XPU deployment recipe for Gemma 4 E4B IT (BF16 + W4A16 QAT)

### DIFF
--- a/models/Google/gemma-4-E4B-it.yaml
+++ b/models/Google/gemma-4-E4B-it.yaml
@@ -22,6 +22,7 @@ meta:
     trillium: verified
     ironwood: verified
     xeon6: verified
+    max1550: verified
 
 model:
   model_id: "google/gemma-4-E4B-it"
@@ -99,6 +100,11 @@ hardware_overrides:
     extra_env:
       VLLM_CPU_KVCACHE_SPACE: "40"
       VLLM_CPU_ATTN_SPLIT_KV: "0"
+  xpu:
+    extra_args:
+      enforce_eager: true
+    extra_env:
+      ZE_AFFINITY_MASK: "0"
 
 strategy_overrides:
   single_node_tp:
@@ -236,7 +242,43 @@ guide: |
       --port 8000
   ```
 
-  For additional Intel Xeon 6 deployment details, see the Intel Software Catalog entries for [Gemma 4 E4B IT](https://aiswcatalog.intel.com/models/google-gemma-4-e4b-it).
+    For additional Intel Xeon 6 deployment details, see the Intel Software Catalog entries for [Gemma 4 E4B IT](https://aiswcatalog.intel.com/models/google-gemma-4-e4b-it).
+
+    ### Intel XPU Deployment via Docker (Data Center GPU Max 1550)
+
+    Gemma 4 E4B fits on a single Max 1550 tile. The per-layer mixed attention backend (Flash Attention for sliding window layers, Triton for global attention layers) is selected automatically.
+
+    **BF16:**
+    ```bash
+    docker run -itd --name gemma4-e4b-xpu \
+      --device /dev/dri --network host \
+      --shm-size 16g \
+      -v ~/.cache/huggingface:/root/.cache/huggingface \
+      -e ZE_AFFINITY_MASK=0 \
+      intel/vllm:latest \
+        --model google/gemma-4-E4B-it \
+        --dtype bfloat16 \
+        --enforce-eager \
+        --max-model-len 32768 \
+        --host 0.0.0.0 --port 8000
+    ```
+
+    **W4A16 QAT (half the memory, longer contexts):**
+    ```bash
+    docker run -itd --name gemma4-e4b-w4a16-xpu \
+      --device /dev/dri --network host \
+      --shm-size 16g \
+      -v ~/.cache/huggingface:/root/.cache/huggingface \
+      -e ZE_AFFINITY_MASK=0 \
+      intel/vllm:latest \
+        --model google/gemma-4-E4B-it-qat-w4a16-ct \
+        --dtype bfloat16 \
+        --enforce-eager \
+        --max-model-len 65536 \
+        --host 0.0.0.0 --port 8000
+    ```
+
+    For text-only workloads, add `--language-model-only` to skip loading vision/audio encoders and free VRAM for KV cache.
 
   ## Client Usage
 

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -260,6 +260,16 @@ hardware_profiles:
   # `restricted: true` keeps it out of the picker unless a recipe explicitly
   # lists it in `meta.hardware` — XPU support ships in the separate
   # `vllm/vllm-openai-xpu` image and is only declared on validated recipes.
+  max1550:
+    brand: Intel
+    generation: xpu
+    display_name: "Data Center GPU Max 1550"
+    description: "Intel Data Center GPU Max 1550 · 68.7 GB HBM2e per tile · OAM module"
+    gpu_count: 4
+    vram_gb: 256
+    multi_node: false
+    restricted: true
+
   arc_pro_b60:
     brand: Intel
     generation: xpu


### PR DESCRIPTION
## Motivation

Add Intel Data Center GPU Max 1550 as a verified deployment target for Gemma 4 E4B IT, including the W4A16 QAT variant (google/gemma-4-E4B-it-qat-w4a16-ct).

## Changes

- **taxonomy.yaml**: Add max1550 hardware profile (Intel Data Center GPU Max 1550, 68.7 GB HBM2e)
- **models/Google/gemma-4-E4B-it.yaml**:
  - Add max1550: verified to hardware list
  - Add xpu hardware_overrides (enforce_eager, ZE_AFFINITY_MASK)
  - Add Intel XPU Docker deployment section covering both BF16 and W4A16 QAT variants

## Validation

Tested on Intel Data Center GPU Max 1550 (TP=1):
- BF16: ~28 tok/s decode (B=1), ~24 GB total memory
- W4A16 QAT: ~32 tok/s decode (B=1), ~13 GB total memory
- Per-layer mixed attention backend (Flash Attention SYCL for sliding window, Triton for global) works automatically