### PR TITLE
Add RedHatAI Gemma, Mellum, and MiniMax recipes

### DIFF
--- a/models/Google/gemma-4-12B-it.yaml
+++ b/models/Google/gemma-4-12B-it.yaml
@@ -64,11 +64,28 @@ variants:
     precision: bf16
     vram_minimum_gb: 29
     description: "Full BF16 — single 40 GB+ NVIDIA GPU"
+  nvfp4:
+    model_id: "RedHatAI/gemma-4-12B-it-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 8
+    description: "RedHatAI compressed-tensors NVFP4 quantization for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
   w4a16:
     model_id: "google/gemma-4-12B-it-qat-w4a16-ct"
     precision: int4
     vram_minimum_gb: 9
     description: "W4A16 QAT (4-bit weights, 16-bit activations, group_size=32) via compressed-tensors — runs on any GPU"
+
+  fp8:
+    model_id: "RedHatAI/gemma-4-12B-it-FP8-Dynamic"
+    precision: fp8
+    vram_minimum_gb: 15
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Google/gemma-4-26B-A4B-it.yaml
+++ b/models/Google/gemma-4-26B-A4B-it.yaml
@@ -69,10 +69,22 @@ features:
       - "--language-model-only"
   spec_decoding:
     description: "MTP speculative decoding for accelerated inference"
-    args:
-      - "--speculative-config"
-      - '{"model":"google/gemma-4-26B-A4B-it-assistant","num_speculative_tokens":4}'
-
+    default_mode: mtp
+    modes:
+      mtp:
+        label: "MTP"
+        description: "Built-in Multi-Token Prediction, 4 draft tokens."
+        args:
+          - "--speculative-config"
+          - '{"model":"google/gemma-4-26B-A4B-it-assistant","num_speculative_tokens":4}'
+      eagle3:
+        label: "Eagle3"
+        description: "Eagle3 speculative decoding with externally trained draft model; the served checkpoint is unchanged."
+        variants:
+          - default
+        args:
+          - "--speculative-config"
+          - '{"model": "RedHatAI/gemma-4-26B-A4B-it-speculator.eagle3", "num_speculative_tokens": 3, "method": "eagle3"}'
 opt_in_features:
   - text_only
   - spec_decoding

--- a/models/Google/gemma-4-31B-it.yaml
+++ b/models/Google/gemma-4-31B-it.yaml
@@ -54,10 +54,38 @@ features:
       - "--language-model-only"
   spec_decoding:
     description: "MTP speculative decoding for accelerated inference"
-    args:
-      - "--speculative-config"
-      - '{"model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":4}'
-
+    default_mode: mtp
+    modes:
+      mtp:
+        label: "MTP"
+        description: "Built-in Multi-Token Prediction, 4 draft tokens."
+        args:
+          - "--speculative-config"
+          - '{"model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":4}'
+      dflash:
+        label: "DFlash"
+        description: "DFlash speculative decoding with an externally trained draft model; the served checkpoint is unchanged."
+        variants:
+          - default
+        args:
+          - "--speculative-config"
+          - '{"model": "RedHatAI/gemma-4-31B-it-speculator.dflash", "num_speculative_tokens": 7, "method": "dflash"}'
+      dspark:
+        label: "DSpark"
+        description: "DSpark drafting with an externally trained draft model; the served checkpoint is unchanged."
+        variants:
+          - default
+        args:
+          - "--speculative-config"
+          - '{"model": "RedHatAI/gemma-4-31B-it-speculator.dspark", "num_speculative_tokens": 7, "method": "dspark"}'
+      eagle3:
+        label: "Eagle3"
+        description: "Eagle3 speculative decoding with externally trained draft model; the served checkpoint is unchanged."
+        variants:
+          - default
+        args:
+          - "--speculative-config"
+          - '{"model": "RedHatAI/gemma-4-31B-it-speculator.eagle3", "num_speculative_tokens": 3, "method": "eagle3"}'
 opt_in_features:
   - text_only
   - spec_decoding
@@ -83,11 +111,30 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
+  redhat_nvfp4:
+    model_id: "RedHatAI/gemma-4-31B-it-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 19
+    description: "RedHatAI compressed-tensors NVFP4 quantization for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
   w4a16:
     model_id: "google/gemma-4-31B-it-qat-w4a16-ct"
     precision: int4
     vram_minimum_gb: 20
     description: "W4A16 QAT (4-bit weights, 16-bit activations, group_size=32) via compressed-tensors — runs on any GPU"
+
+  redhat_fp8:
+    model_id: "RedHatAI/gemma-4-31B-it-FP8-block"
+    precision: fp8
+    label: "FP8 Block (RedHat)"
+    vram_minimum_gb: 38
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
 
 compatible_strategies:
   - single_node_tp

--- a/models/JetBrains/Mellum2-12B-A2.5B-Thinking.yaml
+++ b/models/JetBrains/Mellum2-12B-A2.5B-Thinking.yaml
@@ -39,13 +39,35 @@ features:
       - "--tool-call-parser"
       - "hermes"
 
-opt_in_features: []
+  spec_decoding:
+    description: "DFlash speculative decoding with an externally trained draft model; the served checkpoint is unchanged."
+    args:
+      - "--speculative-config"
+      - '{"model": "RedHatAI/Mellum2-12B-A2.5B-Thinking-speculator.dflash", "num_speculative_tokens": 7, "method": "dflash"}'
+
+opt_in_features:
+  - spec_decoding
 
 variants:
   default:
     precision: bf16
     vram_minimum_gb: 29
     description: "Native bfloat16 weights; fits comfortably on a single H200/H100/A100"
+
+  fp8:
+    model_id: "RedHatAI/Mellum2-12B-A2.5B-Thinking-FP8-Dynamic"
+    precision: fp8
+    vram_minimum_gb: 15
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  nvfp4:
+    model_id: "RedHatAI/Mellum2-12B-A2.5B-Thinking-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 8
+    description: "RedHatAI NVFP4 quantization"
 
 compatible_strategies:
   - single_node_tp

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -60,6 +60,13 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  redhat_nvfp4:
+    model_id: "RedHatAI/MiniMax-M2.5-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 146
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep


### PR DESCRIPTION
Add the following red hat models:

- RedHatAI/gemma-4-12B-it-NVFP4
- RedHatAI/gemma-4-12B-it-FP8-Dynamic
- RedHatAI/gemma-4-26B-A4B-it-speculator.eagle3
- RedHatAI/gemma-4-31B-it-speculator.dflash
- RedHatAI/gemma-4-31B-it-speculator.dspark
- RedHatAI/gemma-4-31B-it-speculator.eagle3
- RedHatAI/gemma-4-31B-it-NVFP4
- RedHatAI/gemma-4-31B-it-FP8-block
- RedHatAI/Mellum2-12B-A2.5B-Thinking-speculator.dflash
- RedHatAI/Mellum2-12B-A2.5B-Thinking-FP8-Dynamic
- RedHatAI/Mellum2-12B-A2.5B-Thinking-NVFP4
- RedHatAI/MiniMax-M2.5-NVFP4