### PR TITLE
Scope Qwen3.6-35B-A3B NVFP4 tuning to per-GPU hardware overrides

### DIFF
--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -36,11 +36,11 @@ model:
 
 features:
   tool_calling:
-    description: "Enable automatic tool choice with Qwen3 Coder parser"
+    description: "Enable automatic tool choice with Qwen3 XML parser"
     args:
       - "--enable-auto-tool-choice"
       - "--tool-call-parser"
-      - "qwen3_coder"
+      - "qwen3_xml"
   reasoning:
     description: "Enable chain-of-thought reasoning with Qwen3 parser"
     args:
@@ -91,7 +91,6 @@ variants:
     tp: 1
     # SM120 GPUs only reach FlashInfer's XQA decode kernel from 0.28.0.
     min_vllm_version: "0.28.0"
-    nightly_required: true
     description: "NVIDIA ModelOpt NVFP4 checkpoint for Blackwell GPUs, including DGX Spark"
     extra_args:
       - "--kv-cache-dtype"
@@ -100,27 +99,84 @@ variants:
       - "marlin"
       - "--enable-prefix-caching"
     hardware_overrides:
-      dgx_station_gb300:
+      dgx_spark_gb10:
         extra_args:
-        - "--gpu-memory-utilization"
-        - "0.92"
-        - "--max-model-len"
-        - "262144"
-        - "--max-num-batched-tokens"
-        - "8192"
-        - "--enable-chunked-prefill"
-        - "--async-scheduling"
-        - "--load-format"
-        - "fastsafetensors"
-      rtx_5090:
-        extra_args:
+          - "--attention-backend"
+          - "flashinfer"
           - "--gpu-memory-utilization"
-          - "0.95"
+          - "0.5"
+          - "--max-model-len"
+          - "262144"
           - "--max-num-seqs"
-          - "4"
+          - "8"
           - "--max-num-batched-tokens"
           - "8192"
           - "--enable-chunked-prefill"
+          - "--async-scheduling"
+          - "--load-format"
+          - "fastsafetensors"
+      dgx_station_gb300:
+        extra_args:
+          - "--attention-backend"
+          - "flashinfer"
+          - "--gpu-memory-utilization"
+          - "0.92"
+          - "--max-model-len"
+          - "262144"
+          - "--max-num-batched-tokens"
+          - "8192"
+          - "--enable-chunked-prefill"
+          - "--async-scheduling"
+          - "--load-format"
+          - "fastsafetensors"
+      rtx_pro_6000:
+        extra_args:
+          - "--quantization"
+          - "modelopt_fp4"
+          - "--block-size"
+          - "128"
+          - "--attention-backend"
+          - "flashinfer"
+          - "--attention-config"
+          - '{"use_trtllm_attention":true}'
+          - "--gpu-memory-utilization"
+          - "0.9"
+          - "--max-num-seqs"
+          - "8"
+          - "--max-num-batched-tokens"
+          - "8192"
+          - "--enable-chunked-prefill"
+          - "--async-scheduling"
+          - "--skip-mm-profiling"
+          - "--load-format"
+          - "fastsafetensors"
+        extra_env:
+          VLLM_HAS_FLASHINFER_CUBIN: "1"
+      rtx_5090:
+        extra_args:
+          - "--quantization"
+          - "modelopt_fp4"
+          - "--block-size"
+          - "128"
+          - "--attention-backend"
+          - "flashinfer"
+          - "--attention-config"
+          - '{"use_trtllm_attention":true}'
+          - "--gpu-memory-utilization"
+          - "0.85"
+          - "--max-model-len"
+          - "65536"
+          - "--max-num-seqs"
+          - "8"
+          - "--max-num-batched-tokens"
+          - "8192"
+          - "--enable-chunked-prefill"
+          - "--async-scheduling"
+          - "--skip-mm-profiling"
+          - "--load-format"
+          - "fastsafetensors"
+        extra_env:
+          VLLM_HAS_FLASHINFER_CUBIN: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -151,9 +207,8 @@ guide: |
   ## Prerequisites
 
   - **vLLM version:** >= 0.17.0
