### PR TITLE
Add Hunyuan Hy4-preview recipe

### DIFF
--- a/models/tencent/Hy4-preview.yaml
+++ b/models/tencent/Hy4-preview.yaml
@@ -9,7 +9,9 @@ meta:
   tasks:
     - text
   performance_headline: "Hunyuan Hy4-preview MoE — 770B/49B on 16xB200, 8xB300 with MTP"
-  related_recipes: []
+  related_recipes:
+    - "tencent/Hy3"
+    - "tencent/Hy3-preview"
   default_hardware: b300
   hardware:
     h100: unsupported
@@ -62,13 +64,13 @@ opt_in_features:
 variants:
   default:
     precision: bf16
-    vram_minimum_gb: 1540
+    vram_minimum_gb: 1848
     description: "Full precision BF16 — 16xB200 or 8xB300 minimum for weights + KV cache"
   fp8:
     model_id: "tencent/Hy4-preview-FP8"
     precision: mxfp8
-    vram_minimum_gb: 770
-    description: "MXFP8-quantized instruct checkpoint (tencent/Hy4-preview-FP8) — fits a single 16xB200 / 8xB300 node with wide headroom."
+    vram_minimum_gb: 924
+    description: "MXFP8-quantized instruct checkpoint (tencent/Hy4-preview-FP8) — fits a single 8xB200 / 8xB300 node with wide headroom."
 
 compatible_strategies:
   - single_node_tp
@@ -90,9 +92,9 @@ hardware_overrides:
 strategy_overrides: {}
 
 guide: |
-  # Hy4 preview Usage Guide
+  # Hy4-preview Usage Guide
 
-  Hy4 preview is Tencent Hy's new-generation open-source Mixture-of-Experts language
+  Hy4-preview is Tencent Hunyuan's new-generation open-source Mixture-of-Experts language
   model. Its backbone has 770B total parameters with 49B activated per token across
   78 layers. The first layer uses a dense FFN; the other 77 layers use 256 routed
   experts (top-8) and 1 shared expert. A native MTP layer adds 10B total parameters
@@ -207,10 +209,10 @@ guide: |
 
   ## References
 
