### PR TITLE
Add RedHatAI Llama, Mistral, and DeepSeek recipes

### DIFF
--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -71,6 +71,13 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  redhat_nvfp4:
+    model_id: "RedHatAI/DeepSeek-R1-NVFP4-FP8-BLOCK"
+    precision: nvfp4
+    label: "NVFP4+FP8 Block (RedHat)"
+    vram_minimum_gb: 444
+    description: "RedHatAI NVFP4+FP8 block mixed-precision checkpoint"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2.yaml
@@ -73,6 +73,13 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  redhat_nvfp4:
+    model_id: "RedHatAI/DeepSeek-V3.2-NVFP4-FP8-BLOCK"
+    precision: nvfp4
+    label: "NVFP4+FP8 Block (RedHat)"
+    vram_minimum_gb: 430
+    description: "RedHatAI NVFP4+FP8 block mixed-precision checkpoint"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -73,6 +73,7 @@ features:
         variants:
           - fp8
           - nvfp4
+          - redhat_nvfp4
         args:
           - "--speculative-config"
           - '{"method":"mtp","num_speculative_tokens":2}'
@@ -98,6 +99,14 @@ features:
               - "--speculative-config"
               - '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","attention_backend":"B12X_MLA_SPARSE"}'
 
+      dflash:
+        label: "DFlash"
+        description: "DFlash speculative decoding with an externally trained draft model; the served checkpoint is unchanged."
+        variants:
+          - default
+        args:
+          - "--speculative-config"
+          - '{"model":"RedHatAI/DeepSeek-V4-Flash-speculator.dflash","num_speculative_tokens":7,"method":"dflash"}'
 opt_in_features:
   - spec_decoding
 
@@ -305,6 +314,12 @@ variants:
           OMPI_MCA_btl_tcp_if_include: "$IFACE_NAME"
           TP_SOCKET_IFNAME: "$IFACE_NAME"
           UCX_NET_DEVICES: "$IFACE_NAME"
+  redhat_nvfp4:
+    model_id: "RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 170
+    description: "RedHatAI NVFP4+FP8 mixed-precision checkpoint for Blackwell GPUs"
   dspark:
     # Official fused DSpark checkpoint — the preview weights with the DSpark draft
     # module attached (config.json gains the dspark_* block). A distinct served

--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -66,6 +66,7 @@ features:
         variants:
           - fp8
           - nvfp4
+          - redhat_nvfp4
         args:
           - "--speculative-config"
           - '{"method":"mtp","num_speculative_tokens":2}'
@@ -144,6 +145,12 @@ variants:
           - "--moe-backend"
           - "deep_gemm_mega_moe"
 
+  redhat_nvfp4:
+    model_id: "RedHatAI/DeepSeek-V4-Pro-NVFP4-FP8"
+    precision: nvfp4
+    label: "NVFP4+FP8 (RedHat)"
+    vram_minimum_gb: 1000
+    description: "RedHatAI NVFP4+FP8 mixed-precision checkpoint"
 kv_offload_support:
   offloading_cpu: verified
   offloading_fs: verified

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -76,6 +76,43 @@ variants:
       - "--kv-cache-dtype"
       - "fp8"
 
+  fp8:
+    model_id: "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic"
+    precision: fp8
+    label: "FP8 Dynamic (RedHat)"
+    vram_minimum_gb: 10
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_fp8:
+    model_id: "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8"
+    precision: fp8
+    label: "FP8 (RedHat)"
+    vram_minimum_gb: 10
+    description: "RedHatAI FP8 quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_fp8_block:
+    model_id: "RedHatAI/Llama-3.1-8B-Instruct-FP8-block"
+    precision: fp8
+    label: "FP8 Block (RedHat)"
+    vram_minimum_gb: 10
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Llama-3.1-8B-Instruct-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 6
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -32,9 +32,15 @@ model:
   base_args: []
   base_env: {}
 
-features: {}
+features:
+  spec_decoding:
+    description: "Eagle3 speculative decoding with externally trained draft model; the served checkpoint is unchanged."
+    args:
+      - "--speculative-config"
+      - '{"model":"RedHatAI/Llama-3.3-70B-Instruct-speculator.eagle3","num_speculative_tokens":3,"method":"eagle3"}'
 
-opt_in_features: []
+opt_in_features:
+  - spec_decoding
 
 variants:
   default:
@@ -52,6 +58,16 @@ variants:
       - "fp8"
     extra_env: {}
 
+  redhat_fp8:
+    model_id: "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic"
+    precision: fp8
+    label: "FP8 (RedHat)"
+    vram_minimum_gb: 84
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
   nvfp4:
     model_id: "nvidia/Llama-3.3-70B-Instruct-NVFP4"
     precision: nvfp4
@@ -60,6 +76,23 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
+
+  redhat_fp8_block:
+    model_id: "RedHatAI/Llama-3.3-70B-Instruct-FP8-block"
+    precision: fp8
+    label: "FP8 Block (RedHat)"
+    vram_minimum_gb: 84
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Llama-3.3-70B-Instruct-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 46
+    description: "RedHatAI NVFP4 quantization"
 
 compatible_strategies:
   - single_node_tp