-  - **NVFP4 vLLM version:** >= 0.28.0 (currently nightly). 0.24.0 loads the
-    checkpoint, but FlashInfer only selects its XQA decode kernel on SM120
-    GPUs from 0.28.0.
+  - **NVFP4 vLLM version:** >= 0.28.0. 0.24.0 loads the checkpoint, but
+    FlashInfer only selects its XQA decode kernel on SM120 GPUs from 0.28.0.
   - **Hardware (BF16):** 1x H200 or 2x H100
   - **Hardware (FP8):** single H100/H200 or 1x MI300X/MI325X/MI355X
   - **Hardware (NVFP4):** NVIDIA Blackwell GPUs, including DGX Spark (GB10)
@@ -207,15 +262,18 @@ guide: |
   ### DGX Spark NVFP4
 
   The NVIDIA ModelOpt NVFP4 checkpoint is served from
-  [`nvidia/Qwen3.6-35B-A3B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4)
-  and requires vLLM nightly or a source build with ModelOpt W4A16/NVFP4 support.
+  [`nvidia/Qwen3.6-35B-A3B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4).
+  GB10's 128 GB of unified memory is shared with the host, so cap
+  `--gpu-memory-utilization` at 0.5.
 
   ```bash
-  # Use container: vllm/vllm-openai:nightly
+  # Use container: vllm/vllm-openai:v0.28.0
 
   vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
+    --tensor-parallel-size 1 \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
+    --attention-backend flashinfer \
     --moe-backend marlin \
     --gpu-memory-utilization 0.5 \
     --max-model-len 262144 \
@@ -227,27 +285,23 @@ guide: |
     --speculative-config '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_coder \
+    --tool-call-parser qwen3_xml \
     --enable-auto-tool-choice
   ```
 
