### PR TITLE
Add RedHatAI variants for remaining model recipes

### DIFF
--- a/models/arcee-ai/Trinity-Large-Thinking.yaml
+++ b/models/arcee-ai/Trinity-Large-Thinking.yaml
@@ -53,6 +53,13 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  redhat_nvfp4:
+    model_id: "RedHatAI/Trinity-Large-Thinking-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 254
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/microsoft/Phi-4-mini-instruct.yaml
+++ b/models/microsoft/Phi-4-mini-instruct.yaml
@@ -64,6 +64,15 @@ variants:
     extra_args:
       - "--trust-remote-code"
 
+  fp8:
+    model_id: "RedHatAI/Phi-4-mini-instruct-FP8-dynamic"
+    precision: fp8
+    vram_minimum_gb: 5
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/moonshotai/Kimi-K2-Thinking.yaml
+++ b/models/moonshotai/Kimi-K2-Thinking.yaml
@@ -61,6 +61,15 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  fp8:
+    model_id: "RedHatAI/Kimi-K2-Thinking-FP8-Block"
+    precision: fp8
+    vram_minimum_gb: 1200
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -88,6 +88,22 @@ variants:
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
+  fp8:
+    model_id: "RedHatAI/Kimi-K2.6-FP8-BLOCK"
+    precision: fp8
+    vram_minimum_gb: 1200
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Kimi-K2.6-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 600
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -164,7 +164,13 @@ variants:
       ascend_910c:
         docker_image: "quay.io/ascend/vllm-ascend:kimi-k3-a3"
     description: "ModelSlim INT4 W4A8 for Ascend NPU. Requires --quantization ascend. Validated on 4× 910C mixed P/D."
-    
+
+  fp8:
+    model_id: "RedHatAI/Kimi-K3-FP8-BLOCK"
+    precision: fp8
+    vram_minimum_gb: 3360
+    description: "RedHatAI FP8 block quantization"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -69,6 +69,16 @@ variants:
     vram_minimum_gb: 22
     description: "Japanese-specialized fine-tune (BF16)"
 
+  redhat_fp8:
+    model_id: "RedHatAI/NVIDIA-Nemotron-Nano-9B-v2-FP8-dynamic"
+    precision: fp8
+    label: "FP8 Dynamic (RedHat)"
+    vram_minimum_gb: 11
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
 compatible_strategies:
   - single_node_tp
   - multi_node_tp

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -40,7 +40,14 @@ features:
       - "openai"
       - "--enable-auto-tool-choice"
 
-opt_in_features: []
+  spec_decoding:
+    description: "Eagle3 speculative decoding with externally trained draft model; the served checkpoint is unchanged."
+    args:
+      - "--speculative-config"
+      - '{"model": "RedHatAI/gpt-oss-20b-speculator.eagle3", "num_speculative_tokens": 3, "method": "eagle3"}'
+
+opt_in_features:
+  - spec_decoding
 
 variants:
   default:

--- a/models/poolside/Laguna-XS.2.yaml
+++ b/models/poolside/Laguna-XS.2.yaml
@@ -74,6 +74,23 @@ variants:
     min_vllm_version: "0.22.0"
     description: "INT4 (W4A16) weights + FP8 KV cache — fits on a single 32GB+ GPU"
 
+  redhat_fp8:
+    model_id: "RedHatAI/Laguna-XS.2-FP8"
+    precision: fp8
+    label: "FP8 (RedHat)"
+    vram_minimum_gb: 40
+    description: "RedHatAI FP8 quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Laguna-XS.2-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 22
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/thinkingmachines/Inkling-Small.yaml
+++ b/models/thinkingmachines/Inkling-Small.yaml
@@ -207,6 +207,14 @@ variants:
         extra_env:
           VLLM_ROCM_USE_AITER: "1"
           VLLM_ROCM_USE_AITER_MOE: "1"
+  fp8:
+    model_id: "RedHatAI/Inkling-Small-FP8-dynamic"
+    precision: fp8
+    vram_minimum_gb: 332
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
 
 compatible_strategies:
   - single_node_tp

--- a/models/thinkingmachines/Inkling.yaml
+++ b/models/thinkingmachines/Inkling.yaml
@@ -148,6 +148,32 @@ variants:
     extra_env:
       FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED: "1"
 
