### PR TITLE
Ling-3.0-flash: add the int4 (compressed-tensors) variant — serves on one H200 at TP=1

### DIFF
--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -2,8 +2,8 @@ meta:
   title: "Ling-3.0-flash"
   slug: "ling-3-0-flash"
   provider: "inclusionAI"
-  description: "Ling-3.0-flash MoE model with BF16 and serialized block-FP8 checkpoints, 124B total / 5.5B active parameters, and a 3.1B MTP layer"
-  date_updated: 2026-08-14
+  description: "Ling-3.0-flash MoE model with BF16, serialized block-FP8 and compressed-tensors int4 checkpoints, 124B total / 5.5B active parameters, and a 3.1B MTP layer"
+  date_updated: 2026-08-25
   difficulty: advanced
   tasks:
     - text
@@ -64,6 +64,12 @@ variants:
     min_vllm_version: "0.26.0"
     tp: 2
     description: "Serialized block-FP8 checkpoint; defaults to TP2 on NVIDIA H200, with TP4+EP4 as a validated alternative"
+  int4:
+    model_id: "inclusionAI/Ling-3.0-flash-int4"
+    precision: int4
+    vram_minimum_gb: 95
+    tp: 1
+    description: "compressed-tensors pack-quantized W4 (group 32) on the routed experts; fits one H200 at TP=1 and serves through vLLM's generic WNA16 Marlin MoE path"
 
 compatible_strategies:
   - single_node_tp
@@ -148,11 +154,55 @@ guide: |
   --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
   ```
 
+  ## Single-GPU int4
+
+  `inclusionAI/Ling-3.0-flash-int4` is a `compressed-tensors` / `pack-quantized`
+  checkpoint: symmetric W4, `group_size: 32`, applied to the **routed experts
+  only** — attention, `lm_head`, the shared expert and the dense projections are
+  all in the config's `ignore` list. It is not covered by the model-specific
+  quantization plumbing in `bailing_moe_v3.py` (which handles block FP8 and
+  mxfp4); it loads through vLLM's generic `compressed-tensors` path, and that is
+  enough to serve it on a **single H200 at TP=1**:
+
+  ```bash
+  vllm serve inclusionAI/Ling-3.0-flash-int4 \
+    --trust-remote-code \
+    --dtype bfloat16 \
+    --tensor-parallel-size 1 \
+    --gpu-memory-utilization 0.9 \
+    --enable-chunked-prefill \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+    --enable-prefix-caching
+  ```
+
+  The engine names the mechanism at startup:
+
+  ```
+  quantization=compressed-tensors ... trust_remote_code=True, dtype=torch.bfloat16
+  INFO [int_wna16.py:297] Using 'MARLIN' WNA16 MoE backend.
+  INFO [cuda.py:492]      Using FLASH_ATTN_MLA attention backend
+  INFO [int_wna16.py:409] Using MarlinExperts
+  ```
+
+  The vendor model card documents SGLang only, and there is no merged vLLM PR
+  specific to Ling int4 — this variant is recorded because the generic path
+  works, not because there is model-specific support behind it. Tool-call and
+  reasoning parsers, chunked prefill and CUDA graph capture behave as they do on
+  the other variants.
+
   ## Validation
 
   Both the default FP8 TP2 path and the TP4+EP4 path were validated on NVIDIA
   H200. TP2 remains the recommended default because it uses fewer GPUs; TP4+EP4
   is an alternative for deployments that prefer expert parallelism.
+
+  The `int4` variant was verified on **1x H200 (SM90), TP=1**, on a `main` build
+  reporting `0.26.1rc1.dev1133+gf94666b60`, serving at `--max-model-len 32768`:
+  77.0 GB of weights on disk, 70.27 GiB resident after load (165 s), 5 min 56 s
+  from container start to ready, `FULL_AND_PIECEWISE` capture (68 PIECEWISE + 68
+  FULL, 2.15 GiB), and a 4,072,594-token KV pool. Single-stream decode measured
+  **159.5 tok/s** at TTFT p50 0.17 s; 973 output tok/s aggregate at concurrency
+  16, with 0 failed requests and 0 preemptions over a 1..24 concurrency sweep.
 
   ## Thinking Mode
 
@@ -181,3 +231,4 @@ guide: |
 
   - [Ling-3.0-flash on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-flash)
   - [Ling-3.0-flash-fp8 on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-flash-fp8)
+  - [Ling-3.0-flash-int4 on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-flash-int4)


### PR DESCRIPTION
## Purpose

Adds an `int4` variant to the Ling-3.0-flash recipe. `inclusionAI/Ling-3.0-flash-int4` **loads and serves on stock vLLM** through the generic `compressed-tensors` WNA16 Marlin MoE path, on a **single H200 at TP=1** — and as far as I can tell nobody has written that down anywhere.

Today the recipe documents BF16 (TP=4 on H20) and serialized block FP8 (TP=2 on H200). Both need 2-4 GPUs. The int4 checkpoint fits one, which makes it a materially different deployment option, and it is currently undiscoverable: the vendor model card documents **SGLang only**, and there is no vLLM PR for it (`#52140`, "Add Ling 3.0 Flash FP4 support", was closed unmerged; `#51045` covered BF16 + MTP + parsers and `#51265` FP8).

