### PR TITLE
Validate hardware keys at build time; drop 5 inert ones

### DIFF
--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -9,7 +9,6 @@ meta:
     - text
   performance_headline: "BF16 is validated on 4x NVIDIA H20; serialized FP8 defaults to TP2 on NVIDIA H200, with TP4+EP4 also validated"
   hardware:
-    h20: verified
     h200: verified
 
 model:

--- a/models/nvidia/Cosmos3-Nano.yaml
+++ b/models/nvidia/Cosmos3-Nano.yaml
@@ -16,7 +16,6 @@ meta:
   hardware:
     h200: verified
     h100: verified
-    a100: verified
 
 model:
   model_id: "nvidia/Cosmos3-Nano"

--- a/models/nvidia/Cosmos3-Super-Image2Video.yaml
+++ b/models/nvidia/Cosmos3-Super-Image2Video.yaml
@@ -16,7 +16,6 @@ meta:
   hardware:
     h200: verified
     h100: verified
-    a100: verified
 
 model:
   model_id: "nvidia/Cosmos3-Super-Image2Video"

--- a/models/nvidia/Cosmos3-Super.yaml
+++ b/models/nvidia/Cosmos3-Super.yaml
@@ -16,7 +16,6 @@ meta:
   hardware:
     h200: verified
     h100: verified
-    a100: verified
 
 model:
   model_id: "nvidia/Cosmos3-Super"

--- a/models/tencent/Hy3-preview.yaml
+++ b/models/tencent/Hy3-preview.yaml
@@ -14,7 +14,6 @@ meta:
     h200: verified
     mi300x: verified
     mi325x: verified
-    mi350x: verified
     mi355x: verified
 
 model:

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -217,6 +217,88 @@ function validateFeatureModes(recipe, sourceFile) {
   }
 }
 
