### PR TITLE
Kimi-K3: set --prefix-match-unit 128 on the Blackwell profile

### DIFF
--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -254,10 +254,11 @@ hardware_overrides:
       - '{"use_prefill_query_quantization":true,"mla_prefill_backend":"flashinfer"}'
       - "--enable-prefix-caching"
       # K3's two KV-cache groups (MLA attention + KDA Mamba) both resolve to a
-      # 1536-token block under the hybrid manager, so the default prefix-cache
-      # hit boundary is every 1536 tokens. 128 divides 1536 (the inflation formula
-      # always yields a multiple of 128) and matches the MLA kernel block
-      # alignment, giving 12x finer prefix hits. No-op without prefix caching.
+      # single block size under the hybrid manager: vLLM pads the attention
+      # block up to match the Mamba state page, so the default prefix-cache hit
+      # boundary is that (large) block size. The inflation formula always
+      # yields a multiple of 128, so 128 divides it and matches the MLA kernel
+      # block alignment, giving finer prefix hits. No-op without prefix caching.
       - "--prefix-match-unit"
       - "128"
     extra_env:
@@ -444,7 +445,7 @@ guide: |
   - **MNNVL environments** (GB200/GB300 NVL): recommend adding `NCCL_MNNVL_ENABLE=1`, `NCCL_CUMEM_ENABLE=1`, and `NCCL_NVLS_ENABLE=1`.
   - **mlx5 dmabuf registration failures**: if engine init fails with "NCCL error: unhandled system error" and the log shows `mlx5dv_reg_dmabuf_mr` errno 524, the kernel/driver lacks mlx5 dmabuf support (NCCL 2.28 registers dmabuf by default). Set `NCCL_DMABUF_ENABLE=0` to fall back to `nvidia_peermem` (must be loaded on the nodes) — still GPUDirect RDMA.
   - **FP8 KV**: If FP8 KV cache is needed, please also add `--attention-config '{"use_prefill_query_quantization":true,"mla_prefill_backend":"flashinfer"}'` when serving vLLM. `flashinfer` is the recommended default and is what the Blackwell profile above emits, but it is not the only supported choice: vLLM 0.27.1 registers three MLA prefill backends — `FLASHINFER`, `TRTLLM_RAGGED` and `TOKENSPEED_MLA` (see `vllm/v1/attention/backends/mla/prefill/registry.py`) — and any of them may be substituted for `mla_prefill_backend` alongside `use_prefill_query_quantization`. Which one wins depends on the input-length distribution, so benchmark before switching.
-  - **Prefix-match unit**: K3 is a hybrid model: its MLA attention layers and KDA (Mamba-like) layers form two KV-cache groups under the hybrid KV-cache manager. With prefix caching on, vLLM pads the attention block size up to match the Mamba state page, so both groups resolve to a 1536-token block — meaning prefix-cache hits only land every 1536 tokens by default. The Blackwell profile sets `--prefix-match-unit 128`, which divides 1536 and aligns with the MLA kernel's native block boundary, giving 12x finer prefix-hit granularity (a hit boundary every 128 tokens instead of 1536). The value is only effective when prefix caching (or a KV connector) is active; it is a no-op otherwise. 128 divides any block size the inflation produces (the formula yields a multiple of 128 across TP sizes), so it is safe under all tensor-parallel layouts.
+  - **Prefix-match unit**: K3 is a hybrid model: its MLA attention layers and KDA (Mamba-like) layers form two KV-cache groups under the hybrid KV-cache manager. With prefix caching on, vLLM pads the attention block size up to match the Mamba state page, so both groups resolve to one (large) block size and the default prefix-cache hit boundary lands on that block — very coarse. The Blackwell profile sets `--prefix-match-unit 128`: the inflation formula always yields a multiple of 128, so 128 divides whatever block size results, and it aligns with the MLA kernel's native block boundary, giving finer prefix-hit granularity. The value is only effective when prefix caching (or a KV connector) is active; it is a no-op otherwise, and it is safe under all tensor-parallel layouts.
   - **Decode context parallelism (DCP)**: enable the `dcp` opt-in feature in the command builder to shard the decode KV cache across the tensor-parallel ranks for decode-heavy long-context serving. It emits `--decode-context-parallel-size 8 --dcp-comm-backend a2a --attention-backend TOKENSPEED_MLA` with `mla_prefill_backend: TRTLLM_RAGGED`, and is scoped to the TP8 single-node profile because the DCP size must divide the tensor-parallel size. On builds that carry them, the `VLLM_USE_DIRECT_DCP_A2A`, `VLLM_USE_DIRECT_DCP_Q_GATHER` and `VLLM_USE_DIRECT_DCP_KV_GATHER` knobs default to auto and turn the direct DCP ops on where applicable; set them to `1` only to pin that path explicitly, or `0` to disable it.
   - Ascend W4A8 checkpoint (ModelScope): https://www.modelscope.cn/models/Eco-Tech/Kimi-K3-w4a8
   - vLLM Ascend tutorial: https://docs.vllm.ai/projects/ascend/en/v0.23.0/tutorials/models/Kimi-K3.html

--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Moonshot AI"
   description: "Pre-release 2.8T-parameter native multimodal MoE with Kimi Delta Attention, Gated MLA, Attention Residuals, and a 1M-token context window"
   date_added: 2026-07-27
-  date_updated: 2026-08-15
+  date_updated: 2026-08-27
   difficulty: hard
   tasks:
     - multimodal
@@ -253,6 +253,13 @@ hardware_overrides:
       - "--attention-config"
       - '{"use_prefill_query_quantization":true,"mla_prefill_backend":"flashinfer"}'
       - "--enable-prefix-caching"