I went in expecting a loader traceback. It came up on the first attempt with no adaptations.

## Why it works

The checkpoint's `quantization_config` is `compressed-tensors` / `pack-quantized`, symmetric `num_bits: 4`, `strategy: group`, `group_size: 32`, and the `ignore` list excludes attention, `lm_head`, the shared expert and all the dense `(gate|up|gate_up|down|eh)_proj` — so **only the routed experts are quantized**.

`bailing_moe_v3.py`'s model-specific quantization plumbing is block-FP8 / mxfp4 oriented (`_is_block_fp8_config`, `_configure_ling_fp8_quant_config`, the mxfp4 weights mapper) and never fires on this config. vLLM falls through to the generic `compressed-tensors` path, which handles it:

```
quantization=compressed-tensors ... trust_remote_code=True, dtype=torch.bfloat16
INFO [int_wna16.py:297] Using 'MARLIN' WNA16 MoE backend.
INFO [cuda.py:492]      Using FLASH_ATTN_MLA attention backend out of potential backends: ['FLASH_ATTN_MLA', 'FLASHMLA', 'TRITON_MLA'].
INFO [int_wna16.py:409] Using MarlinExperts
INFO [gpu_model_runner.py:5508] Model loading took 70.27 GiB memory and 165.49 seconds
```

TP=1 also removes every expert-sharding hazard, which is probably part of why it is uneventful.

## What was measured

| | |
|---|---|
| Hardware | 1x **H200** (SM90), TP=1 |
| Engine | `main` build reporting `0.26.1rc1.dev1133+gf94666b60`, pinned by image digest |
| Checkpoint | `inclusionAI/Ling-3.0-flash-int4` @ `7a27e9eb8179b2c2eb71eb214f0dab14ec6a63f2`, **77.0 GB** on disk, MIT, ungated |
| Flags | `--trust-remote-code --dtype bfloat16 --tensor-parallel-size 1 --gpu-memory-utilization 0.9 --max-model-len 32768 --enable-chunked-prefill --enable-prefix-caching --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'` |
| Load | 70.27 GiB resident, 165 s; **5 min 56 s** container start → ready |
| Graphs | `FULL_AND_PIECEWISE`, 68 PIECEWISE + 68 FULL, 2.15 GiB |
| KV pool | **4,072,594 tokens**, max concurrency 124.3x at 32k |
| Kernels | `MarlinExperts` (WNA16 Marlin MoE) + `FLASH_ATTN_MLA` |
| Single-stream decode | **159.5 tok/s**, TTFT p50 0.17 s / p90 0.19 s |
| Concurrency 1..24 sweep | monotone; 973 output tok/s aggregate at c=16, **0 failed requests, 0 preemptions** |

Quality spot checks at temperature 0 return correct answers (capital-of-France, arithmetic, chemical symbol) plus coherent free-form text, with the reasoning trace inline and terminated by `</think>` when no parser is configured. This is a smoke test, not an eval — I have not run lm-eval against the BF16 reference, so the PR claims "it serves and is numerically sane", not "int4 is accuracy-neutral".

One caveat worth knowing for anyone reproducing: the checkpoint's `config.json` carries an `auto_map`, so `AutoTokenizer.from_pretrained` on the model directory stops on an interactive `Do you wish to run the custom code? [y/N]` prompt — an indefinite hang inside a benchmark harness rather than an error. Loading the tokenizer files without `config.json` present sidesteps it.

## What the PR changes

- New `int4` variant: `model_id`, `precision: int4`, `vram_minimum_gb: 95`, `tp: 1`, description.
- A `## Single-GPU int4` section in the guide with the serve command, the startup lines that name the mechanism, and an explicit note that this rides the generic path and has no model-specific support behind it.
- A validation paragraph with the numbers above, an entry in `## References`, and `meta.description` / `date_updated` refreshed.

`node scripts/build-recipes-api.mjs` passes (`✓ JSON API: 176 models …`). The rendered `single_node_tp` command for the new variant on H200 comes out as TP=1 with the base args and both parsers, as intended.

## Notes for reviewers

- I deliberately did **not** set a variant-level `min_vllm_version`. The recipe already carries `nightly_required: true`, and I can only attest to the specific `main` build above — I have not bisected which released tag is the earliest that works. Happy to add one if a maintainer knows the answer.
- `vram_minimum_gb: 95` is `77 GB × 1.2` per the CONTRIBUTING formula, and is consistent with what was observed (70.27 GiB weights, comfortable KV headroom at `--gpu-memory-utilization 0.9` on a 141 GB card).
- If maintainers would rather not carry a variant whose upstream support is incidental rather than intentional, I am equally happy to reduce this to a note in the guide, or to close it in favour of an issue.

---

<sub>Findings measured on my own hardware; PR text drafted with AI assistance and reviewed by me.</sub>
