### PR TITLE
[ROCm] [New-Model] Add GLM-5.3-Flash mi355x recipe

### DIFF
--- a/models/zai-org/GLM-5.3-Flash.yaml
+++ b/models/zai-org/GLM-5.3-Flash.yaml
@@ -13,6 +13,7 @@ meta:
     h100: verified
     b200: verified
     gb200: verified
+    mi355x: verified
 
 model:
   model_id: "zai-org/GLM-5.3-Flash"
@@ -86,6 +87,14 @@ hardware_overrides:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
+  amd:
+    extra_args:
+      - "--max-num-seqs"
+      - "512"
+      - "--attention-backend"
+      - "ROCM_AITER_MLA_SPARSE"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
 
 strategy_overrides:
   pd_cluster:
@@ -118,8 +127,9 @@ guide: |
   through 8 of 288 experts, and supports image and video inputs. The checkpoint declares
   a maximum context length of 1,048,576 tokens and includes one MTP draft layer.
 
-  The current vLLM implementation supports NVIDIA Hopper and newer GPUs only. It can
-  scale with tensor, pipeline, expert, or data+expert parallelism.
+  The implementation supports NVIDIA Hopper and newer GPUs, and AMD Instinct
+  gfx950 via ROCm. It can scale with
+  tensor, pipeline, expert, or data+expert parallelism.
 
   ## Prerequisites
 
@@ -210,6 +220,28 @@ guide: |
   )
   print(response.choices[0].message.content)
   ```
+
+  ## Running on MI355X (gfx950)
+
+  The `vllm/vllm-openai-rocm:glm53-flash` docker image gates on gfx950 only.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve zai-org/GLM-5.3-Flash \
+    --served-model-name zai-org/GLM-5.3-Flash \
+    --tensor-parallel-size 4 \
+    --max-num-seqs 512 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
+    --attention-backend ROCM_AITER_MLA_SPARSE
+  ```
+
+  At TP=4 the FP8 checkpoint reports a 14.92M-token KV pool and ~113.81x max
+  concurrency at 128K context; the BF16 checkpoint reports an 8.87M-token KV
+  pool at the same TP and context.
+
+  > Note: MTP speculative decoding is not supported on ROCm with this image.
 
   ## Benchmarking
 


### PR DESCRIPTION
Validates [zai-org/GLM-5.3-Flash](https://huggingface.co/zai-org/GLM-5.3-Flash) and
[zai-org/GLM-5.3-Flash-BF16](https://huggingface.co/zai-org/GLM-5.3-Flash-BF16) on AMD
Instinct gfx950 (CDNA 4) with the published `vllm/vllm-openai-rocm:glm53-flash` image,
and marks `mi355x: verified`.

## Required ROCm settings

Three settings ship as an `amd` hardware override. Each is a hard startup failure
otherwise, not a tuning preference:

| Setting | Why |
| --- | --- |
| `VLLM_ROCM_USE_AITER=1` | *"Sparse attention indexer ROCm path is only supported on AITER"* |
| `--max-num-seqs 512` | 512 Mamba cache blocks available; the default 1024 aborts CUDA graph capture |
| `--attention-backend ROCM_AITER_MLA_SPARSE` | Pins the backend ROCm already auto-selects for sparse MLA |

They apply to every precision, so they sit at the top level rather than per-variant;
confirmed to propagate into the promoted BF16 variant's rendering.

## Not supported on ROCm

MTP speculative decoding faults the GPU at startup (`Memory access fault` on every TP
rank), reproduced at both 5 and 1 draft tokens and on both checkpoints. Documented as a
guide note; the feature definition is unchanged.

## Testing

MI350X (gfx950), TP4. Both checkpoints: server start, `/v1/models`, chat completion, tool
calling (`glm47`), reasoning (`glm45`), 90,043-token needle retrieval. Backend selected:
`ROCM_AITER_MLA_SPARSE`.

`vllm bench serve`, in 32000 / out 256 / conc 4, 16 prompts:

| Checkpoint | Output tok/s | Total tok/s | KV pool |
| --- | --- | --- | --- |
| FP8 | 87.10 | 10974.10 | 14.92M tokens |
| BF16 | 85.35 | 10754.35 | 8.87M tokens |

## Notes

- Verified on an **MI350X**; MI355X is the same gfx950 class and the image gates on
  `on_gfx950()`, but was not separately served. Happy to set the badge to `unverified`.
- TP4 was verified; the rendered command uses the node-wide TP8 default, untested here.