+  fp8:
+    model_id: "RedHatAI/Inkling-FP8-dynamic"
+    precision: fp8
+    vram_minimum_gb: 1170
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_fp8:
+    model_id: "RedHatAI/Inkling-FP8-block"
+    precision: fp8
+    label: "FP8 Block (RedHat)"
+    vram_minimum_gb: 1170
+    description: "RedHatAI FP8 block quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_nvfp4:
+    model_id: "RedHatAI/Inkling-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 618
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/zai-org/GLM-4.6.yaml
+++ b/models/zai-org/GLM-4.6.yaml
@@ -61,6 +61,32 @@ variants:
     vram_minimum_gb: 428
     description: "Native FP8 checkpoint with minimal accuracy loss — recommended for cost-efficient serving"
 
+  redhat_fp8:
+    model_id: "RedHatAI/GLM-4.6-FP8-dynamic"
+    precision: fp8
+    label: "FP8 Dynamic (RedHat)"
+    vram_minimum_gb: 429
+    description: "RedHatAI FP8 (E4M3) with dynamic per-token activation quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  redhat_fp8_plain:
+    model_id: "RedHatAI/GLM-4.6-FP8"
+    precision: fp8
+    label: "FP8 (RedHat)"
+    vram_minimum_gb: 429
+    description: "RedHatAI FP8 quantization"
+    extra_args:
+      - "--kv-cache-dtype"
+      - "fp8"
+
+  nvfp4:
+    model_id: "RedHatAI/GLM-4.6-NVFP4"
+    precision: nvfp4
+    vram_minimum_gb: 223
+    description: "RedHatAI NVFP4 quantization"
+
 compatible_strategies:
   - single_node_tp
   - single_node_tep

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -55,8 +55,11 @@ features:
         variants:
           - default
           - nvfp4
+          - redhat_nvfp4
           - bf16
           - mxfp4
+          - redhat_fp8
+          - redhat_nvfp4_plain
         args:
           - "--speculative-config"
           - '{"method":"mtp","num_speculative_tokens":5}'
@@ -98,10 +101,31 @@ variants:
     precision: nvfp4
     vram_minimum_gb: 558
     description: "NVIDIA modelopt NVFP4 checkpoint — only MoE expert linears are quantized to NVFP4; shared experts, attention, embeddings, and the early dense layers stay FP8/BF16, with FP8 KV cache. Blackwell GPUs (B200/B300) only."
+  redhat_nvfp4:
+    model_id: "RedHatAI/GLM-5.2-NVFP4-FP8"
+    precision: nvfp4
+    label: "NVFP4+FP8 (RedHat)"
+    vram_minimum_gb: 558
+    description: "RedHatAI NVFP4+FP8 mixed-precision checkpoint (MoE expert linears NVFP4, attention/embeddings FP8) for Blackwell GPUs"
   bf16:
     precision: bf16
     vram_minimum_gb: 1786
     description: "Full precision BF16 — requires multi-node deployment"
+
+  redhat_fp8:
+    model_id: "RedHatAI/GLM-5.2-FP8"
+    precision: fp8
+    label: "FP8 (RedHat)"
+    vram_minimum_gb: 892
+    description: "RedHatAI FP8 quantization"
+
+  redhat_nvfp4_plain:
+    model_id: "RedHatAI/GLM-5.2-NVFP4"
+    precision: nvfp4
+    label: "NVFP4 (RedHat)"
+    vram_minimum_gb: 477
+    description: "RedHatAI NVFP4 quantization"
+
 
 compatible_strategies:
   - single_node_tp


### PR DESCRIPTION
Add the following red hat models:

- RedHatAI/Trinity-Large-Thinking-NVFP4
- RedHatAI/Phi-4-mini-instruct-FP8-dynamic
- RedHatAI/Kimi-K2-Thinking-FP8-Block
- RedHatAI/Kimi-K2.6-FP8-BLOCK
- RedHatAI/Kimi-K2.6-NVFP4
- RedHatAI/Kimi-K3-FP8-BLOCK
- RedHatAI/NVIDIA-Nemotron-Nano-9B-v2-FP8-dynamic
- RedHatAI/gpt-oss-20b-speculator.eagle3
- RedHatAI/Laguna-XS.2-FP8
- RedHatAI/Laguna-XS.2-NVFP4
- RedHatAI/Inkling-Small-FP8-dynamic
- RedHatAI/Inkling-FP8-dynamic
- RedHatAI/Inkling-FP8-block
- RedHatAI/Inkling-NVFP4
- RedHatAI/GLM-4.6-FP8-dynamic
- RedHatAI/GLM-4.6-FP8
- RedHatAI/GLM-4.6-NVFP4
- RedHatAI/GLM-5.2-NVFP4-FP8
- RedHatAI/GLM-5.2-FP8
- RedHatAI/GLM-5.2-NVFP4