### PR TITLE
Qwen3.6-35B-A3B: require vLLM 0.28.0 for the NVFP4 variant

### DIFF
--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -151,7 +151,9 @@ guide: |
   ## Prerequisites
 
   - **vLLM version:** >= 0.17.0
-  - **DGX Spark NVFP4 vLLM version:** >= 0.24.0
+  - **NVFP4 vLLM version:** >= 0.28.0 (currently nightly). 0.24.0 loads the
+    checkpoint, but FlashInfer only selects its XQA decode kernel on SM120
+    GPUs from 0.28.0.
   - **Hardware (BF16):** 1x H200 or 2x H100
   - **Hardware (FP8):** single H100/H200 or 1x MI300X/MI325X/MI355X
   - **Hardware (NVFP4):** NVIDIA Blackwell GPUs, including DGX Spark (GB10)
@@ -209,7 +211,7 @@ guide: |
   and requires vLLM nightly or a source build with ModelOpt W4A16/NVFP4 support.
 
   ```bash
-  # Use container: vllm/vllm-openai:v0.24.0-ubuntu2404
+  # Use container: vllm/vllm-openai:nightly
 
   vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
     --trust-remote-code \
@@ -233,10 +235,10 @@ guide: |
 
   The NVIDIA ModelOpt NVFP4 checkpoint is served from
   [`nvidia/Qwen3.6-35B-A3B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4)
-  and requires vLLM v0.24.0 or later.
+  and requires vLLM 0.28.0 or later (currently nightly) for the XQA decode path.
 
   ```bash
-  # Use container: vllm/vllm-openai:v0.24.0-ubuntu2404
+  # Use container: vllm/vllm-openai:nightly
 
   vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
     --tensor-parallel-size 1 \

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -89,6 +89,9 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 21
     tp: 1
+    # SM120 GPUs only reach FlashInfer's XQA decode kernel from 0.28.0.
+    min_vllm_version: "0.28.0"
+    nightly_required: true
     description: "NVIDIA ModelOpt NVFP4 checkpoint for Blackwell GPUs, including DGX Spark"
     extra_args:
       - "--kv-cache-dtype"


### PR DESCRIPTION
The `nvfp4` variant inherits `min_vllm_version: "0.17.0"`, but on SM120 GPUs
(RTX PRO 6000, RTX 5090, DGX Spark) FlashInfer only selects its XQA decode kernel from 0.28.0.

In `vllm/v1/attention/backends/flashinfer.py`, `_get_flashinfer_trtllm_api_decode_kernel()`
returns `XQA` for `is_device_capability(90)` alone in `v0.27.1`; the
`or is_device_capability_family(120)` branch first appears in `v0.28.0rc1`
(0 occurrences in `v0.27.1`, 8 in `v0.28.0rc1`).

0.28.0 is not on PyPI yet, so `nightly_required: true` points the Install block at the
nightly wheel index instead of a version pip cannot resolve. The guide's 0.24.0 references
are updated to match: 0.24.0 still loads the checkpoint, 0.28.0 is what the XQA path needs.

DGX Station GB300 is SM100-family and takes the trtllm-gen path, so the floor is stricter
than it needs; `min_vllm_version` is per-variant and cannot be set per-GPU.

**Testing.** Served the NVFP4 checkpoint on RTX PRO 6000 Max-Q and RTX 5090 (both sm120) on a
0.27.2-series build; serve log confirms FlashInfer with `decode_backend=xqa` and
`Using 'MARLIN' NvFp4 MoE`. At 32K cached prefix + 2K ISL + 256 OSL, BS1: decode 344 tok/s
(Pro 6000), 427 tok/s (RTX 5090). The version boundary comes from the tag diff, not from
booting 0.28.0, which is unreleased.