-  ### RTX Pro 6000 NVFP4
-
-  The NVIDIA ModelOpt NVFP4 checkpoint is served from
-  [`nvidia/Qwen3.6-35B-A3B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4)
-  and requires vLLM 0.28.0 or later (currently nightly) for the XQA decode path.
+  ### DGX Station NVFP4
 
   ```bash
-  # Use container: vllm/vllm-openai:nightly
+  # Use container: vllm/vllm-openai:v0.28.0
 
   vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
     --tensor-parallel-size 1 \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
+    --attention-backend flashinfer \
     --moe-backend marlin \
-    --gpu-memory-utilization 0.9 \
+    --gpu-memory-utilization 0.92 \
     --max-model-len 262144 \
-    --max-num-seqs 8 \
     --max-num-batched-tokens 8192 \
     --enable-chunked-prefill \
     --async-scheduling \
@@ -255,7 +309,75 @@ guide: |
     --speculative-config '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_coder \
+    --tool-call-parser qwen3_xml \
+    --enable-auto-tool-choice
+  ```
+
+  ### RTX PRO 6000 NVFP4
+
+  The consumer/workstation Blackwell parts (SM120) take a different path from
+  GB10/GB300: the checkpoint is loaded through `modelopt_fp4` with FlashInfer's
+  TRT-LLM attention kernels, which need `--block-size 128` and the
+  `VLLM_HAS_FLASHINFER_CUBIN=1` cubin cache. MTP also runs deeper here — 4
+  draft tokens on the `flashinfer_cutlass` MoE backend rather than 3 on Triton.
+
+  ```bash
+  # Use container: vllm/vllm-openai:v0.28.0
+
+  export VLLM_HAS_FLASHINFER_CUBIN=1
+
+  vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
+    --trust-remote-code \
+    --quantization modelopt_fp4 \
+    --kv-cache-dtype fp8 \
+    --block-size 128 \
+    --moe-backend marlin \
+    --attention-backend flashinfer \
+    --attention-config '{"use_trtllm_attention":true}' \
+    --gpu-memory-utilization 0.9 \
+    --max-num-seqs 8 \
+    --max-num-batched-tokens 8192 \
+    --enable-chunked-prefill \
+    --async-scheduling \
+    --enable-prefix-caching \
+    --skip-mm-profiling \
+    --load-format fastsafetensors \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":4,"moe_backend":"flashinfer_cutlass"}'
+  ```
+
+  ### GeForce RTX 5090 NVFP4
+
+  Same SM120 path as the RTX PRO 6000, but 32 GB of VRAM means the context has
+  to come down — 64K rather than the full 256K.
+
+  ```bash
+  # Use container: vllm/vllm-openai:v0.28.0
+
+  export VLLM_HAS_FLASHINFER_CUBIN=1
+
+  vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --tensor-parallel-size 1 \
+    --trust-remote-code \
+    --quantization modelopt_fp4 \
+    --kv-cache-dtype fp8 \
+    --block-size 128 \
+    --moe-backend marlin \
+    --attention-backend flashinfer \
+    --attention-config '{"use_trtllm_attention":true}' \
+    --gpu-memory-utilization 0.85 \
+    --max-model-len 65536 \
+    --max-num-seqs 8 \
+    --max-num-batched-tokens 8192 \
+    --enable-chunked-prefill \
+    --enable-prefix-caching \
+    --async-scheduling \
+    --skip-mm-profiling \
+    --load-format fastsafetensors \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":4,"moe_backend":"flashinfer_cutlass"}' \
+    --reasoning-parser qwen3 \
+    --tool-call-parser qwen3_xml \
     --enable-auto-tool-choice
   ```
 

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -48,18 +48,12 @@ features:
       - "qwen3"
   spec_decoding:
     description: "Multi-token prediction speculative decoding for lower latency"
-    # Single method, expressed as a mode so the config can vary per GPU id
-    # (mode hardware_overrides resolve exact id -> generation -> brand, while a
-    # flat feature's only resolve by generation and every profile here is
-    # "blackwell"). One mode renders no picker row in the UI.
     modes:
       mtp:
         args:
           - "--speculative-config"
           - '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}'
         hardware_overrides:
-          # SM120 runs the draft on FlashInfer's CUTLASS MoE kernels, which
-          # sustain a deeper draft than Triton does on GB10/GB300.
           rtx_pro_6000:
             args:
               - "--speculative-config"
@@ -106,8 +100,8 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 21
     tp: 1
-    # SM120 GPUs only reach FlashInfer's XQA decode kernel from 0.28.0.
     min_vllm_version: "0.28.0"
+    docker_image: "vllm/vllm-openai:v0.28.0"
     description: "NVIDIA ModelOpt NVFP4 checkpoint for Blackwell GPUs, including DGX Spark"
     extra_args:
       - "--kv-cache-dtype"
@@ -228,172 +222,17 @@ guide: |
   - **Hardware (FP8):** single H100/H200 or 1x MI300X/MI325X/MI355X
   - **Hardware (NVFP4):** NVIDIA Blackwell GPUs, including DGX Spark (GB10)
 
-  ### Install vLLM
+  ## NVFP4 on Blackwell
 
-  ```bash
-  uv venv
-  source .venv/bin/activate
-  uv pip install -U vllm --torch-backend=auto
-  ```
-
-  ## Launching the Server
-
-  ### Single-GPU FP8
-
-  ```bash
-  vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
-    --max-model-len 262144 \
-    --reasoning-parser qwen3
-  ```
-
-  ### BF16 on 2xH200 (TP2)
-
-  ```bash
-  vllm serve Qwen/Qwen3.6-35B-A3B \
-    --tensor-parallel-size 2 \
-    --max-model-len 262144 \
-    --reasoning-parser qwen3
-  ```
-
-  ### MTP speculative decoding
-
-  ```bash
-  vllm serve Qwen/Qwen3.6-35B-A3B \
-    --tensor-parallel-size 2 \
-    --max-model-len 262144 \
-    --reasoning-parser qwen3 \
-    --speculative-config '{"method": "mtp", "num_speculative_tokens": 2}'
-  ```
-
-  ### AMD (MI300X / MI325X / MI355X)
-
-  ```bash
-  VLLM_ROCM_USE_AITER=1 vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
-    --max-model-len 262144 \
-    --reasoning-parser qwen3 \
-    --trust-remote-code
-  ```
-
-  ### DGX Spark NVFP4
-
-  The NVIDIA ModelOpt NVFP4 checkpoint is served from
-  [`nvidia/Qwen3.6-35B-A3B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-35B-A3B-NVFP4).
-  GB10's 128 GB of unified memory is shared with the host, so cap
-  `--gpu-memory-utilization` at 0.5.
-
-  ```bash
-  # Use container: vllm/vllm-openai:v0.28.0
-
-  vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
-    --tensor-parallel-size 1 \
-    --trust-remote-code \
-    --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
-    --moe-backend marlin \
-    --gpu-memory-utilization 0.5 \
-    --max-model-len 262144 \
-    --max-num-seqs 8 \
-    --max-num-batched-tokens 8192 \
-    --enable-chunked-prefill \
-    --async-scheduling \
-    --enable-prefix-caching \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}' \
-    --load-format fastsafetensors \
-    --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_xml \
-    --enable-auto-tool-choice
-  ```
-
-  ### DGX Station NVFP4
-
-  ```bash
-  # Use container: vllm/vllm-openai:v0.28.0
-
-  vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
-    --tensor-parallel-size 1 \
-    --trust-remote-code \
-    --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
-    --moe-backend marlin \
-    --gpu-memory-utilization 0.92 \
-    --max-model-len 262144 \
-    --max-num-batched-tokens 8192 \
-    --enable-chunked-prefill \
-    --async-scheduling \
-    --enable-prefix-caching \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}' \
-    --load-format fastsafetensors \
-    --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_xml \
-    --enable-auto-tool-choice
-  ```
-
-  ### RTX PRO 6000 NVFP4
-
-  The consumer/workstation Blackwell parts (SM120) take a different path from
-  GB10/GB300: the checkpoint is loaded through `modelopt_fp4` with FlashInfer's
-  TRT-LLM attention kernels, which need `--block-size 128` and the
-  `VLLM_HAS_FLASHINFER_CUBIN=1` cubin cache. MTP also runs deeper here — 4
-  draft tokens on the `flashinfer_cutlass` MoE backend rather than 3 on Triton.
-
-  ```bash
-  # Use container: vllm/vllm-openai:v0.28.0
-
-  export VLLM_HAS_FLASHINFER_CUBIN=1
-
-  vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
-    --trust-remote-code \
-    --quantization modelopt_fp4 \
-    --kv-cache-dtype fp8 \
-    --block-size 128 \
-    --moe-backend marlin \
-    --attention-backend flashinfer \
-    --attention-config '{"use_trtllm_attention":true}' \
-    --gpu-memory-utilization 0.9 \
-    --max-num-seqs 8 \
-    --max-num-batched-tokens 8192 \
-    --enable-chunked-prefill \
-    --async-scheduling \
-    --enable-prefix-caching \
-    --skip-mm-profiling \
-    --load-format fastsafetensors \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":4,"moe_backend":"flashinfer_cutlass"}'
-  ```
-
-  ### GeForce RTX 5090 NVFP4
-
-  Same SM120 path as the RTX PRO 6000, but 32 GB of VRAM means the context has
-  to come down — 64K rather than the full 256K.
-
-  ```bash
-  # Use container: vllm/vllm-openai:v0.28.0
-
-  export VLLM_HAS_FLASHINFER_CUBIN=1
-
-  vllm serve nvidia/Qwen3.6-35B-A3B-NVFP4 \
-    --host 0.0.0.0 \
-    --port 8000 \
-    --tensor-parallel-size 1 \
-    --trust-remote-code \
-    --quantization modelopt_fp4 \
-    --kv-cache-dtype fp8 \
-    --block-size 128 \
-    --moe-backend marlin \
-    --attention-backend flashinfer \
-    --attention-config '{"use_trtllm_attention":true}' \
-    --gpu-memory-utilization 0.85 \
-    --max-model-len 65536 \
-    --max-num-seqs 8 \
-    --max-num-batched-tokens 8192 \
-    --enable-chunked-prefill \
-    --enable-prefix-caching \
-    --async-scheduling \
-    --skip-mm-profiling \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":4,"moe_backend":"flashinfer_cutlass"}' \
-    --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_xml \
-    --enable-auto-tool-choice
-  ```
+  Two distinct paths. GB10 (DGX Spark) and GB300 (DGX Station) run the
+  checkpoint on the default loader with FlashInfer attention and a 3-token MTP
+  draft on Triton; on Spark, unified memory is shared with the host, so
+  `--gpu-memory-utilization` is capped at 0.5. The SM120 parts (RTX PRO 6000,
+  RTX 5090) go through `modelopt_fp4` with FlashInfer's TRT-LLM attention
+  kernels — hence `--block-size 128`, `VLLM_HAS_FLASHINFER_CUBIN=1`, and a
+  deeper 4-token MTP draft on `flashinfer_cutlass`. The RTX 5090's 32 GB caps
+  the context at 64K. Pick the hardware above and the command builder emits the
+  right set.
 
   ## Processing Ultra-Long Texts
 

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -103,17 +103,15 @@ variants:
     min_vllm_version: "0.28.0"
     docker_image: "vllm/vllm-openai:v0.28.0"
     description: "NVIDIA ModelOpt NVFP4 checkpoint for Blackwell GPUs, including DGX Spark"
