### PR TITLE
Update Muse Glimmer nightly and DFlash warmup settings

### DIFF
--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Muse (Meta)"
   description: "Dense 29.6B vision-language model with a ViT-G/14 perception encoder and 128K context, distilled from Muse Spark for local agentic use. Emits channel-scoped reasoning and XML-style ATEM tool calls rather than JSON, so it needs the dedicated `muse_glimmer` tool-call and reasoning parsers."
   date_added: 2026-08-09
-  date_updated: 2026-08-10
+  date_updated: 2026-08-23
   difficulty: advanced
   tasks:
     - text
@@ -83,6 +83,8 @@ features:
       rtx_5090: unsupported
     description: "DFlash block-diffusion draft head — predicts a whole block in one forward, verified in parallel by the target. `num_speculative_tokens: 15` is not a tuning knob: the head has `block_size: 16` and slot 0 re-presents the last accepted token, so 15 is what remains."
     args:
+      - "--max-num-seqs"
+      - "32"
       - "--speculative-config"
       - '{"method": "dflash", "model": "meta-models/Muse-Glimmer-30B-assistant", "num_speculative_tokens": 15}'
 
@@ -371,7 +373,8 @@ guide: |
   attend to each other bidirectionally — and the target verifies them in parallel.
 
   ```bash
-  --speculative-config '{"method": "dflash", "model": "meta-models/Muse-Glimmer-30B-assistant", "num_speculative_tokens": 15}'
+  --max-num-seqs 32 \
+    --speculative-config '{"method": "dflash", "model": "meta-models/Muse-Glimmer-30B-assistant", "num_speculative_tokens": 15}'
   ```
 
   **`num_speculative_tokens: 15` is fixed, not tuned.** The head has

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -30,19 +30,13 @@ meta:
 
 model:
   model_id: "meta-models/Muse-Glimmer-30B"
-  # Not in any released wheel — the model code and both parsers land upstream on
-  # nightly first, so `nightly_required` points the Install block at the nightly
-  # index. The version below is the unreleased target, not something installable.
-  min_vllm_version: "0.27.0"
-  docker_image:
-    nvidia:
-      # Single-key map: the site pins cu130 and hides the cu129 toggle rather
-      # than fabricating a -cu129 tag that may not be published.
-      cu130: "vllm/vllm-openai:muse-glimmer"
+  # Muse Glimmer landed after v0.27.1 and is available in nightly.
+  min_vllm_version: "nightly"
+  docker_image: "vllm/vllm-openai:nightly"
   nightly_required: true
   install:
     docker:
-      note: "Docker is the supported path — the model code and the muse_glimmer parsers are not in any released vLLM wheel. On ROCm, please install the code from https://github.com/vllm-project/vllm/pull/51655 ."
+      note: "Muse Glimmer support is available in the official vLLM nightly image and has not shipped in a stable release yet."
     pip: false
   architecture: dense
   # Model card states ~29.6B total including the perception encoder. Measured from
@@ -168,7 +162,7 @@ guide: |
   ## Prerequisites
 
   - **Hardware**: DGX Spark. FP4 weights might also run on 5090.
-  - **Image**: `vllm/vllm-openai:muse-glimmer`, code will be released soon.
+  - **Image**: `vllm/vllm-openai:nightly`.
 
   ## Checkpoints
 
@@ -228,8 +222,7 @@ guide: |
 
   ## Running on MI300X/MI325X/MI355X
 
-  As of now, please install the code from https://github.com/vllm-project/vllm/pull/51655
-  if it hasn't been merged yet. After the PR is merged use `vllm/vllm-openai-rocm:nightly` image.
+  Use the official `vllm/vllm-openai-rocm:nightly` image.
 
   ```bash
   export VLLM_ROCM_USE_AITER=1
@@ -371,6 +364,9 @@ guide: |
   Muse Glimmer ships a DFlash block-diffusion draft head. Rather than proposing
   one token at a time, it predicts a whole block in a single forward — the slots
   attend to each other bidirectionally — and the target verifies them in parallel.
+
+  DFlash uses 16 query positions per active request during warmup. To keep the
+  expanded batch within vLLM's token budget, replace the earlier sequence limit with:
 
   ```bash
   --max-num-seqs 32 \


### PR DESCRIPTION
## Summary

- switch Muse Glimmer from the model-specific preview image to the official vLLM nightly image
- update the stale nightly version and CUDA/ROCm installation guidance
- add `--max-num-seqs 32` only when DFlash is enabled and explain the warmup constraint in the guide

## Why

Native Muse Glimmer support merged in vllm-project/vllm#51655. The official nightly image checked on 2026-08-23 is built from `e9d1398d` and contains that support, so the older `vllm/vllm-openai:muse-glimmer` preview image is no longer needed.

DFlash creates 16 query positions per active request during warmup. Current B200 nightly defaults fit that shape exactly, but other supported hardware profiles or explicit scheduler settings can still make `max_num_seqs * (num_speculative_tokens + 1)` exceed `max_num_batched_tokens`. Scoping the smaller sequence limit to the opt-in `spec_decoding` feature keeps those generated commands safe without changing non-speculative serving.

This does not duplicate an existing PR. I checked issue #782 and open PR searches for the issue number, Muse Glimmer nightly migration, DFlash, and the sequence-limit mismatch; no other open PR modifies this recipe.

Addresses #782.

## Tests

- `node scripts/build-recipes-api.mjs`
  - passed: 173 models, 9 strategies, and 2 KV-store deployments
- direct command synthesis for B200 with tool calling, reasoning, and speculative decoding
  - confirmed the Docker image is `vllm/vllm-openai:nightly`
  - confirmed the generated command includes `--max-num-seqs 32` and the DFlash config
- `git diff --check`
  - passed
- GPU warmup was not run in this environment
- model evaluation: not applicable; this changes recipe installation, concurrency, and documentation, not model output behavior

## AI assistance

OpenAI Codex was used to investigate the failure, verify the nightly image lineage, prepare the diff, and run recipe validation. The submitter reviewed the final change.