+      # K3's two KV-cache groups (MLA attention + KDA Mamba) both resolve to a
+      # 1536-token block under the hybrid manager, so the default prefix-cache
+      # hit boundary is every 1536 tokens. 128 divides 1536 (the inflation formula
+      # always yields a multiple of 128) and matches the MLA kernel block
+      # alignment, giving 12x finer prefix hits. No-op without prefix caching.
+      - "--prefix-match-unit"
+      - "128"
     extra_env:
       VLLM_ALLREDUCE_USE_FLASHINFER: "1"
       VLLM_ENGINE_READY_TIMEOUT_S: "3600"
@@ -437,6 +444,7 @@ guide: |
   - **MNNVL environments** (GB200/GB300 NVL): recommend adding `NCCL_MNNVL_ENABLE=1`, `NCCL_CUMEM_ENABLE=1`, and `NCCL_NVLS_ENABLE=1`.
   - **mlx5 dmabuf registration failures**: if engine init fails with "NCCL error: unhandled system error" and the log shows `mlx5dv_reg_dmabuf_mr` errno 524, the kernel/driver lacks mlx5 dmabuf support (NCCL 2.28 registers dmabuf by default). Set `NCCL_DMABUF_ENABLE=0` to fall back to `nvidia_peermem` (must be loaded on the nodes) — still GPUDirect RDMA.
   - **FP8 KV**: If FP8 KV cache is needed, please also add `--attention-config '{"use_prefill_query_quantization":true,"mla_prefill_backend":"flashinfer"}'` when serving vLLM. `flashinfer` is the recommended default and is what the Blackwell profile above emits, but it is not the only supported choice: vLLM 0.27.1 registers three MLA prefill backends — `FLASHINFER`, `TRTLLM_RAGGED` and `TOKENSPEED_MLA` (see `vllm/v1/attention/backends/mla/prefill/registry.py`) — and any of them may be substituted for `mla_prefill_backend` alongside `use_prefill_query_quantization`. Which one wins depends on the input-length distribution, so benchmark before switching.
+  - **Prefix-match unit**: K3 is a hybrid model: its MLA attention layers and KDA (Mamba-like) layers form two KV-cache groups under the hybrid KV-cache manager. With prefix caching on, vLLM pads the attention block size up to match the Mamba state page, so both groups resolve to a 1536-token block — meaning prefix-cache hits only land every 1536 tokens by default. The Blackwell profile sets `--prefix-match-unit 128`, which divides 1536 and aligns with the MLA kernel's native block boundary, giving 12x finer prefix-hit granularity (a hit boundary every 128 tokens instead of 1536). The value is only effective when prefix caching (or a KV connector) is active; it is a no-op otherwise. 128 divides any block size the inflation produces (the formula yields a multiple of 128 across TP sizes), so it is safe under all tensor-parallel layouts.
   - **Decode context parallelism (DCP)**: enable the `dcp` opt-in feature in the command builder to shard the decode KV cache across the tensor-parallel ranks for decode-heavy long-context serving. It emits `--decode-context-parallel-size 8 --dcp-comm-backend a2a --attention-backend TOKENSPEED_MLA` with `mla_prefill_backend: TRTLLM_RAGGED`, and is scoped to the TP8 single-node profile because the DCP size must divide the tensor-parallel size. On builds that carry them, the `VLLM_USE_DIRECT_DCP_A2A`, `VLLM_USE_DIRECT_DCP_Q_GATHER` and `VLLM_USE_DIRECT_DCP_KV_GATHER` knobs default to auto and turn the direct DCP ops on where applicable; set them to `1` only to pin that path explicitly, or `0` to disable it.
   - Ascend W4A8 checkpoint (ModelScope): https://www.modelscope.cn/models/Eco-Tech/Kimi-K3-w4a8
   - vLLM Ascend tutorial: https://docs.vllm.ai/projects/ascend/en/v0.23.0/tutorials/models/Kimi-K3.html


### PR DESCRIPTION
## What

Adds `--prefix-match-unit 128` to the Kimi-K3 Blackwell hardware profile (where `--enable-prefix-caching` is already enabled), plus a guide note.

## Why

K3 is a hybrid model: its MLA attention layers and KDA (Mamba-like) layers form two KV-cache groups under the hybrid KV-cache manager. With prefix caching on, vLLM pads the attention block size up to match the Mamba state page, so **both groups resolve to a 1536-token block**. The default prefix-cache hit boundary is therefore every 1536 tokens — very coarse.

`128` divides 1536 and aligns with the MLA kernel's native block boundary (`kernel_block_alignment_size`), giving **12x finer prefix-hit granularity** (a hit boundary every 128 tokens instead of 1536). The inflation formula in `vllm/platforms/interface.py` always yields a multiple of 128 across TP sizes, so 128 is valid under every tensor-parallel layout. The flag is a no-op where prefix caching is off, so it is scoped to the Blackwell hardware override (the only profile that enables `--enable-prefix-caching`).

## Scope

- `models/moonshotai/Kimi-K3.yaml` only — Blackwell `hardware_overrides` block + guide note + `date_updated` bump.
- Hopper / AMD / Ascend profiles are untouched (they don't enable prefix caching, so the flag would be a no-op there).

## Validation

- `node scripts/build-recipes-api.mjs` → `✓ JSON API: 178 models` (clean parse).
- Confirmed the flag lands in the Blackwell `recommended_command` (`public/moonshotai/Kimi-K3.json`) and does **not** leak into the Hopper/AMD per-hw renderings.

## Notes

- Not duplicating an existing PR: no recipe or vLLM doc sets `--prefix-match-unit` for K3 today.
- AI assistance was used to investigate the block-size resolution; the change and rationale were reviewed end-to-end.

Co-authored-by: Mistral Vibe <vibe@mistral.ai>