-    extra_args:
-      - "--kv-cache-dtype"
-      - "fp8"
-      - "--moe-backend"
-      - "marlin"
-      - "--enable-prefix-caching"
     hardware_overrides:
       dgx_spark_gb10:
         extra_args:
+          - "--kv-cache-dtype"
+          - "fp8"
           - "--attention-backend"
           - "flashinfer"
+          - "--moe-backend"
+          - "marlin"
           - "--gpu-memory-utilization"
           - "0.5"
           - "--max-model-len"
@@ -124,12 +122,17 @@ variants:
           - "8192"
           - "--enable-chunked-prefill"
           - "--async-scheduling"
+          - "--enable-prefix-caching"
           - "--load-format"
           - "fastsafetensors"
       dgx_station_gb300:
         extra_args:
+          - "--kv-cache-dtype"
+          - "fp8"
           - "--attention-backend"
           - "flashinfer"
+          - "--moe-backend"
+          - "marlin"
           - "--gpu-memory-utilization"
           - "0.92"
           - "--max-model-len"
@@ -138,14 +141,19 @@ variants:
           - "8192"
           - "--enable-chunked-prefill"
           - "--async-scheduling"
+          - "--enable-prefix-caching"
           - "--load-format"
           - "fastsafetensors"
       rtx_pro_6000:
         extra_args:
           - "--quantization"
           - "modelopt_fp4"
