### PR TITLE
Add RedHatAI Qwen recipe variants

### DIFF
--- a/models/Qwen/Qwen2.5-32B.yaml
+++ b/models/Qwen/Qwen2.5-32B.yaml
@@ -33,6 +33,15 @@ variants:
     vram_minimum_gb: 77
     description: "Full precision BF16 — TPU v6e 2x2 (4 chips, TP=4) or a single 80GB+ GPU"
 
+  fp8:
+    model_id: "RedHatAI/Qwen2.5-32B-FP8-dynamic"
+    precision: fp8
+    vram_minimum_gb: 39
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-72B-Instruct.yaml
@@ -55,6 +55,15 @@ variants:
       - "--quantization"
       - "awq"
 
+  fp8:
+    model_id: "RedHatAI/Qwen2.5-VL-72B-Instruct-FP8-dynamic"
+    precision: fp8
+    vram_minimum_gb: 87
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/Qwen/Qwen2.5-VL-7B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-7B-Instruct.yaml
@@ -54,6 +54,15 @@ variants:
       - "--quantization"
       - "awq"
 
+  fp8:
+    model_id: "RedHatAI/Qwen2.5-VL-7B-Instruct-FP8-Dynamic"
+    precision: fp8
+    vram_minimum_gb: 9
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -35,7 +35,14 @@ features:
       - "--tool-call-parser"
       - "hermes"
 
-opt_in_features: []
+  spec_decoding:
+    description: "Eagle3 speculative decoding with externally trained draft model; the served checkpoint is unchanged."
+    args:
+      - "--speculative-config"
+      - '{"model": "RedHatAI/Qwen3-235B-A22B-Instruct-2507-speculator.eagle3", "num_speculative_tokens": 3, "method": "eagle3"}'
+
+opt_in_features:
+  - spec_decoding
 
 variants:
   default:
@@ -59,6 +66,13 @@ variants:
       - "fp8"
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Qwen3-235B-A22B-Instruct-2507-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 152
+    description: "RedHatAI NVFP4 quantization"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Qwen/Qwen3-32B.yaml
+++ b/models/Qwen/Qwen3-32B.yaml
@@ -40,7 +40,14 @@ features:
       - "--reasoning-parser"
       - "qwen3"
 
-opt_in_features: []
+  spec_decoding:
+    description: "Eagle3 speculative decoding with externally trained draft model; the served checkpoint is unchanged."
+    args:
+      - "--speculative-config"
+      - '{"model": "RedHatAI/Qwen3-32B-speculator.eagle3", "num_speculative_tokens": 3, "method": "eagle3"}'
+
+opt_in_features:
+  - spec_decoding
 
 variants:
   default:
@@ -60,6 +67,39 @@ variants:
     extra_args:
       - "--quantization"
       - "awq"
+
+  redhat_fp8:
+    model_id: "RedHatAI/Qwen3-32B-FP8-dynamic"
+    precision: fp8
+    label: "FP8 Dynamic (RedHat)"
+    vram_minimum_gb: 39
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_fp8_block:
+    model_id: "RedHatAI/Qwen3-32B-FP8-block"
+    precision: fp8
+    label: "FP8 Block (RedHat)"
+    vram_minimum_gb: 39
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  nvfp4:
+    model_id: "RedHatAI/Qwen3-32B-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 22
+    description: "RedHatAI NVFP4 quantization"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Qwen3-32B-NVFP4A16"
+    precision: nvfp4
+    label: "NVFP4 A16 (RedHat)"
+    vram_minimum_gb: 22
+    description: "RedHatAI NVFP4 with BF16 activations"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Qwen/Qwen3-4B.yaml
+++ b/models/Qwen/Qwen3-4B.yaml
@@ -51,6 +51,16 @@ variants:
     vram_minimum_gb: 5
     description: "Qwen official FP8 checkpoint"
 
