### PR TITLE
Enable the Offloading options on GLM-5.3

### DIFF
--- a/models/zai-org/GLM-5.3.yaml
+++ b/models/zai-org/GLM-5.3.yaml
@@ -76,6 +76,10 @@ compatible_strategies:
   - multi_node_dep
   - pd_cluster
 
+kv_offload_support:
+  offloading_cpu: verified
+  offloading_fs: verified
+
 hardware_overrides:
   hopper:
     # H100/H200 use plain fp8 KV cache; Blackwell keeps base_args' fp8_e4m3.


### PR DESCRIPTION
Marks `kv_offload_support` verified on `zai-org/GLM-5.3`, matching its `GLM-5.2` sibling and following #778.

**Validated** on 8xH200 (TP8, vLLM `0.28.0` from the recipe's own image, recipe's `--kv-cache-dtype fp8_e4m3` plus the Hopper override to `fp8`): serve with the option's `--kv-transfer-config`, send a greedy prompt, confirm `kv_offload_store_bytes` > 0, reset the prefix cache, resend, confirm `kv_offload_load_bytes` > 0 and that the tokens come back from the tier.

| config | prompt tokens | store | load |
|---|---|---|---|
| `offloading_cpu` | 138,615 | 59,763,793,920 | 59,763,793,920 |
| `offloading_fs` | 44,498 | 19,111,157,760 | 19,111,157,760 |

The two rows use different prompt sizes, so the byte gap between them is prompt length rather than a difference between the configs — both work out to ~430 KB of KV per token. Both runs returned identical output across the reset, with `prefix_cache_hits_total` at 0 for the fresh prefix, so the read-back came from the tier rather than a warm GPU cache. Under `offloading_fs` the node's `/mnt/kv_cache` held 112 GB across 1,084 files.

Two things worth recording for anyone serving this recipe on Hopper:

- **`--max-model-len` is required on 8xH200, independent of offloading.** FP8 weights take 94.46 GiB per rank, leaving 25.94 GiB of KV, while the model's native 1,048,576-token context needs 52.68 GiB for a single request — vLLM refuses to start. The guide's "FP8 on 8xH200 (standard)" command sets no `--max-model-len`, and only the B200 section discusses the context-fitting lever. These runs used `--max-model-len 262144`, which sizes the GPU KV cache at 604,096 tokens.
- **`offloading_fs` promotions are bounded by `cpu_bytes_to_use`.** Every filesystem-tier promotion stages through the option's 34.36 GB DRAM tier. At ~430 KB of KV per token, a 110,764-token prefix stores 47.7 GB and does not fit: the blocks reach disk and the fs tier reports lookup hits, but the promotion cannot allocate, `CPU_to_GPU` transfers stay at 0 and the prefix is recomputed. The `offloading_fs` row above uses a 44,498-token prefix, which does promote — `load_bytes` 19,111,157,760 with identical output, against `load_bytes` 0 on the large one. Allocation failures are counted in both cases; what separates them is whether the promotion completes. `offloading_cpu` has no such limit at its 512 GiB default.

`node scripts/build-recipes-api.mjs` passes: `✓ JSON API: 180 models (...), 181 promoted variants, 9 strategies, ...`

Not a duplicate: no open PR touches `kv_offload_support` on any GLM-5.3 recipe (checked `gh pr list --repo vllm-project/recipes --state open --search offload` and `--search GLM-5.3`). Scope is `zai-org/GLM-5.3` only — `GLM-5.3-Flash` is a separate recipe and was not exercised.