--- a/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -61,6 +61,38 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  redhat_fp8:
+    model_id: "RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic"
+    precision: fp8
+    label: "FP8 (RedHat)"
+    vram_minimum_gb: 131
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Llama-4-Scout-17B-16E-Instruct-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 65
+    description: "RedHatAI compressed-tensors NVFP4 quantization for Blackwell GPUs"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+    extra_env:
+      VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+  redhat_fp8_block:
+    model_id: "RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-block"
+    precision: fp8
+    label: "FP8 Block (RedHat)"
+    vram_minimum_gb: 131
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
+++ b/models/mistralai/Ministral-3-14B-Instruct-2512.yaml
@@ -80,6 +80,22 @@ variants:
       - "--kv-cache-dtype"
       - "fp8"
 
+  redhat_fp8:
+    model_id: "RedHatAI/Ministral-3-14B-Instruct-2512-FP8-dynamic"
+    precision: fp8
+    label: "FP8 Dynamic (RedHat)"
+    vram_minimum_gb: 17
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  nvfp4:
+    model_id: "RedHatAI/Ministral-3-14B-Instruct-2512-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 9
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp
@@ -245,7 +261,6 @@ guide: |
   Serving benchmarks used `vllm bench serve` with random 1024-token input/output,
   `--max-concurrency 32`, and `--num-prompts 100` against each variant above.
   Accuracy used `lm-eval` GSM8K (5-shot, `flexible-extract` / `strict-match` filters).
-
 
   ### Throughput
 

--- a/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
+++ b/models/mistralai/Mistral-Large-3-675B-Instruct-2512.yaml
@@ -76,6 +76,13 @@ variants:
       - "--kv-cache-dtype"
       - "fp8"
 
+  redhat_nvfp4:
+    model_id: "RedHatAI/Mistral-Large-3-675B-Instruct-2512-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 405
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/mistralai/Mistral-Small-4-119B-2603.yaml
+++ b/models/mistralai/Mistral-Small-4-119B-2603.yaml
@@ -44,10 +44,30 @@ features:
       - "mistral"
   spec_decoding:
     description: "EAGLE speculative decoding via the mistralai/Mistral-Small-4-119B-2603-eagle 2-layer draft head"
-    args:
-      - "--speculative-config"
-      - '{"model":"mistralai/Mistral-Small-4-119B-2603-eagle","num_speculative_tokens":3,"method":"eagle","max_model_len":"65536"}'
-
+    default_mode: eagle
+    modes:
+      eagle:
+        label: "EAGLE"
+        description: "EAGLE speculative decoding."
+        args:
+          - "--speculative-config"
+          - '{"model":"mistralai/Mistral-Small-4-119B-2603-eagle","num_speculative_tokens":3,"method":"eagle","max_model_len":"65536"}'
+      dspark:
+        label: "DSpark"
+        description: "DSpark drafting with an externally trained draft model; the served checkpoint is unchanged."
+        variants:
+          - default
+        args:
+          - "--speculative-config"
+          - '{"model": "RedHatAI/Mistral-Small-4-119B-2603-speculator.dspark", "num_speculative_tokens": 7, "method": "dspark"}'
+      dflash:
+        label: "DFlash"
+        description: "DFlash speculative decoding with an externally trained draft model; the served checkpoint is unchanged."
+        variants:
+          - default
+        args:
+          - "--speculative-config"
+          - '{"model": "RedHatAI/Mistral-Small-4-119B-2603.dflash", "num_speculative_tokens": 7, "method": "dflash"}'
 opt_in_features:
   - spec_decoding
 
@@ -61,6 +81,13 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 72
     description: "NVFP4 4-bit weights for B200-class GPUs (Marlin fallback on Hopper)"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Mistral-Small-4-119B-2603-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 72
+    description: "RedHatAI NVFP4 quantization"
 
 compatible_strategies:
   - single_node_tp


### PR DESCRIPTION
Add the following red hat models:

- RedHatAI/DeepSeek-R1-NVFP4-FP8-BLOCK
- RedHatAI/DeepSeek-V3.2-NVFP4-FP8-BLOCK
- RedHatAI/DeepSeek-V4-Flash-speculator.dflash
- RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8
- RedHatAI/DeepSeek-V4-Pro-NVFP4-FP8
- RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic
- RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8
- RedHatAI/Llama-3.1-8B-Instruct-FP8-block
- RedHatAI/Llama-3.1-8B-Instruct-NVFP4
- RedHatAI/Llama-3.3-70B-Instruct-speculator.eagle3
- RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
- RedHatAI/Llama-3.3-70B-Instruct-FP8-block
- RedHatAI/Llama-3.3-70B-Instruct-NVFP4
- RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
- RedHatAI/Llama-4-Scout-17B-16E-Instruct-NVFP4
- RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-block
- RedHatAI/Ministral-3-14B-Instruct-2512-FP8-dynamic
- RedHatAI/Ministral-3-14B-Instruct-2512-NVFP4
- RedHatAI/Mistral-Large-3-675B-Instruct-2512-NVFP4
- RedHatAI/Mistral-Small-4-119B-2603-speculator.dspark
- RedHatAI/Mistral-Small-4-119B-2603.dflash
- RedHatAI/Mistral-Small-4-119B-2603-NVFP4