### PR TITLE
Fix deprecated flashinfer-autotune flag in DeepSeek-V3.2 recipe

### DIFF
--- a/models/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2.yaml
@@ -24,7 +24,7 @@ model:
   supports_dcp: true
   base_args:
     - "--trust-remote-code"
-    - "--kernel-config.enable_flashinfer_autotune=False"
+    - "--no-enable-flashinfer-autotune"
   base_env: {}
 
 dependencies:
@@ -117,7 +117,7 @@ guide: |
   vllm serve deepseek-ai/DeepSeek-V3.2 \
     --tensor-parallel-size 8 \
     --trust-remote-code \
-    --kernel-config.enable_flashinfer_autotune=False \
+    --no-enable-flashinfer-autotune \
     --tokenizer-mode deepseek_v32 \
     --tool-call-parser deepseek_v32 \
     --enable-auto-tool-choice \


### PR DESCRIPTION
## Summary
- The DeepSeek-V3.2 recipe used `--kernel-config.enable_flashinfer_autotune=False`, a dotted KernelConfig CLI override.
- vLLM added a dedicated top-level flag for this in vllm-project/vllm#34006 (`--enable-flashinfer-autotune` / `--no-enable-flashinfer-autotune`), which the newer DeepSeek-V4 recipes already use. Replaced both occurrences (`base_args` and the guide's example command) with `--no-enable-flashinfer-autotune`.

## Test plan
- `node scripts/build-recipes-api.mjs` equivalent: parsed the YAML with `python3 -c "import yaml; yaml.safe_load(...)"` — valid.
- On a machine with an NVIDIA GPU (RTX 3090, vLLM 0.28.0 installed via `uv pip install vllm`):
  - `vllm serve --help=KernelConfig` shows `--enable-flashinfer-autotune, --no-enable-flashinfer-autotune` as a live flag.
  - `vllm serve --help=all` has zero matches for `--kernel-config.` — the old dotted override doesn't exist in the current CLI.
  - `EngineArgs.add_cli_args(...).parse_args(['--trust-remote-code', '--no-enable-flashinfer-autotune'])` parses cleanly, setting `enable_flashinfer_autotune = False`.

AI assistance was used to review this recipe and prepare this change; I reviewed the diff and the test output above myself.