-  - [Hugging Face: Hy4 preview](https://huggingface.co/tencent/Hy4-preview)
-  - [Hugging Face: Hy4 preview-FP8](https://huggingface.co/tencent/Hy4-preview-FP8)
-  - [ModelScope: Hy4 preview](https://modelscope.cn/models/Tencent-Hunyuan/Hy4-preview)
+  - [Hugging Face: Hy4-preview](https://huggingface.co/tencent/Hy4-preview)
+  - [Hugging Face: Hy4-preview-FP8](https://huggingface.co/tencent/Hy4-preview-FP8)
+  - [ModelScope: Hy4-preview](https://modelscope.cn/models/Tencent-Hunyuan/Hy4-preview)
   - [GitHub: Tencent-Hunyuan/Hy4-preview](https://github.com/Tencent-Hunyuan/Hy4-preview)
-  - [GitCode: Hy4 preview](https://ai.gitcode.com/tencent_hunyuan/Hy4-preview)
-  - [CNB: Hy4 preview](https://cnb.cool/ai-models/tencent/Hy4-preview)
+  - [GitCode: Hy4-preview](https://ai.gitcode.com/tencent_hunyuan/Hy4-preview)
+  - [CNB: Hy4-preview](https://cnb.cool/ai-models/tencent/Hy4-preview)
   - [AngelSlim quantization toolkit](https://github.com/tencent/AngelSlim)

--- a/models/tencent/Hy4-preview.yaml
+++ b/models/tencent/Hy4-preview.yaml
@@ -1,0 +1,216 @@
+meta:
+  title: "Hy4-preview"
+  slug: "hy4-preview"
+  provider: "Hunyuan (Tencent)"
+  description: "Tencent Hunyuan Hy4-preview — scaled-up MoE language model (770B total / 49B active) with a 10B MTP layer for speculative decoding, 1M context, and hy_v4 tool/reasoning parsers"
+  date_added: 2026-08-28
+  date_updated: 2026-08-28
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "Hunyuan Hy4-preview MoE — 770B/49B on 16xB200, 8xB300 with MTP"
+  related_recipes: []
+  default_hardware: b300
+  hardware:
+    h100: unsupported
+    h200: unsupported
+    b200: verified
+    b300: verified
+    mi300x: unsupported
+    mi325x: unsupported
+    mi355x: unsupported
+
+model:
+  model_id: "tencent/Hy4-preview"
+  min_vllm_version: "0.29.0"
+  docker_image:
+    nvidia: "vllm/vllm-openai:hy4-preview"
+  nightly_required: true
+  install:
+    docker:
+      note: "Use the dedicated hy4-preview image until changes land in vllm:latest."
+    pip:
+      note: "Hy4-preview's latest optimizations aren't in a stable release yet — use nightly wheels or build from source."
+  architecture: moe
+  parameter_count: "770B"
+  active_parameters: "49B"
+  context_length: 1048576
+  base_args: []
+  base_env: {}
+
+features:
+  tool_calling:
+    description: "Hunyuan v4 tool call parser with automatic tool choice"
+    args:
+      - "--tool-call-parser"
+      - "hy_v4"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "Hunyuan v4 reasoning parser for thinking-mode chain-of-thought extraction"
+    args:
+      - "--reasoning-parser"
+      - "hy_v4"
+  spec_decoding:
+    description: "Multi-Token Prediction speculative decoding using the model's built-in MTP layer"
+    args:
+      - "--speculative-config"
+      - '{"method":"mtp","num_speculative_tokens":3}'
+
+opt_in_features:
+  - spec_decoding
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 1540
+    description: "Full precision BF16 — 16xB200 or 8xB300 minimum for weights + KV cache"
+  fp8:
+    model_id: "tencent/Hy4-preview-FP8"
+    precision: mxfp8
+    vram_minimum_gb: 770
+    description: "MXFP8-quantized instruct checkpoint (tencent/Hy4-preview-FP8) — fits a single 16xB200 / 8xB300 node with wide headroom."
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tp
+  - multi_node_tep
+  - multi_node_dep
+
+hardware_overrides:
+  # Suggest enable hpc-ops for better performance on Blackwell
+  blackwell:
+    extra_env:
+      VLLM_ENABLE_HPC_OPS: "1"
+    extra_args:
+      - "--attention-backend"
+      - "FLASHMLA_SPARSE"
+
+strategy_overrides: {}
+
+guide: |
+  # Hy4 preview Usage Guide
+
+  Hy4 preview is Tencent Hy's new-generation open-source Mixture-of-Experts language
+  model. Its backbone has 770B total parameters with 49B activated per token across
+  78 layers. The first layer uses a dense FFN; the other 77 layers use 256 routed
+  experts (top-8) and 1 shared expert. A native MTP layer adds 10B total parameters
+  (0.7B activated) for speculative decoding.
+
+  On the architecture side, inspired by DeepSeek and GLM, the attention module employs Gated DeepSeek Sparse Attention (Gated DSA) with IndexCache for cross-layer sparse index reuse. The residual pathway uses iHC (identity Hyper-Connections) to expand inter-layer information flow.
+
+  ## vLLM Setup
+
+  Choose one of the following setup methods.
+
+  ### Using Docker
+
+  ```bash
+  docker run --gpus all \
+    -p 8000:8000 \
+    --ipc=host \
+    -e VLLM_ENABLE_HPC_OPS=1 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai:hy4-preview tencent/Hy4-preview-FP8 \
+      --tensor-parallel-size 8 \
+      --speculative-config '{"num_speculative_tokens":3,"method":"mtp"}' \
+      --attention-backend FLASHMLA_SPARSE \
+      --tool-call-parser hy_v4 \
+      --reasoning-parser hy_v4 \
+      --enable-auto-tool-choice \
+      --port 8000 \
+      --served-model-name hy4-preview
+  ```
+
+  Build vLLM from source:
+
+  ```bash
+  uv venv --python 3.12 --seed --managed-python
+  source .venv/bin/activate
+  git clone https://github.com/vllm-project/vllm.git
+  cd vllm
+  uv pip install --editable . --torch-backend=auto
+  ```
+
+  ## vLLM Deployment
+
+  Start the FP8 model with MTP enabled:
+
+  ```bash
+  export VLLM_ENABLE_HPC_OPS=1
+
+  vllm serve tencent/Hy4-preview-FP8 \
+    --tensor-parallel-size 8 \
+    --speculative-config '{"num_speculative_tokens":3,"method":"mtp"}' \
+    --attention-backend FLASHMLA_SPARSE \
+    --tool-call-parser hy_v4 \
+    --reasoning-parser hy_v4 \
+    --enable-auto-tool-choice \
+    --port 8000 \
+    --served-model-name hy4-preview
+  ```
+
+  ## OpenAI Client Example
+
+  Tencent recommends `temperature=0.9` and `top_p=1.0`. Reasoning defaults to
+  `high`, which is suitable for math, coding, and other complex tasks.
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://127.0.0.1:8000/v1", api_key="EMPTY")
+
+  response = client.chat.completions.create(
+      model="hy4-preview",
+      messages=[
+          {"role": "user", "content": "Hello! Can you briefly introduce yourself?"},
+      ],
+      temperature=0.9,
+      top_p=1.0,
+  )
+  output_msg = response.choices[0].message
+  print(output_msg.reasoning_content)  # chain-of-thought
+  print(output_msg.content)             # final answer
+  ```
+
+  For a direct response without deep reasoning, pass `reasoning_effort="no_think"`:
+
+  ```python
+  response = client.chat.completions.create(
+      model="hy4-preview",
+      messages=[
+          {"role": "user", "content": "Hello! Can you briefly introduce yourself?"},
+      ],
+      temperature=0.9,
+      top_p=1.0,
+      extra_body={"chat_template_kwargs": {"reasoning_effort": "no_think"}},
+  )
+  print(response.choices[0].message.content)
+  ```
+
+  ### cURL Usage
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "hy4-preview",
+      "messages": [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello! Can you briefly introduce yourself?"}
+      ],
+      "temperature": 0.9,
+      "top_p": 1.0
+    }'
+  ```
+
+  ## References
+
+  - [Hugging Face: Hy4 preview](https://huggingface.co/tencent/Hy4-preview)
+  - [Hugging Face: Hy4 preview-FP8](https://huggingface.co/tencent/Hy4-preview-FP8)
+  - [ModelScope: Hy4 preview](https://modelscope.cn/models/Tencent-Hunyuan/Hy4-preview)
+  - [GitHub: Tencent-Hunyuan/Hy4-preview](https://github.com/Tencent-Hunyuan/Hy4-preview)
+  - [GitCode: Hy4 preview](https://ai.gitcode.com/tencent_hunyuan/Hy4-preview)
+  - [CNB: Hy4 preview](https://cnb.cool/ai-models/tencent/Hy4-preview)
+  - [AngelSlim quantization toolkit](https://github.com/tencent/AngelSlim)


### PR DESCRIPTION
## Summary

Adds a recipe for [`tencent/Hy4-preview`](https://huggingface.co/tencent/Hy4-preview) — Tencent Hunyuan's new-generation open-source MoE: **770B total / 49B active** across 78 layers (layer 1 dense FFN, layers 2-78 with 256 routed experts top-8 + 1 shared expert), a native **10B MTP layer** (0.7B active) for speculative decoding, and **1M context**.

Architecturally it uses Gated DeepSeek Sparse Attention (Gated DSA) with IndexCache for cross-layer sparse index reuse, and iHC (identity Hyper-Connections) on the residual pathway.

## Recipe details

| | |
|---|---|
| Variants | BF16 (default, 1540 GB) and MXFP8 [`tencent/Hy4-preview-FP8`](https://huggingface.co/tencent/Hy4-preview-FP8) (770 GB) |
| Hardware | Verified on **B200** and **B300**; `default_hardware: b300` (8xB300 fits BF16 single-node) |
| Features | `tool_calling` + `reasoning` via the `hy_v4` parsers; `spec_decoding` (MTP, 3 tokens) opt-in |
| Strategies | single- and multi-node TP / TEP / DEP |
| Blackwell override | `VLLM_ENABLE_HPC_OPS=1` and `--attention-backend FLASHMLA_SPARSE` |
| Image | Pinned to `vllm/vllm-openai:hy4-preview` until the changes land in a stable release; pip path uses nightly wheels (`min_vllm_version: 0.29.0`) |

Hopper (H100/H200) and AMD (MI300X/MI325X/MI355X) are marked `unsupported` — the Gated DSA + `FLASHMLA_SPARSE` path has no build there today.

## Test plan

- [x] `node scripts/build-recipes-api.mjs` → `✓ JSON API: 179 models, 9 strategies, 2 kv-store deployments`
- [x] Both HF repos resolve (200 from the HF API)
- [x] `recommended_command` renders as `b300 / single_node_tp`, matching the guide's 8-GPU deployment example