### PR TITLE
Update DFlash2 description and num_speculative_tokens for best performance for qwen3.8-27b-fp8 for hopper

### DIFF
--- a/models/Qwen/Qwen3.8-27B.yaml
+++ b/models/Qwen/Qwen3.8-27B.yaml
@@ -111,7 +111,7 @@ features:
           - '{"method":"qwen3_5_mtp","num_speculative_tokens":3,"enforce_eager":true}'
       dflash:
         label: "DFlash2"
-        description: "External DFlash2 drafter (incoai/Qwen3.8-27B-DFlash2). method is dflash; DFlash2 is selected by the draft architecture. Needs a vLLM build that includes vllm-project/vllm#52816 (merged 2026-08-21, not in a stable release yet). num_speculative_tokens best is 5 for hopper."
+        description: "External DFlash2 drafter (incoai/Qwen3.8-27B-DFlash2). method is dflash; DFlash2 is selected by the draft architecture. Needs a vLLM build that includes vllm-project/vllm#52816 (merged 2026-08-21, not in a stable release yet). num_speculative_tokens is best set to 5 for Hopper GPUs."
         variants: [default]
         args:
           - "--speculative-config"

--- a/models/Qwen/Qwen3.8-27B.yaml
+++ b/models/Qwen/Qwen3.8-27B.yaml
@@ -111,11 +111,11 @@ features:
           - '{"method":"qwen3_5_mtp","num_speculative_tokens":3,"enforce_eager":true}'
       dflash:
         label: "DFlash2"
-        description: "External DFlash2 drafter (incoai/Qwen3.8-27B-DFlash2). method is dflash; DFlash2 is selected by the draft architecture. Needs a vLLM build that includes vllm-project/vllm#52816 (merged 2026-08-21, not in a stable release yet). num_speculative_tokens must be 7 (block_size 8 minus one)."
+        description: "External DFlash2 drafter (incoai/Qwen3.8-27B-DFlash2). method is dflash; DFlash2 is selected by the draft architecture. Needs a vLLM build that includes vllm-project/vllm#52816 (merged 2026-08-21, not in a stable release yet). num_speculative_tokens best is 5 for hopper."
         variants: [default]
         args:
           - "--speculative-config"
-          - '{"method":"dflash","model":"incoai/Qwen3.8-27B-DFlash2","num_speculative_tokens":7}'
+          - '{"method":"dflash","model":"incoai/Qwen3.8-27B-DFlash2","num_speculative_tokens":5}'
   text_only:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
@@ -361,7 +361,7 @@ guide: |
   [vllm#52816](https://github.com/vllm-project/vllm/pull/52816).
   ```bash
   vllm serve Qwen/Qwen3.8-27B \
-    --speculative-config '{"method":"dflash","model":"incoai/Qwen3.8-27B-DFlash2","num_speculative_tokens":7}'
+    --speculative-config '{"method":"dflash","model":"incoai/Qwen3.8-27B-DFlash2","num_speculative_tokens":5}'
   ```
   
   ## Client usage


### PR DESCRIPTION
hopper: 7->5 is best suggestion

benchmark results:

### Performance (H20, Qwen3.8-27B-FP8)

Workload: `vllm bench serve --backend openai-chat --dataset-name random --random-input-len 64000 --random-output-len 3000 --num-prompts 10 --request-rate 10`.

Numbers are logger **Avg generation throughput** in the decode phase (samples ≥ 50 tok/s). `vllm bench serve` summary lines are not in the test notes.

| Spec | `num_speculative_tokens` | Decode gen tok/s (mean / median / max) | Mean accept. length (late decode) | Avg draft accept. rate (late decode) | GPU KV cache | Concurrency @ 256k |
|---|---:|---|---:|---:|---:|---:|
| MTP | 3 | **264.8 / 278.0 / 320.6** | ~2.8–3.0 | ~61–66% | 1,559,405 | 6.09× |
| DFlash2 | 7 | **234.7 / 255.5 / 322.6** | ~2.5–2.7 | ~22–24% | 1,156,401 | 4.52× |
| DFlash2 | 5 | **290.6 / 304.1 / 346.5** | ~2.6–2.7 | ~33–34% | — | — |

DFlash2-7 is slower than MTP-3 on this long-context workload: extra draft tokens do not pay off (draft accept ~23% vs MTP ~63%). Dropping DFlash2 to **5** recovers the gap and beats MTP-3 (median **304** vs **278** tok/s).

ShareGPT (same card; DFlash2-5 not logged):

| Spec | `num_speculative_tokens` | Logger gen tok/s (mean / median / max) | Mean accept. length | Avg draft accept. rate |
|---|---:|---|---:|---:|
| MTP | 3 | **862.7 / 869.1 / 1100.7** | ~2.2–2.4 | ~40–46% |
| DFlash2 | 7 | **673.6 / 674.4 / 809.2** | ~2.6–2.8 | ~22–26% |

