### PR TITLE
Tune Nemotron-3.5-Lightning NVFP4 for DGX Spark

### DIFF
--- a/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
@@ -13,6 +13,7 @@ meta:
   hardware:
     h100: verified
     dgx_spark_gb10: verified
+    rtx_pro_6000: verified
     dgx_station_gb300: verified
 
 model:
@@ -120,6 +121,25 @@ variants:
           - "--max-num-batched-tokens"
           - "32768"
       dgx_spark_gb10:
+        extra_args:
+          - "--attention-backend"
+          - "FLASHINFER"
+          - "--linear-backend"
+          - "marlin"
+          - "--attention-config"
+          - '{"use_trtllm_attention":true}'
+          - "--enable-flashinfer-autotune"
+          - "--mamba-cache-mode"
+          - "none"
+          - "--async-scheduling"
+          - "--enable-chunked-prefill"
+          - "--gpu-memory-utilization"
+          - "0.8"
+          - "--load-format"
+          - "instanttensor"
+          - "--safetensors-load-strategy"
+          - "prefetch"
+      rtx_pro_6000:
         extra_args:
           - "--attention-backend"
           - "FLASHINFER"

--- a/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
@@ -66,11 +66,6 @@ features:
         args:
           - "--speculative-config"
           - '{"method":"dspark","model":"nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark","num_speculative_tokens":3}'
-        hardware_overrides:
-          dgx_spark_gb10:
-            args:
-              - "--speculative-config"
-              - '{"method":"dspark","model":"nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark","num_speculative_tokens":3,"rejection_sample_method":"synthetic","attention_backend":"TRITON_ATTN","quantization":"modelopt_fp4"}'
       mtp:
         label: "MTP"
         description: "Built-in Multi-Token Prediction heads — no extra checkpoint to download."

--- a/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
@@ -66,6 +66,11 @@ features:
         args:
           - "--speculative-config"
           - '{"method":"dspark","model":"nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark","num_speculative_tokens":3}'
+        hardware_overrides:
+          dgx_spark_gb10:
+            args:
+              - "--speculative-config"
+              - '{"method":"dspark","model":"nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark","num_speculative_tokens":3,"rejection_sample_method":"synthetic","attention_backend":"TRITON_ATTN","quantization":"modelopt_fp4"}'
       mtp:
         label: "MTP"
         description: "Built-in Multi-Token Prediction heads — no extra checkpoint to download."
@@ -121,10 +126,23 @@ variants:
           - "32768"
       dgx_spark_gb10:
         extra_args:
+          - "--attention-backend"
+          - "FLASHINFER"
+          - "--linear-backend"
+          - "marlin"
+          - "--attention-config"
+          - '{"use_trtllm_attention":true}'
+          - "--enable-flashinfer-autotune"
+          - "--mamba-cache-mode"
+          - "none"
+          - "--async-scheduling"
+          - "--enable-chunked-prefill"
           - "--gpu-memory-utilization"
-          - "0.7"
+          - "0.8"
           - "--load-format"
-          - "fastsafetensors"
+          - "instanttensor"
+          - "--safetensors-load-strategy"
+          - "prefetch"
       dgx_station_gb300:
         extra_args:
           - "--attention-backend"


### PR DESCRIPTION
Retune the NVFP4 variant of Nemotron 3.5 Lightning on DGX Spark and RTX Pro 6000, which now share the same per-GPU override: the FlashInfer attention backend with TRT-LLM attention, the marlin linear backend, FlashInfer autotune, chunked prefill plus async scheduling, no Mamba cache alignment, 0.8 GPU memory utilization, and instanttensor loading with safetensors prefetch. RTX Pro 6000 is a restricted profile, so it is also declared as verified hardware in meta so the pill shows up.