### PR TITLE
Add DGX Spark, RTX Pro 6000 and RTX 5090 to the browse hardware filter

### DIFF
--- a/src/components/recipes/BrowseList.jsx
+++ b/src/components/recipes/BrowseList.jsx
@@ -81,6 +81,9 @@ const HW_BRANDS = [
       { id: "gb200", label: "GB200" },
       { id: "gb300", label: "GB300" },
       { id: "dgx_station_gb300", label: "DGX Station" },
+      { id: "dgx_spark_gb10", label: "DGX Spark" },
+      { id: "rtx_pro_6000", label: "RTX Pro 6000" },
+      { id: "rtx_5090", label: "RTX 5090" },
     ],
   },
   {


### PR DESCRIPTION
The browse page's hardware filter only listed datacenter parts, so recipes verified on the workstation and desktop profiles had no way to be filtered for even though the taxonomy and several recipes already use them. Add DGX Spark (GB10), RTX Pro 6000 and RTX 5090 as NVIDIA chips alongside DGX Station; between them they already cover 19 verified recipes.