### PR TITLE
Enable the Offloading options on Qwen3.8-27B

### DIFF
--- a/models/Qwen/Qwen3.8-27B.yaml
+++ b/models/Qwen/Qwen3.8-27B.yaml
@@ -212,6 +212,10 @@ variants:
 # loads. There is no schema mechanism to gate a strategy by node count, so offering it at
 # all would ship a command that cannot start. It costs nothing: 51.7 GiB of BF16 weights fit
 # one GPU, so nothing here needs a second node.
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 compatible_strategies:
   - single_node_tp
 


### PR DESCRIPTION
Marks `kv_offload_support` verified on `Qwen/Qwen3.8-27B`, following #778.

**Validated** on 1xH200 (TP1, BF16 default variant, vLLM `0.1.dev19754+g3a0914114` from the recipe's own `vllm/vllm-openai:qwen38` image, recipe defaults at the full 262,144 context): serve with the option's `--kv-transfer-config`, send a greedy prompt, confirm `kv_offload_store_bytes` > 0, reset the prefix cache, resend, confirm `kv_offload_load_bytes` > 0 and that the tokens come back from the tier.

| config | store | load |
|---|---|---|
| `offloading_cpu` | 12,432,048,128 | 10,429,988,864 |
| `offloading_fs` | 12,432,048,128 | 10,429,988,864 |

Hybrid attention is the part worth checking here: with linear attention on 48 of 64 layers, vLLM resolves the full-attention block size to 784 to match the GDN page size (`cache_config_info{block_size="784", mamba_block_size="16"}` in both runs), and `CPUOffloadingSpec` and `TieringOffloadingSpec` both accept that block size. On the replay `prefix_cache_hits_total` was 0 against 156,800 `external_prefix_cache_hits_total`, so the read-back came from the tier and not a warm GPU cache; under `offloading_fs` the node's `/mnt/kv_cache` held 16 GB across 84 files.

Scope is `Qwen3.8-27B` only — `Qwen3.8-Flash-Next` and `Qwen3.8-2.4T-A95B` are separate recipes and were not exercised.