+          - "--kv-cache-dtype"
+          - "fp8"
           - "--block-size"
           - "128"
+          - "--moe-backend"
+          - "marlin"
           - "--attention-backend"
           - "flashinfer"
           - "--attention-config"
@@ -156,8 +164,9 @@ variants:
           - "8"
           - "--max-num-batched-tokens"
           - "8192"
-          - "--enable-chunked-prefill"
           - "--async-scheduling"
+          - "--enable-chunked-prefill"
+          - "--enable-prefix-caching"
           - "--skip-mm-profiling"
           - "--load-format"
           - "fastsafetensors"
@@ -167,8 +176,12 @@ variants:
         extra_args:
           - "--quantization"
           - "modelopt_fp4"
+          - "--kv-cache-dtype"
+          - "fp8"
           - "--block-size"
           - "128"
+          - "--moe-backend"
+          - "marlin"
           - "--attention-backend"
           - "flashinfer"
           - "--attention-config"
@@ -182,6 +195,7 @@ variants:
           - "--max-num-batched-tokens"
           - "8192"
           - "--enable-chunked-prefill"
+          - "--enable-prefix-caching"
           - "--async-scheduling"
           - "--skip-mm-profiling"
         extra_env:
@@ -224,15 +238,24 @@ guide: |
 
   ## NVFP4 on Blackwell
 
