### PR TITLE
add Qwen3 1.7,8,30B-A3B model support for Xeon

### DIFF
--- a/models/Qwen/Qwen3-1.7B.yaml
+++ b/models/Qwen/Qwen3-1.7B.yaml
@@ -1,0 +1,129 @@
+meta:
+  title: "Qwen3-1.7B"
+  slug: "qwen3-1.7b"
+  provider: "Qwen"
+  description: "Qwen3 1.7B dense model with hybrid thinking/non-thinking modes, validated for BF16 serving on Intel Xeon 6."
+  date_added: 2026-08-14
+  date_updated: 2026-08-14
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "Validated on Intel Xeon 6 (GNR) with BF16 serving"
+  related_recipes:
+    - "Qwen/Qwen3-4B"
+  hardware:
+    xeon6: verified
+
+model:
+  model_id: "Qwen/Qwen3-1.7B"
+  min_vllm_version: "0.8.5"
+  architecture: dense
+  parameter_count: "1.7B"
+  active_parameters: "1.7B"
+  context_length: 40960
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Enable automatic tool choice with the Hermes parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "hermes"
+  reasoning:
+    description: "Enable Qwen3 thinking mode with the Qwen3 reasoning parser"
+    args:
+      - "--reasoning-parser"
+      - "qwen3"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 5
+    description: "Full precision BF16"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+
+hardware_overrides:
+  cpu:
+    extra_args:
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--gpu-memory-utilization"
+      - "0.8"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Qwen3-1.7B is a compact dense Qwen3 model with hybrid thinking and non-thinking
+  modes. This recipe includes an Intel Xeon 6 CPU configuration validated with
+  BF16 serving.
+
+  ## Prerequisites
+
+  - Hardware: 1x Xeon 6 CPUs
+  - vLLM >= 0.8.5
+
+  ### pip (Intel Xeon 6 CPUs)
+
+  For Intel and AMD x86 CPUs, follow the
+  [CPU pre-built wheels](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/#pre-built-wheels)
+  installation instructions.
+
+  ### Docker (Intel Xeon 6 CPUs)
+
+  ```bash
+  docker pull vllm/vllm-openai-cpu:latest-x86_64
+  ```
+
+  ## Intel Xeon 6
+
+  Choose the tensor parallel size based on the system topology and deployment
+  requirements. Add `--tensor-parallel-size <N>` when needed; the recipe does
+  not prescribe a Xeon 6 TP value or hard-code NUMA node IDs.
+
+  ```bash
+  vllm serve Qwen/Qwen3-1.7B \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.8
+  ```
+
+  Docker:
+
+  ```bash
+  docker run -itd --name qwen3-1-7b-cpu \
+    --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 \
+      --model Qwen/Qwen3-1.7B \
+      --max-num-batched-tokens 16384 \
+      --gpu-memory-utilization 0.8 \
+      --host 0.0.0.0 \
+      --port 8000
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
+  response = client.chat.completions.create(
+      model="Qwen/Qwen3-1.7B",
+      messages=[{"role": "user", "content": "Explain tensor parallelism briefly."}],
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3-1.7B)
+  - [vLLM CPU installation](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/)

--- a/models/Qwen/Qwen3-30B-A3B.yaml
+++ b/models/Qwen/Qwen3-30B-A3B.yaml
@@ -1,0 +1,129 @@
+meta:
+  title: "Qwen3-30B-A3B"
+  slug: "qwen3-30b-a3b"
+  provider: "Qwen"
+  description: "Qwen3 MoE model with 30.5B total and 3.3B active parameters, validated for BF16 serving on Intel Xeon 6."
+  date_added: 2026-08-14
+  date_updated: 2026-08-14
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Validated on Intel Xeon 6 (GNR) with BF16 serving"
+  related_recipes:
+    - "Qwen/Qwen3-235B-A22B-Instruct-2507"
+  hardware:
+    xeon6: verified
+
+model:
+  model_id: "Qwen/Qwen3-30B-A3B"
+  min_vllm_version: "0.8.5"
+  architecture: moe
+  parameter_count: "30.5B"
+  active_parameters: "3.3B"
+  context_length: 40960
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Enable automatic tool choice with the Hermes parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "hermes"
+  reasoning:
+    description: "Enable Qwen3 thinking mode with the Qwen3 reasoning parser"
+    args:
+      - "--reasoning-parser"
+      - "qwen3"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 74
+    description: "Full precision BF16"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+
+hardware_overrides:
+  cpu:
+    extra_args:
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--gpu-memory-utilization"
+      - "0.8"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Qwen3-30B-A3B is a mixture-of-experts Qwen3 model with 30.5B total parameters
+  and 3.3B active parameters per token. This recipe includes an Intel Xeon 6 CPU
+  configuration validated with BF16 serving.
+
+  ## Prerequisites
+
+  - Hardware: 4x Xeon 6 CPUs.
+  - vLLM >= 0.8.5
+
+  ### pip (Intel Xeon 6 CPUs)
+
+  For Intel and AMD x86 CPUs, follow the
+  [CPU pre-built wheels](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/#pre-built-wheels)
+  installation instructions.
+
+  ### Docker (Intel Xeon 6 CPUs)
+
+  ```bash
+  docker pull vllm/vllm-openai-cpu:latest-x86_64
+  ```
+
+  ## Intel Xeon 6
+
+  Choose the tensor parallel size based on the system topology and deployment
+  requirements. Add `--tensor-parallel-size <N>` when needed; the recipe does
+  not prescribe a Xeon 6 TP value or hard-code NUMA node IDs.
+
+  ```bash
+  vllm serve Qwen/Qwen3-30B-A3B \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.8
+  ```
+
+  Docker:
+
+  ```bash
+  docker run -itd --name qwen3-30b-a3b-cpu \
+    --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 \
+      --model Qwen/Qwen3-30B-A3B \
+      --max-num-batched-tokens 16384 \
+      --gpu-memory-utilization 0.8 \
+      --host 0.0.0.0 \
+      --port 8000
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
+  response = client.chat.completions.create(
+      model="Qwen/Qwen3-30B-A3B",
+      messages=[{"role": "user", "content": "Explain tensor parallelism briefly."}],
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3-30B-A3B)
+  - [vLLM CPU installation](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/)

--- a/models/Qwen/Qwen3-8B.yaml
+++ b/models/Qwen/Qwen3-8B.yaml
@@ -1,0 +1,130 @@
+meta:
+  title: "Qwen3-8B"
+  slug: "qwen3-8b"
+  provider: "Qwen"
+  description: "Qwen3 8.2B dense model with hybrid thinking/non-thinking modes, validated for BF16 serving on Intel Xeon 6."
+  date_added: 2026-08-14
+  date_updated: 2026-08-14
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "Validated on Intel Xeon 6 (GNR) with BF16 serving"
+  related_recipes:
+    - "Qwen/Qwen3-4B"
+    - "Qwen/Qwen3-32B"
+  hardware:
+    xeon6: verified
+
+model:
+  model_id: "Qwen/Qwen3-8B"
+  min_vllm_version: "0.8.5"
+  architecture: dense
+  parameter_count: "8.2B"
+  active_parameters: "8.2B"
+  context_length: 40960
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Enable automatic tool choice with the Hermes parser"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "hermes"
+  reasoning:
+    description: "Enable Qwen3 thinking mode with the Qwen3 reasoning parser"
+    args:
+      - "--reasoning-parser"
+      - "qwen3"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 20
+    description: "Full precision BF16"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+
+hardware_overrides:
+  cpu:
+    extra_args:
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--gpu-memory-utilization"
+      - "0.8"
+
+strategy_overrides: {}
+
+guide: |
+  ## Overview
+
+  Qwen3-8B is a dense Qwen3 model with hybrid thinking and non-thinking modes.
+  This recipe includes an Intel Xeon 6 CPU configuration validated with BF16
+  serving.
+
+  ## Prerequisites
+
+  - Hardware: 2x Xeon 6 CPUs
+  - vLLM >= 0.8.5
+
+  ### pip (Intel Xeon 6 CPUs)
+
+  For Intel and AMD x86 CPUs, follow the
+  [CPU pre-built wheels](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/#pre-built-wheels)
+  installation instructions.
+
+  ### Docker (Intel Xeon 6 CPUs)
+
+  ```bash
+  docker pull vllm/vllm-openai-cpu:latest-x86_64
+  ```
+
+  ## Intel Xeon 6
+
+  Choose the tensor parallel size based on the system topology and deployment
+  requirements. Add `--tensor-parallel-size <N>` when needed; the recipe does
+  not prescribe a Xeon 6 TP value or hard-code NUMA node IDs.
+
+  ```bash
+  vllm serve Qwen/Qwen3-8B \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.8
+  ```
+
+  Docker:
+
+  ```bash
+  docker run -itd --name qwen3-8b-cpu \
+    --network host \
+    --shm-size 16g \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 \
+      --model Qwen/Qwen3-8B \
+      --max-num-batched-tokens 16384 \
+      --gpu-memory-utilization 0.8 \
+      --host 0.0.0.0 \
+      --port 8000
+  ```
+
+  ## Client Usage
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="unused")
+  response = client.chat.completions.create(
+      model="Qwen/Qwen3-8B",
+      messages=[{"role": "user", "content": "Explain tensor parallelism briefly."}],
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ## References
+
+  - [Model card](https://huggingface.co/Qwen/Qwen3-8B)
+  - [vLLM CPU installation](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/)


### PR DESCRIPTION
## Summary

Add Intel Xeon 6 recipes for:

- `Qwen/Qwen3-1.7B`
- `Qwen/Qwen3-8B`
- `Qwen/Qwen3-30B-A3B`

The configurations are based on validated Xeon 6 (GNR) BF16 serving runs.

This PR adds:

- `xeon6: verified`
- CPU install and Docker guidance
- CPU tuning:
  - `--max-num-batched-tokens 16384`
  - `--gpu-memory-utilization 0.8`
- Qwen3 tool-calling and reasoning feature definitions consistent with the existing Qwen3 recipes

## Validation

All three validation rows passed using vLLM `releases/v0.21.0` with 1024-token input / 1024-token output workloads:

- `Qwen/Qwen3-1.7B`: PASS
- `Qwen/Qwen3-8B`: PASS
- `Qwen/Qwen3-30B-A3B`: PASS

## Differences from the validation Excel

Some benchmark settings are intentionally not carried into the portable recipes:

- `dtype=bfloat16`: represented by the default `precision: bf16` variant; no explicit `--dtype` argument is required.
- `--trust-remote-code`: removed because Qwen3 and Qwen3MoE have native vLLM support.
- `--max-num-seqs=256`: removed because it is benchmark tuning; the deployment recipes leave sequence concurrency to vLLM defaults or user configuration.
- `--no-enable-prefix-caching`: removed because it is a benchmark-control setting and is not required for general serving; the random validation workload does not use a shared prefix.
- TP values (`TP=1` / `TP=2`): not fixed; users choose TP based on CPU topology and deployment requirements.
- `DP=6` / `DP=2` and router DP: out of scope for these model recipes.
- `CPU_VISIBLE_MEMORY_NODES` and explicit CPU binding: removed because they are host/topology specific.
- `VLLM_ENGINE_ITERATION_TIMEOUT_S=600`: removed because it is a benchmark/repro stability setting rather than a general serving requirement.
- Legacy launcher settings such as `VLLM_RPC_TIMEOUT` and `VLLM_ALLOW_LONG_MAX_MODEL_LEN` are not needed.
