### PR TITLE
Mark MI300X and MI325X as unsupported for GLM-5.3-Flash

### DIFF
--- a/models/zai-org/GLM-5.3-Flash.yaml
+++ b/models/zai-org/GLM-5.3-Flash.yaml
@@ -13,6 +13,8 @@ meta:
     h100: verified
     b200: verified
     gb200: verified
+    mi300x: unsupported
+    mi325x: unsupported
     mi355x: verified
 
 model:


### PR DESCRIPTION
## Problem

The recipe page for GLM-5.3-Flash shows MI325X and MI300X as selectable AMD hardware tabs. However, the `vllm/vllm-openai-rocm:glm53-flash` Docker image does not actually support these GPUs.

## Root cause

The image contains a platform guard in `vllm/models/glm5next/__init__.py`:

```python
raise NotImplementedError("glm 5 next currently supports ROCm gfx950 only.")
```

- MI300X = gfx942 (CDNA 3) — **not supported**
- MI325X = gfx942 (CDNA 3) — **not supported**
- MI350X = gfx950 (CDNA 4) — supported
- MI355X = gfx950 (CDNA 4) — supported (verified)

## Evidence

Deployed the recipe on MI325X (gfx942) with TP=8, `--max-num-seqs 512`, `--tool-call-parser glm47`, `--reasoning-parser glm45`. The server crashes at model import time before any weights are loaded:

```
NotImplementedError: glm 5 next currently supports ROCm gfx950 only.
```

The same image runs correctly on MI350X (gfx950) — server boots, weights load, inference works.

## Fix

Add `mi300x: unsupported` and `mi325x: unsupported` to `meta.hardware` in the recipe YAML. The frontend `isHardwareSupported()` function treats absence as "assumed to work" — only an explicit `"unsupported"` value hides the tab.

The guide section already states "The vllm/vllm-openai-rocm:glm53-flash docker image gates on gfx950 only" but the hardware picker does not reflect this. This PR aligns the picker with the documented behavior.