-  Two distinct paths. GB10 (DGX Spark) and GB300 (DGX Station) run the
-  checkpoint on the default loader with FlashInfer attention and a 3-token MTP
-  draft on Triton; on Spark, unified memory is shared with the host, so
-  `--gpu-memory-utilization` is capped at 0.5. The SM120 parts (RTX PRO 6000,
-  RTX 5090) go through `modelopt_fp4` with FlashInfer's TRT-LLM attention
-  kernels — hence `--block-size 128`, `VLLM_HAS_FLASHINFER_CUBIN=1`, and a
-  deeper 4-token MTP draft on `flashinfer_cutlass`. The RTX 5090's 32 GB caps
-  the context at 64K. Pick the hardware above and the command builder emits the
-  right set.
+  All NVFP4 tuning lives in `variants.nvfp4.hardware_overrides`, keyed by GPU
+  profile, so the exact flag set for a box is readable straight from the recipe
+  YAML (or from `by_hardware` in the JSON API) without going through the
+  command builder.
+
+  Four profiles are tuned and verified. DGX Spark (GB10) and DGX Station
+  (GB300) run the checkpoint on the default loader with FlashInfer attention,
+  `--moe-backend marlin` and a 3-token MTP draft on Triton; Spark shares
+  unified memory with the host, so `--gpu-memory-utilization` is capped at 0.5.
+  The SM120 parts (RTX PRO 6000, RTX 5090) load through `--quantization
+  modelopt_fp4` with FlashInfer's TRT-LLM attention kernels, which need
+  `--block-size 128` and `VLLM_HAS_FLASHINFER_CUBIN=1`, and sustain a deeper
+  4-token MTP draft on `flashinfer_cutlass`. The RTX 5090's 32 GB caps context
+  at 64K.
+
+  Datacenter Blackwell (B200/GB200/B300/GB300) intentionally carries no
+  overrides — it runs vLLM's own NVFP4 defaults, which select the native FP4
+  path rather than the Marlin W4A16 kernel the workstation parts need.
 
   ## Processing Ultra-Long Texts
 

--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -48,9 +48,26 @@ features:
       - "qwen3"
   spec_decoding:
     description: "Multi-token prediction speculative decoding for lower latency"
-    args:
-      - "--speculative-config"
-      - '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}'
+    # Single method, expressed as a mode so the config can vary per GPU id
+    # (mode hardware_overrides resolve exact id -> generation -> brand, while a
+    # flat feature's only resolve by generation and every profile here is
+    # "blackwell"). One mode renders no picker row in the UI.
+    modes:
+      mtp:
+        args:
+          - "--speculative-config"
+          - '{"method":"mtp","num_speculative_tokens":3,"moe_backend":"triton"}'
+        hardware_overrides:
+          # SM120 runs the draft on FlashInfer's CUTLASS MoE kernels, which
+          # sustain a deeper draft than Triton does on GB10/GB300.
+          rtx_pro_6000:
+            args:
+              - "--speculative-config"
+              - '{"method":"mtp","num_speculative_tokens":4,"moe_backend":"flashinfer_cutlass"}'
+          rtx_5090:
+            args:
+              - "--speculative-config"
+              - '{"method":"mtp","num_speculative_tokens":4,"moe_backend":"flashinfer_cutlass"}'
   text_only:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
@@ -173,8 +190,6 @@ variants:
           - "--enable-chunked-prefill"
           - "--async-scheduling"
           - "--skip-mm-profiling"
-          - "--load-format"
-          - "fastsafetensors"
         extra_env:
           VLLM_HAS_FLASHINFER_CUBIN: "1"
 
@@ -374,7 +389,6 @@ guide: |
     --enable-prefix-caching \
     --async-scheduling \
     --skip-mm-profiling \
-    --load-format fastsafetensors \
     --speculative-config '{"method":"mtp","num_speculative_tokens":4,"moe_backend":"flashinfer_cutlass"}' \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen3_xml \


### PR DESCRIPTION
The NVFP4 variant's extra_args were authored in the DGX Spark PR (#480) but written at variant level, so Spark tuning silently applied to every Blackwell profile — including B200/GB200/B300/GB300, where --moe-backend marlin forces a W4A16 kernel instead of the native FP4 path. This moves the whole arg set into variants.nvfp4.hardware_overrides for the four verified local profiles (DGX Spark, DGX Station, RTX PRO 6000, RTX 5090), each block self-contained so the flags for a given box are readable straight from the YAML and the JSON API's by_hardware entries; datacenter Blackwell now falls through to vLLM's own NVFP4 defaults. Also adds the SM120 path the RTX profiles were missing entirely (modelopt_fp4, --block-size 128, --attention-config use_trtllm_attention, --skip-mm-profiling, VLLM_HAS_FLASHINFER_CUBIN=1), moves spec_decoding to a single-mode block so the MTP draft depth can vary per GPU id (4 tokens on flashinfer_cutlass for SM120, 3 on triton for GB10/GB300), pins the v0.28.0 container, and drops the guide's duplicated launch commands in favour of the command builder.