### PR TITLE
GLM5: add Ascend 950DT single-node variant

### DIFF
--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -108,7 +108,7 @@ variants:
           HCCL_INTRA_ROCE_ENABLE: "0"
           DYNAMIC_EPLB: "true"
           OMP_PROC_BIND: "false"
-          OMP_NUM_THREADS: "100"
+          OMP_NUM_THREADS: "16"
           HCCL_BUFFSIZE: "400"
 
 compatible_strategies:

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -12,6 +12,7 @@ meta:
   related_recipes: []
   hardware:
     h200: verified
+    ascend_950dt: verified
 
 model:
   model_id: "zai-org/GLM-5"
@@ -68,6 +69,47 @@ variants:
       - "fp8"
     extra_env:
       VLLM_USE_FLASHINFER_MOE_FP4: "1"
+
+  ascend_w4a4:
+    model_id: "Eco-Tech/GLM-5.1-w4a4c8-mxfp4"
+    precision: mxfp4
+    vram_minimum_gb: 768
+    supported_hardware: [ascend_950dt]
+    description: "MXFP4/W4A4C8 checkpoint for one Ascend 950DT server (8 NPUs)."
+    hardware_overrides:
+      ascend_950dt:
+        docker_image: "swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:v0.23.0-a5"
+        extra_args:
+          - "--quantization"
+          - "ascend"
+          - "--enable-expert-parallel"
+          - "--enable-prefix-caching"
+          - "--max-num-seqs"
+          - "128"
+          - "--max-model-len"
+          - "202752"
+          - "--max-num-batched-tokens"
+          - "8192"
+          - "--gpu-memory-utilization"
+          - "0.95"
+          - "--compilation-config"
+          - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+          - "--hf-overrides"
+          - '{"use_index_cache":true,"index_topk_freq":4}'
+          - "--additional-config"
+          - '{"enable_cpu_binding":true,"multistream_overlap_shared_expert":true,"enable_sparse_c8":true,"enable_dsa_cp":true,"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":50,"algorithm_execution_interval":5,"eplb_policy_type":2,"num_redundant_experts":0}}'
+        extra_env:
+          HCCL_DFS_CONFIG: "task_exception:off,inconsistent_check:off"
+          PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+          HCCL_OP_EXPANSION_MODE: "AIV"
+          VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+          VLLM_ASCEND_ENABLE_PREFETCH_MLP: "1"
+          HCCL_INTRA_PCIE_ENABLE: "1"
+          HCCL_INTRA_ROCE_ENABLE: "0"
+          DYNAMIC_EPLB: "true"
+          OMP_PROC_BIND: "false"
+          OMP_NUM_THREADS: "100"
+          HCCL_BUFFSIZE: "400"
 
 compatible_strategies:
   - single_node_tp
@@ -143,6 +185,13 @@ guide: |
        --served-model-name glm-5-fp8
   ```
 
+  ### Ascend 950DT with MXFP4/W4A4C8
+
+  The `ascend_w4a4` variant is verified on one Ascend 950DT server with eight NPUs.
+  It uses the ModelScope checkpoint `Eco-Tech/GLM-5.1-w4a4c8-mxfp4` and the vLLM Ascend
+  A5 image. Select the `single_node_tep` strategy; the hardware profile supplies the
+  eight-device tensor-parallel width. The variant-specific environment and flags are
+  included by the command builder.
   ## Client Usage
 
   ```python

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -311,6 +311,18 @@ hardware_profiles:
   # `restricted: true` keeps it out of the picker unless a recipe explicitly
   # lists it in `meta.hardware` — Ascend support ships in vllm-ascend and is
   # only declared on validated recipes.
+  ascend_950dt:
+    brand: Huawei
+    generation: npu
+    display_name: "Ascend 950DT"
+    description: "Huawei Ascend 950DT · 8× NPU · 128 GB HBM each · vLLM Ascend backend"
+    gpu_count: 8
+    vram_gb: 1024
+    multi_node: false
+    scalable: false
+    restricted: true
+
+
   ascend_950pr:
     brand: Huawei
     generation: npu

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -315,9 +315,9 @@ hardware_profiles:
     brand: Huawei
     generation: npu
     display_name: "Ascend 950DT"
-    description: "Huawei Ascend 950DT · 8× NPU · 128 GB HBM each · vLLM Ascend backend"
+    description: "Huawei Ascend 950DT · 8× NPU · 96 GB HBM each · vLLM Ascend backend"
     gpu_count: 8
-    vram_gb: 1024
+    vram_gb: 768
     multi_node: false
     scalable: false
     restricted: true


### PR DESCRIPTION
## Summary
- add the restricted `ascend_950dt` hardware profile (8 NPUs, single node)
- add a GLM-5 `ascend_w4a4` variant for `Eco-Tech/GLM-5.1-w4a4c8-mxfp4`
- map the vLLM Ascend A5 image, quantization flags, runtime environment, and single-node guide

## Hardware and validation
This configuration is based on an end-to-end single-node validation on one Ascend 950DT server with 8 NPUs using the vLLM Ascend A5 image:
`swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:v0.23.0-a5`

The variant is restricted to `ascend_950dt` through `supported_hardware`; other hardware variants remain unchanged. The eight-device tensor-parallel width comes from the new taxonomy profile.

## Scope
This PR intentionally targets single-node serving only. It does not add PD or multi-node scenarios, and does not expose internal CI runner labels or local cache paths.

## Validation
- parsed `taxonomy.yaml` and `models/zai-org/GLM-5.yaml` successfully with PyYAML
- verified the diff is limited to the taxonomy and GLM-5 recipe

Closes no issue.