### PR TITLE
[ROCm] Update MiniMax-M3 InferenceX MI355X reproduction

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "MiniMax"
   description: "MiniMax M3 vision-language MoE (427B total / 26B active) for frontier coding, agent toolchains, and 1M-token reasoning via MSA sparse attention — native multimodal (image + video + computer use); BF16 plus MXFP8, NVIDIA Blackwell NVFP4, and AMD MI355X MXFP4 variants. Runs on NVIDIA (Hopper/Blackwell) and AMD CDNA4/CDNA3."
   date_added: 2026-06-12
-  date_updated: 2026-08-03
+  date_updated: 2026-08-29
   difficulty: advanced
   tasks:
     - text
@@ -706,27 +706,72 @@ guide: |
 
   The command above is the default serving configuration. The
   [SemiAnalysis InferenceX](https://inferencex.semianalysis.com/) MI355X
-  benchmark lane for this checkpoint is a separate **high-concurrency benchmark**
-  configuration — not the recipe default. To reproduce that sweep, start from the
-  default command above and apply these deltas:
+  agentic-coding lane for this checkpoint is a **separate benchmark
+  configuration** — single-node, text-only, GPU-resident, and driven by the GQA
+  EAGLE3 draft head. It is not the recipe default and not a general serving
+  recommendation.
 
-  - Use `--tensor-parallel-size 4` (the sweep runs TP4; the default recipe keeps
-    TP8 for KV-cache and multimodal-encoder headroom).
-  - Add `--kv-cache-dtype fp8`.
-  - Use the text-only language-model path with `--no-enable-prefix-caching`,
-    `--language-model-only`, and an explicit `--max-model-len`.
-  - Force the AITER MXFP4 MoE backend with `--moe-backend aiter` plus the AITER
-    MoE env vars below.
-  - Run on a current `vllm/vllm-openai-rocm:nightly` (the lane pins a specific
-    nightly build — don't hard-code a transient tag).
-  - Export INT4 quantized all-reduce before launch:
+  The lane is the `minimaxm3-fp4-mi355x-vllm-agentic-mtp` entry in
+  `configs/amd-master.yaml`, launched by
+  `benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_mtp.sh` in
+  [SemiAnalysisAI/InferenceX](https://github.com/SemiAnalysisAI/InferenceX):
+
+  | Setting | Benchmark lane |
+  |---------|----------------|
+  | Served checkpoint | `amd/MiniMax-M3-MXFP4` |
+  | Hardware | one MI355X node |
+  | Scenario | agentic-coding trace replay |
+  | Parallelism | TP4 and TP2 — no expert parallelism, no KV offload |
+  | TP4 concurrency sweep | 1, 2, 4, 5, 8, 10, 12, 15, 20, 24, 28, 32 |
+  | TP2 concurrency sweep | 1, 2, 5 |
+  | Draft head | `Inferact/MiniMax-M3-EAGLE3-GQA`, 3 speculative tokens |
+  | Attention | `ROCM_AITER_UNIFIED_ATTN` for both the target and the draft |
+  | Model path | text-only (`--language-model-only`), prefix caching enabled |
+
+  Differences from the default command above: TP4/TP2 instead of TP8, the
+  text-only language-model path, `--kv-cache-dtype fp8`, the AITER MXFP4 MoE
+  backend, unified AITER attention instead of `TRITON_ATTN`, and the GQA EAGLE3
+  draft. The lane also pins thinking server-side with
+  `--default-chat-template-kwargs` instead of passing `--reasoning-parser`, and
+  it passes no `--hf-overrides` — the pinned image supplies the sparse-PA
+  index-cache and top-k refresh behavior itself, and re-adding the override
+  would rewrite the served model config.
+
+  Run it on a current official `vllm/vllm-openai-rocm:nightly`. The lane pins one
+  exact nightly digest rather than a release tag: the AITER shuffled KV-cache
+  layout that MiniMax-M3 sparse paged attention relies on was changed by the
+  KV-cache layout standardization in
+  [vllm-project/vllm#51718](https://github.com/vllm-project/vllm/pull/51718),
+  and the nightly restores it. Don't hard-code a transient tag here — the digest
+  validated for these numbers lives in the InferenceX config.
+
+  #### Environment
 
   ```bash
+  # TP4 and TP2 are the only topologies this lane validates.
+  TP_SIZE="${TP_SIZE:-4}"
+  CONC="${CONC:-32}"
+  if [ "$TP_SIZE" -ne 4 ] && [ "$TP_SIZE" -ne 2 ]; then
+    echo "TP_SIZE must be 2 or 4 for this benchmark lane" >&2
+    exit 1
+  fi
+
+  # The AITER page-16 sparse-attention path needs exactly one KV head per TP
+  # rank. MiniMax-M3 has four KV heads, so TP4 takes that fast path while TP2
+  # uses vLLM's supported Triton sparse-attention fallback. Applying the TP4
+  # layout at TP2 is not a valid configuration.
+  if [ "$TP_SIZE" -eq 4 ]; then
+    export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
+  else
+    export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=0
+  fi
+
   # Kernel selection — required to match the benchmarked MoE path.
   # Without these (and `--moe-backend aiter` on the serve command), vLLM's MXFP4
   # MoE oracle selects the TRITON_UNFUSED fallback on gfx950 instead of the
   # AITER_MXFP4_MXFP4 kernel the InferenceX lane actually runs.
   export VLLM_ENGINE_READY_TIMEOUT_S=3600
+  export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
   export VLLM_USE_BREAKABLE_CUDAGRAPH=0
   export VLLM_ROCM_USE_AITER=1
   export VLLM_ROCM_USE_AITER_MOE=1
@@ -738,24 +783,50 @@ guide: |
   export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256
   ```
 
-  The full reproduction serve command is then:
+  #### Serving and evaluation (real target verification)
+
+  This is the form to use for the lane's accuracy evaluation and for any normal
+  serving. The draft's proposals are verified against the real target model:
 
   ```bash
   vllm serve amd/MiniMax-M3-MXFP4 \
     --port "${PORT:-8000}" \
-    --tensor-parallel-size 4 \
+    --tensor-parallel-size "$TP_SIZE" \
     --trust-remote-code \
     --block-size 128 \
-    --no-enable-prefix-caching \
+    --gpu-memory-utilization 0.85 \
+    --enable-chunked-prefill \
+    --max-num-batched-tokens 32768 \
     --language-model-only \
-    --max-model-len "$MAX_MODEL_LEN" \
-    --attention-backend TRITON_ATTN \
+    --enable-prefix-caching \
+    --attention-backend ROCM_AITER_UNIFIED_ATTN \
     --moe-backend aiter \
     --kv-cache-dtype fp8 \
     --tool-call-parser minimax_m3 \
     --enable-auto-tool-choice \
-    --reasoning-parser minimax_m3
+    --default-chat-template-kwargs '{"thinking_mode":"enabled"}' \
+    --max-num-seqs "$((2 * CONC))" \
+    --stream-interval 20 \
+    --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "ROCM_AITER_UNIFIED_ATTN"}'
   ```
+
+  #### Throughput measurement only (synthetic acceptance)
+
+  The throughput arm of the sweep replaces only the `--speculative-config` with
+  a synthetic rejection sampler so that every concurrency point is measured
+  against the same acceptance rate:
+
+  ```bash
+    --speculative-config '{"method": "eagle3", "model": "Inferact/MiniMax-M3-EAGLE3-GQA", "num_speculative_tokens": 3, "attention_backend": "ROCM_AITER_UNIFIED_ATTN", "rejection_sample_method": "synthetic", "synthetic_acceptance_length": 2.78}'
+  ```
+
+  `2.78` is **not** a tuning knob and **not** a production shortcut. It is the
+  committed golden EAGLE3-GQA acceptance length for MiniMax-M3 with thinking
+  enabled at 3 speculative tokens, taken from
+  [`golden_al_distribution/minimaxm3_eagle3_gqa.yaml`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/golden_al_distribution/minimaxm3_eagle3_gqa.yaml).
+  Synthetic rejection standardizes throughput comparisons; it bypasses real
+  verification, so it must never be used for accuracy evaluation or for serving
+  users. Use the real-verification form above for everything else.
 
   Selecting the AITER MXFP4 MoE backend (`--moe-backend aiter`) is a
   kernel-selection choice (same MXFP4 math, faster kernel), not a precision
@@ -764,6 +835,14 @@ guide: |
   pending accuracy validation**. Performance figures on the InferenceX dashboard
   are **reported externally by SemiAnalysis and have not been reproduced in this
   repository.**
+
+  #### References for this benchmark lane
+
+  - Source PR: [SemiAnalysisAI/InferenceX#2781](https://github.com/SemiAnalysisAI/InferenceX/pull/2781)
+  - Full sweep run: [actions/runs/33239952571](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33239952571)
+  - Agentic eval job: [job/99067626974](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33239952571/job/99067626974)
+  - Golden GQA acceptance-length curve: [`minimaxm3_eagle3_gqa.yaml`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/golden_al_distribution/minimaxm3_eagle3_gqa.yaml)
+  - KV-cache layout change the image pin compensates for: [vllm-project/vllm#51718](https://github.com/vllm-project/vllm/pull/51718)
 
   ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Update the existing MiniMax-M3 MXFP4 guide with the current SemiAnalysis InferenceX MI355X single-node agentic reproduction configuration.
- Document TP2/TP4 layout behavior, unified AITER attention for the target and the GQA EAGLE3 draft, prefix caching, and the current GPU-only sweep.
- Separate benchmark-only synthetic acceptance from real target-verification serving/evaluation.
- Keep the normal recipe command builder and other hardware/variants unchanged.

## Source configuration

- InferenceX PR: https://github.com/SemiAnalysisAI/InferenceX/pull/2781
- InferenceX head at the time of writing: `4c00a7d1e6a375219cdd6c1c00f2d40a29b6b38e`
- Validated image: `vllm/vllm-openai-rocm:nightly-6d4562c59b97b4e35d459ff9389e71b6fe4995de`
- Full sweep: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33239952571
- Agentic eval: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33239952571/job/99067626974
- Golden GQA AL: https://github.com/SemiAnalysisAI/InferenceX/blob/main/golden_al_distribution/minimaxm3_eagle3_gqa.yaml
- Related vLLM change: https://github.com/vllm-project/vllm/pull/51718

**Which SHA validated what.** The full sweep and the agentic eval job both ran at `a7195ba7cfe15365bd867828f73abca3873ea973`, not at the current head. The only commit after that point, `4c00a7d1e6a375219cdd6c1c00f2d40a29b6b38e`, touches `perf-changelog.yaml` and nothing else, so the benchmark script, config matrix, image pin, model, draft model, acceptance mode, and topology this guide documents are byte-identical to the state the sweep validated. `check-changelog` is green at the current head.

The configuration documented here comes from `configs/amd-master.yaml` (`minimaxm3-fp4-mi355x-vllm-agentic-mtp`) and `benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_mtp.sh` at that head:

| Area | Documented behavior |
|---|---|
| Served checkpoint | `amd/MiniMax-M3-MXFP4` |
| Hardware | one MI355X node |
| Parallelism | TP4 and TP2, no expert parallelism, no KV offload |
| TP4 sweep | 1, 2, 4, 5, 8, 10, 12, 15, 20, 24, 28, 32 |
| TP2 sweep | 1, 2, 5 |
| Draft | `Inferact/MiniMax-M3-EAGLE3-GQA`, 3 speculative tokens |
| Attention | `ROCM_AITER_UNIFIED_ATTN` for the target and inside `--speculative-config` |
| Sparse layout | `VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1` at TP4, `0` at TP2 |

### What changed relative to the previously documented reproduction

The section merged in #846 has since gone stale in five ways, all fixed here:

- it described the sweep as TP4-only; the lane also runs TP2, with a different KV-cache layout;
- it instructed `--no-enable-prefix-caching`; prefix caching is enabled;
- it used `TRITON_ATTN` for the target and said nothing about the draft; both are now `ROCM_AITER_UNIFIED_ATTN`;
- it required an explicit `--max-model-len`; the script no longer sets one;
- it did not document the EAGLE3 draft, the synthetic-acceptance throughput arm, or `--hf-overrides` (which has been removed — re-adding it would rewrite the served model config).

Following the review feedback on #846, `--max-num-seqs` is parameterized as `"$((2 * CONC))"` rather than hard-coded, and `TP_SIZE` is validated so the TP4-only layout setting cannot silently be applied at TP2.

## Scope and non-goals

- One source file: `models/MiniMaxAI/MiniMax-M3.yaml`.
- This documents a separate InferenceX benchmark path; it does not change the general TP8/default serving configuration.
- Guide-only by design, consistent with the maintainer direction on #824 that a benchmark-specific agentic configuration belongs in the guide. The recipe-wide AMD `hardware_overrides` keeps `TRITON_ATTN`: promoting the lane's knobs into `variants.mxfp4.hardware_overrides.mi355x` would also change generated commands for unvalidated TP8, multimodal, and multi-node combinations, and the schema cannot express the narrow intersection of variant=mxfp4 x hardware=mi355x x strategy=single_node_tp x spec mode=eagle3_gqa x the validated TP2/TP4 topology.
- Synthetic acceptance length `2.78` is used only for comparable InferenceX throughput measurement, and is the committed golden EAGLE3-GQA value for thinking-enabled at 3 speculative tokens. Eval and normal serving use real target verification.
- Evidence covers the EAGLE3-**GQA** draft head only; no claim is made about the non-GQA EAGLE3 path.
- No claim that this repository independently reproduced the performance results. The published numbers are reported by SemiAnalysis.
- No MI355X benchmark was re-run for this PR; validation here is structural and render-level, plus the linked InferenceX run.

## Validation

- [x] `node scripts/build-recipes-api.mjs` — `✓ JSON API: 180 models ... 9 strategies`, no recipe errors
- [x] `pnpm build` — succeeded, prerendered `/MiniMaxAI/MiniMax-M3`
- [x] `git diff --check` and `git diff --cached --check` — clean
- [x] Previewed `/MiniMaxAI/MiniMax-M3` on `pnpm dev` — table, four sub-headings, code blocks, and all five reference links render correctly; long lines scroll rather than clip
- [x] Confirmed the default generated MI355X/MXFP4 command is unchanged — diffed the whole generated `public/MiniMaxAI/` tree against a pre-edit build: every per-hardware and per-strategy rendering is byte-identical, and the only differences anywhere are the `guide` string and `meta.date_updated`
- [x] `bash -n` on each fenced command block extracted from the new subsection, plus an execution check that `TP_SIZE=4` sets the layout to `1`, `TP_SIZE=2` sets it to `0`, and `TP_SIZE=8` is rejected
- [x] Confirmed only the intended YAML is staged; no `public/`, `node_modules/`, or lockfile churn

Not run: `pnpm validate` and `pnpm lint` both fail on `main` before this change and for reasons unrelated to it — `package.json` points `validate` at `hooks/validate.mjs`, which is not tracked in the repository, and `next lint` has no ESLint config to load so it drops into an interactive prompt. This PR touches no JavaScript.

Made with [Cursor](https://cursor.com)