+// Validate every hardware-keyed map against the taxonomy vocabulary. Hardware
+// lookups are exact string matches (`isHardwareSupported`, `hardwareKeyedValue`),
+// so a key naming no known GPU is silently inert: an author's `verified` badge
+// never renders, and — worse — an intended `unsupported` opt-out never disables
+// anything. Nothing downstream can detect that, hence the build-time check.
+//
+// Two keyspaces, matching the schema in CLAUDE.md:
+//   - exact:   only a taxonomy profile id (`meta.hardware`, `supported_hardware`)
+//   - layered: profile id > generation > brand > `default` (`strategy_hardware`,
+//              variant `tp`, `hardware_overrides`)
+function validateHardwareKeys(recipe, sourceFile, taxonomy, strategies) {
+  const errors = [];
+  const profiles = taxonomy?.hardware_profiles || {};
+  const ids = new Set(Object.keys(profiles));
+  const generations = new Set();
+  const brands = new Set();
+  for (const p of Object.values(profiles)) {
+    if (p?.generation) generations.add(p.generation);
+    if (p?.brand) brands.add(String(p.brand).toLowerCase());
+  }
+  const layered = new Set([...ids, ...generations, ...brands, "default"]);
+
+  const exact = (loc, key) => {
+    if (!ids.has(key)) errors.push(`${loc} references unknown hardware profile ${key}`);
+  };
+  const keyed = (loc, key) => {
+    if (!layered.has(key)) errors.push(`${loc} references unknown hardware key ${key}`);
+  };
+  const keysOf = (o) => (o && typeof o === "object" && !Array.isArray(o) ? Object.keys(o) : []);
+
+  if (recipe?.meta?.default_hardware) exact("meta.default_hardware", recipe.meta.default_hardware);
+  for (const k of keysOf(recipe?.meta?.hardware)) exact("meta.hardware", k);
+
+  for (const [kvId, map] of Object.entries(recipe?.kv_cache_strategy_hardware || {})) {
+    for (const k of keysOf(map)) exact(`kv_cache_strategy_hardware.${kvId}`, k);
+  }
+
+  for (const [sId, map] of Object.entries(recipe?.strategy_hardware || {})) {
+    for (const k of keysOf(map)) keyed(`strategy_hardware.${sId}`, k);
+  }
+
+  for (const k of keysOf(recipe?.hardware_overrides)) keyed("hardware_overrides", k);
+
+  // `strategy_min_gpus` mixes strategy ids with an exact-GPU-id keyspace; only
+  // the latter is ours to check.
+  for (const k of keysOf(recipe?.strategy_min_gpus)) {
+    if (!strategies?.[k]) exact("strategy_min_gpus", k);
+  }
+
+  for (const [variantKey, variant] of Object.entries(recipe?.variants || {})) {
+    const at = `variants.${variantKey}`;
+    for (const k of variant?.supported_hardware || []) exact(`${at}.supported_hardware`, k);
+    for (const k of keysOf(variant?.hardware_overrides)) keyed(`${at}.hardware_overrides`, k);
+    if (variant?.tp && typeof variant.tp === "object") {
+      for (const k of keysOf(variant.tp)) keyed(`${at}.tp`, k);
+    }
+    // `precision_hardware` widens a precision's hardware constraint by value,
+    // not by key — check the vocabulary it names.
+    const ph = variant?.precision_hardware;
+    if (ph?.generation && !generations.has(ph.generation)) {
+      errors.push(`${at}.precision_hardware.generation references unknown generation ${ph.generation}`);
+    }
+    if (ph?.brand && !brands.has(String(ph.brand).toLowerCase())) {
+      errors.push(`${at}.precision_hardware.brand references unknown brand ${ph.brand}`);
+    }
+  }
+
+  for (const [featureKey, feature] of Object.entries(recipe?.features || {})) {
+    for (const k of keysOf(feature?.hardware_overrides)) keyed(`features.${featureKey}.hardware_overrides`, k);
+    for (const [modeKey, mode] of Object.entries(feature?.modes || {})) {
+      const at = `features.${featureKey}.modes.${modeKey}`;
+      for (const k of keysOf(mode?.hardware)) keyed(`${at}.hardware`, k);
+      for (const k of keysOf(mode?.hardware_overrides)) keyed(`${at}.hardware_overrides`, k);
+    }
+  }
+
+  if (errors.length) {
+    const rel = path.relative(ROOT, sourceFile);
+    throw new Error(`Invalid hardware keys in ${rel}:\n  - ${errors.join("\n  - ")}`);
+  }
+}
+
 // Wrap a rendered (command, argv) pair in `docker run`. Returns
 // { docker_command, docker_argv } so each form has its docker counterpart.
 function dockerize(command, argv, env, dockerMeta, port = 8000) {
@@ -704,6 +786,7 @@ let collisionCount = 0;
 for (const file of findYamlFiles(modelsDir)) {
   const r = normalizeDates(readYaml(file));
   validateFeatureModes(r, file);
+  validateHardwareKeys(r, file, taxonomy, strategies);
   // Derive HF identity from path. Only `hf_id` is exposed in the public JSON;
   // `org` and `repo` are trivially `hf_id.split("/")` for consumers.
   const rel = path.relative(modelsDir, file);


### PR DESCRIPTION
## Problem

Hardware lookups are exact string matches — `isHardwareSupported` is `recipe.meta.hardware[hwId] !== "unsupported"`, and `hardwareKeyedValue` resolves the layered keyspace by exact key. So a key that names no taxonomy profile is **silently inert**, and nothing downstream can tell:

- an author's `verified` claim never renders a badge (the pill it targets doesn't exist), and
- an intended `unsupported` opt-out **never disables anything** — the pill stays enabled and selectable.

The second case is the dangerous one: the YAML reads as a deliberate opt-out while the UI happily offers the hardware.

## Change

Adds `validateHardwareKeys`, modeled on the existing `validateFeatureModes` (same throw-on-unknown-reference shape, called right beside it), covering both keyspaces documented in the schema:

| keyspace | accepts | maps checked |
|---|---|---|
| exact | taxonomy profile id only | `meta.hardware`, `meta.default_hardware`, `kv_cache_strategy_hardware.*`, `variants.*.supported_hardware`, the GPU-id half of `strategy_min_gpus` |
| layered | id > generation > brand > `default` | `strategy_hardware.*`, `hardware_overrides`, `variants.*.hardware_overrides`, `variants.*.tp`, `features.*.modes.*.{hardware,hardware_overrides}` |

plus the value vocabulary of `variants.*.precision_hardware.{generation,brand}`.

## What it caught

Five pre-existing keys, all `verified`, all naming **real GPUs the taxonomy doesn't model** — so these aren't typos:

| file | key |
|---|---|
| `models/nvidia/Cosmos3-Nano.yaml` | `a100` |
| `models/nvidia/Cosmos3-Super.yaml` | `a100` |
| `models/nvidia/Cosmos3-Super-Image2Video.yaml` | `a100` |
| `models/inclusionAI/Ling-3.0-flash.yaml` | `h20` |
| `models/tencent/Hy3-preview.yaml` | `mi350x` |

They render nothing today, so this PR removes them rather than leaving dead metadata.

**The alternative is adding `a100` / `h20` / `mi350x` to `taxonomy.yaml`**, which would make the claims real. I didn't do that here because the taxonomy is global: a new profile becomes a pill on all 179 recipes, and since *absent = silent default = assumed to work*, A100 (80 GB, no FP8) would implicitly claim compatibility with every modern recipe until each one is audited. That's a much larger, more opinionated change — happy to open it separately if maintainers prefer that direction, in which case the deletions here can be dropped.

## Test plan

- [x] Before the removals, the new check fails the build as intended: `Invalid hardware keys in models/inclusionAI/Ling-3.0-flash.yaml: - meta.hardware references unknown hardware profile h20`
- [x] After: `✓ JSON API: 179 models (154 with recommended_command, 763 default-hw alternatives, 1443 per-hw renderings), 171 promoted variants, 9 strategies, 2 kv-store deployments, 2 platforms` — identical to the counts on `main`, confirming the removed keys were inert
- [x] The check passes clean across all 179 existing recipes, so the layered keyspaces are not over-constrained