### PR TITLE
Fix Qwen3.8-Flash-Next YaRN recipe: --rope-scaling → --hf-overrides

### DIFF
--- a/models/Qwen/Qwen3.8-Flash-Next.yaml
+++ b/models/Qwen/Qwen3.8-Flash-Next.yaml
@@ -300,7 +300,7 @@ guide: |
   VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
   vllm serve Qwen/Qwen3.8-Flash-Next-FP8 \
     --tensor-parallel-size 4 \
-    --rope-scaling '{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}' \
+    --hf-overrides '{"rope_parameters":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}}' \
     --max-model-len 1000000 \
     --no-enable-flashinfer-autotune \
     --enable-auto-tool-choice \


### PR DESCRIPTION
## Fix `--rope-scaling` → `--hf-overrides` in the YaRN section

`--rope-scaling` was removed in vLLM 0.11.1 (PR #28006). The recipe still uses it, so the YaRN command crashes on boot on any vLLM ≥ 0.11.1 — including the image the recipe references.

```diff
-    --rope-scaling '{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}' \
+    --hf-overrides '{"rope_parameters":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":262144}}' \
```

Tested: old flag crashes, new one boots fine and gives `max_model_len=1000000`.