+  redhat_fp8:
+    model_id: "RedHatAI/Qwen3-4B-FP8-dynamic"
+    precision: fp8
+    label: "FP8 Dynamic (RedHat)"
+    vram_minimum_gb: 5
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp
@@ -129,7 +139,6 @@ guide: |
       --host 0.0.0.0 \
       --port 8000
   ```
-
 
   ## Configuration Tips
 

--- a/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -65,6 +65,16 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  redhat_fp8:
+    model_id: "RedHatAI/Qwen3-Coder-480B-A35B-Instruct-FP8"
+    precision: fp8
+    label: "FP8 (RedHat)"
+    vram_minimum_gb: 576
+    description: "RedHatAI FP8 quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -64,6 +64,43 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  redhat_fp8:
+    model_id: "RedHatAI/Qwen3-Next-80B-A3B-Instruct-FP8-dynamic"
+    precision: fp8
+    label: "FP8 Dynamic (RedHat)"
+    vram_minimum_gb: 96
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_fp8_plain:
+    model_id: "RedHatAI/Qwen3-Next-80B-A3B-Instruct-FP8"
+    precision: fp8
+    label: "FP8 (RedHat)"
+    vram_minimum_gb: 96
+    description: "RedHatAI FP8 quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_fp8_block:
+    model_id: "RedHatAI/Qwen3-Next-80B-A3B-Instruct-FP8-block"
+    precision: fp8
+    label: "FP8 Block (RedHat)"
+    vram_minimum_gb: 96
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Qwen3-Next-80B-A3B-Instruct-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 48
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -31,7 +31,6 @@ model:
   docker_image:
     amd: "vllm/vllm-openai-rocm:v0.22.1"
 
-
 dependencies:
   - note: "Recommended for offline multimodal inference (image/video pre-processing helpers)"
     command: "uv pip install qwen-vl-utils==0.0.14"
@@ -73,6 +72,33 @@ variants:
       - "fp8"
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+  redhat_fp8:
+    model_id: "RedHatAI/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic"
+    precision: fp8
+    label: "FP8 Dynamic (RedHat)"
+    vram_minimum_gb: 282
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_fp8_block:
+    model_id: "RedHatAI/Qwen3-VL-235B-A22B-Instruct-FP8-block"
+    precision: fp8
+    label: "FP8 Block (RedHat)"
+    vram_minimum_gb: 282
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Qwen3-VL-235B-A22B-Instruct-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 150
+    description: "RedHatAI NVFP4 quantization"
 
 compatible_strategies:
   - single_node_tp


### PR DESCRIPTION
Add the follwoing red hat models:

- RedHatAI/Qwen2.5-32B-FP8-dynamic
- RedHatAI/Qwen2.5-VL-72B-Instruct-FP8-dynamic
- RedHatAI/Qwen2.5-VL-7B-Instruct-FP8-Dynamic
- RedHatAI/Qwen3-235B-A22B-Instruct-2507-speculator.eagle3
- RedHatAI/Qwen3-235B-A22B-Instruct-2507-NVFP4
- RedHatAI/Qwen3-32B-speculator.eagle3
- RedHatAI/Qwen3-32B-FP8-dynamic
- RedHatAI/Qwen3-32B-FP8-block
- RedHatAI/Qwen3-32B-NVFP4
- RedHatAI/Qwen3-32B-NVFP4A16
- RedHatAI/Qwen3-4B-FP8-dynamic
- RedHatAI/Qwen3-Coder-480B-A35B-Instruct-FP8
- RedHatAI/Qwen3-Next-80B-A3B-Instruct-FP8-dynamic
- RedHatAI/Qwen3-Next-80B-A3B-Instruct-FP8
- RedHatAI/Qwen3-Next-80B-A3B-Instruct-FP8-block
- RedHatAI/Qwen3-Next-80B-A3B-Instruct-NVFP4
- RedHatAI/Qwen3-VL-235B-A22B-Instruct-FP8-dynamic
- RedHatAI/Qwen3-VL-235B-A22B-Instruct-FP8-block
- RedHatAI/Qwen3-VL-235B-A22B-Instruct-NVFP4