### PR TITLE
Qwen3.6-27B: require vLLM 0.28.0 for the NVFP4 variant

### DIFF
--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -90,6 +90,9 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 27
     tp: 1
+    # SM120 GPUs only reach FlashInfer's XQA decode kernel from 0.28.0.
+    min_vllm_version: "0.28.0"
+    nightly_required: true
     description: "NVIDIA ModelOpt NVFP4 checkpoint — MLP linears quantized to NVFP4, attention linears and KV cache in FP8. Single Blackwell GPU, including DGX Spark."
     hardware_overrides:
       dgx_station_gb300:
@@ -146,7 +149,9 @@ guide: |
   ## Prerequisites
 
   - **vLLM version:** >= 0.17.0
-  - **DGX Spark NVFP4 vLLM version:** >= 0.24.0
+  - **NVFP4 vLLM version:** >= 0.28.0 (currently nightly). 0.24.0 loads the
+    checkpoint, but FlashInfer only selects its XQA decode kernel on SM120
+    GPUs from 0.28.0.
   - **Hardware (BF16):** 1x H200 or 2x H100
   - **Hardware (FP8):** single 40 GB GPU (H100/H200/L40S)
   - **Hardware (Int4):** single 24 GB GPU
@@ -200,12 +205,12 @@ guide: |
 
   The NVIDIA ModelOpt NVFP4 checkpoint is served from
   [`nvidia/Qwen3.6-27B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4)
-  and requires vLLM 0.24.0+.
+  and requires vLLM 0.28.0+ (currently nightly) for the XQA decode path.
 
   #### **Single node (TP1)**
 
   ```bash
-  # Use container: vllm/vllm-openai:v0.24.0-ubuntu2404
+  # Use container: vllm/vllm-openai:nightly
 
   vllm serve nvidia/Qwen3.6-27B-NVFP4 \
     --trust-remote-code \
@@ -236,7 +241,7 @@ guide: |
   export IB_IF="rocep1s0f1,roceP2p1s0f1" # BOTH matching RoCE interfaces
   export MASTER_PORT=29501               # Free port on the Head Node
   export CONTAINER_NAME=vllm_node
-  export IMAGE="vllm/vllm-openai:v0.24.0-ubuntu2404"
+  export IMAGE="vllm/vllm-openai:nightly"
   ```
 
   ```bash
@@ -327,10 +332,10 @@ guide: |
 
   The NVIDIA ModelOpt NVFP4 checkpoint is served from
   [`nvidia/Qwen3.6-27B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4)
-  and requires vLLM 0.24.0+.
+  and requires vLLM 0.28.0+ (currently nightly) for the XQA decode path.
 
   ```bash
-  # Use container: vllm/vllm-openai:v0.24.0-ubuntu2404
+  # Use container: vllm/vllm-openai:nightly
 
   vllm serve nvidia/Qwen3.6-27B-NVFP4 \
     --trust-remote-code \


### PR DESCRIPTION
Same change as #833, for the 27B sibling.

The `nvfp4` variant inherits `min_vllm_version: "0.17.0"`, but on SM120 GPUs
(RTX PRO 6000, RTX 5090, DGX Spark) FlashInfer only selects its XQA decode kernel from 0.28.0.

In `vllm/v1/attention/backends/flashinfer.py`, `_get_flashinfer_trtllm_api_decode_kernel()`
returns `XQA` for `is_device_capability(90)` alone in `v0.27.1`; the
`or is_device_capability_family(120)` branch first appears in `v0.28.0rc1`
(0 occurrences in `v0.27.1`, 8 in `v0.28.0rc1`).

0.28.0 is not on PyPI yet, so `nightly_required: true` points the Install block at the
nightly wheel index instead of a version pip cannot resolve. The guide's 0.24.0 references
are updated to match: 0.24.0 still loads the checkpoint, 0.28.0 is what the XQA path needs.

DGX Station GB300 is SM100-family and takes the trtllm-gen path, so the floor is stricter
than it needs; `min_vllm_version` is per-variant and cannot be set per-GPU.

**Testing.** Served the NVFP4 checkpoint on RTX PRO 6000 Max-Q and RTX 5090 (both sm120) on a
0.27.2-series build; serve log confirms FlashInfer with `decode_backend=xqa`. At 32K cached
prefix + 2K ISL + 256 OSL, BS1, decode throughput with XQA vs the pre-XQA FlashInfer kernel:
151 vs 104 tok/s (Pro 6000, +44%) and 164 vs 154 tok/s (RTX 5090, +7%). The version boundary
comes from the tag diff, not from booting 0.28.0, which is unreleased.
