### PR TITLE
Update deprecated `reasoning_content` references to `reasoning`

### DIFF
--- a/models/LiquidAI/LFM2.5-1.2B-Thinking.yaml
+++ b/models/LiquidAI/LFM2.5-1.2B-Thinking.yaml
@@ -29,7 +29,7 @@ model:
 
 features:
   reasoning:
-    description: "Split the model's <think>…</think> chain-of-thought into a separate reasoning_content field via vLLM's qwen3 parser"
+    description: "Split the model's <think>…</think> chain-of-thought into a separate reasoning field via vLLM's qwen3 parser"
     args:
       - "--reasoning-parser"
       - "qwen3"
@@ -71,7 +71,7 @@ guide: |
 
   ### Key Features
   - **Hybrid backbone**: Gated short convolutions interleaved with grouped-query attention — a smaller KV cache and lower decode latency than a same-size full-attention transformer.
-  - **`<think>` reasoning**: Emits an explicit `<think>…</think>` chain-of-thought on non-trivial problems; vLLM's `qwen3` parser splits it into a separate `reasoning_content` field.
+  - **`<think>` reasoning**: Emits an explicit `<think>…</think>` chain-of-thought on non-trivial problems; vLLM's `qwen3` parser splits it into a separate `reasoning` field.
   - **32K context**: 32,768-token context window.
   - **Tool calling**: Pythonic tool calls surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
   - **Native vLLM support**: Served via the `Lfm2ForCausalLM` architecture.
@@ -109,7 +109,7 @@ guide: |
   ## Deployment Configurations
 
   ### Quick Start (Single GPU, BF16)
-  Enable the reasoning parser so the chain-of-thought is returned in `reasoning_content`:
+  Enable the reasoning parser so the chain-of-thought is returned in `reasoning`:
   ```bash
   vllm serve LiquidAI/LFM2.5-1.2B-Thinking \
     --reasoning-parser qwen3
@@ -152,12 +152,12 @@ guide: |
       extra_body={"top_k": 50, "repetition_penalty": 1.05},
   )
   msg = response.choices[0].message
-  print("reasoning:", msg.reasoning_content)
+  print("reasoning:", msg.reasoning)
   print("answer:", msg.content)
   ```
 
   > **Note**: the model opens the `<think>` channel for non-trivial problems; a simple prompt may
-  > be answered directly, in which case `reasoning_content` is empty. That is expected behavior —
+  > be answered directly, in which case `reasoning` is empty. That is expected behavior —
   > the `qwen3` parser extracts the block whenever it is present.
 
   ### Tool Calling

--- a/models/LiquidAI/LFM2.5-8B-A1B.yaml
+++ b/models/LiquidAI/LFM2.5-8B-A1B.yaml
@@ -29,7 +29,7 @@ model:
 
 features:
   reasoning:
-    description: "Split the model's <think>…</think> chain-of-thought into a separate reasoning_content field via vLLM's qwen3 parser"
+    description: "Split the model's <think>…</think> chain-of-thought into a separate reasoning field via vLLM's qwen3 parser"
     args:
       - "--reasoning-parser"
       - "qwen3"
@@ -71,7 +71,7 @@ guide: |
 
   ### Key Features
   - **Hybrid + MoE**: Gated short convolutions + grouped-query attention with sparse expert FFNs — ~1B active parameters per token out of ~8B total.
-  - **`<think>` reasoning**: Emits an explicit `<think>…</think>` chain-of-thought on non-trivial problems; vLLM's `qwen3` parser splits it into `reasoning_content`.
+  - **`<think>` reasoning**: Emits an explicit `<think>…</think>` chain-of-thought on non-trivial problems; vLLM's `qwen3` parser splits it into `reasoning`.
   - **Tool calling**: Pythonic tool calls surfaced as OpenAI `tool_calls` by vLLM's native `lfm2` parser.
   - **128K context**: Long-context support (`max_position_embeddings = 128000`).
   - **Native vLLM support**: Served via the `Lfm2MoeForCausalLM` architecture.
@@ -160,12 +160,12 @@ guide: |
       extra_body={"top_k": 80, "repetition_penalty": 1.05},
   )
   msg = response.choices[0].message
-  print("reasoning:", msg.reasoning_content)
+  print("reasoning:", msg.reasoning)
   print("answer:", msg.content)
   ```
 
   > **Note**: the model opens the `<think>` channel for non-trivial problems; a simple prompt may
-  > be answered directly, in which case `reasoning_content` is empty. That is expected behavior —
+  > be answered directly, in which case `reasoning` is empty. That is expected behavior —
   > the `qwen3` parser extracts the block whenever it is present.
 
   ### Tool Calling

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -489,7 +489,7 @@ guide: |
     based on the task.
 
   Pass it per request through `chat_template_kwargs`. The same value also tunes
-  the `minimax_m3` reasoning parser, so `reasoning_content` and `content` are
+  the `minimax_m3` reasoning parser, so `reasoning` and `content` are
   split correctly in every mode.
 
   ```python
@@ -506,9 +506,7 @@ guide: |
       extra_body={"chat_template_kwargs": {"thinking_mode": "enabled"}},
   )
   msg = response.choices[0].message
-  # vLLM exposes the <mm:think> block as `reasoning` (the older
-  # `reasoning_content` field is deprecated but still aliased).
-  print(getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None))
+  print(msg.reasoning)  # the <mm:think> block
   print(msg.content)  # the final answer
   ```
 

--- a/models/arcee-ai/Trinity-Large-Thinking.yaml
+++ b/models/arcee-ai/Trinity-Large-Thinking.yaml
@@ -136,7 +136,7 @@ guide: |
   )
 
   msg = response.choices[0].message
-  reasoning = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
+  reasoning = msg.reasoning
   print("reasoning:", reasoning)
   print("content:", msg.content)
   print("tool_calls:", msg.tool_calls)
@@ -160,7 +160,7 @@ guide: |
   ```
 
   Rules:
-  - Pass reasoning back as `reasoning` (even if your client exposes it as `reasoning_content`).
+  - Pass reasoning back as `reasoning`.
   - Keep `content` as an empty string (not `null`) on tool-only turns.
   - Append the assistant message before tool-result messages.
   - Use `/v1/chat/completions` for structured reasoning output.

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -39,7 +39,7 @@ features:
       - "--tool-call-parser"
       - "ling3"
   reasoning:
-    description: "Split Ling 3 thinking traces into reasoning_content"
+    description: "Split Ling 3 thinking traces into reasoning"
     args:
       - "--reasoning-parser"
       - "ling3"
@@ -298,7 +298,8 @@ guide: |
       max_tokens=200000,
       extra_body={"chat_template_kwargs": {"enable_thinking": True}},
   )
-  print(response.choices[0].message.reasoning_content)
+  msg = response.choices[0].message
+  print(msg.reasoning)
   print(response.choices[0].message.content)
   ```
 

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -300,7 +300,7 @@ guide: |
   )
   msg = response.choices[0].message
   print(msg.reasoning)
-  print(response.choices[0].message.content)
+  print(msg.content)
   ```
 
   When serving a quantized variant, set `model` in the client request to the

--- a/models/inclusionAI/Ling-3.0-tiny.yaml
+++ b/models/inclusionAI/Ling-3.0-tiny.yaml
@@ -38,7 +38,7 @@ features:
       - "--tool-call-parser"
       - "ling3"
   reasoning:
-    description: "Split Ling 3 thinking traces into reasoning_content"
+    description: "Split Ling 3 thinking traces into reasoning"
     args:
       - "--reasoning-parser"
       - "ling3"
@@ -150,8 +150,9 @@ guide: |
           "chat_template_kwargs": {"enable_thinking": True},
       },
   )
-  print(response.choices[0].message.reasoning_content)
-  print(response.choices[0].message.content)
+  msg = response.choices[0].message
+  print(msg.reasoning)
+  print(msg.content)
   ```
 
   Set `enable_thinking` to `false` for direct answers. When using a quantized

--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -64,7 +64,7 @@ features:
       - "--tool-call-parser"
       - "muse_glimmer"
   reasoning:
-    description: "Channel-scoped chain-of-thought. Surfaces as `message.reasoning` (non-streaming) and `delta.reasoning` (streaming) — note this model uses `reasoning`, not `reasoning_content`. Effort is controlled by a `Reasoning strength: <low|medium|high|xhigh>` line in the system prompt."
+    description: "Channel-scoped chain-of-thought. Surfaces as `message.reasoning` (non-streaming) and `delta.reasoning` (streaming). Effort is controlled by a `Reasoning strength: <low|medium|high|xhigh>` line in the system prompt."
     args:
       - "--reasoning-parser"
       - "muse_glimmer"

--- a/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
+++ b/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
@@ -161,7 +161,7 @@ guide: |
   )
   for chunk in stream:
       delta = chunk.choices[0].delta
-      rc = getattr(delta, "reasoning_content", None)
+      rc = getattr(delta, "reasoning", getattr(delta, "reasoning_content", None))
       if rc:
           print(rc, end="", flush=True)
       if delta.content:

--- a/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
+++ b/models/mistralai/Ministral-3-8B-Reasoning-2512.yaml
@@ -161,6 +161,7 @@ guide: |
   )
   for chunk in stream:
       delta = chunk.choices[0].delta
+      # vLLM 0.11.0 uses reasoning_content; 0.11.1+ uses reasoning.
       rc = getattr(delta, "reasoning", getattr(delta, "reasoning_content", None))
       if rc:
           print(rc, end="", flush=True)

--- a/models/mistralai/Mistral-Medium-3.5-128B.yaml
+++ b/models/mistralai/Mistral-Medium-3.5-128B.yaml
@@ -101,7 +101,7 @@ guide: |
 
   Reasoning is opt-in per request via `reasoning_effort: "high"` — when set,
   the model emits `[THINK]...[/THINK]` blocks that the Mistral reasoning
-  parser surfaces as `message.reasoning_content`. Tool calling uses the
+  parser surfaces as `message.reasoning`. Tool calling uses the
   `[AVAILABLE_TOOLS]` / `[TOOL_CALLS]` chat-template tokens.
 
   ## Prerequisites
@@ -177,7 +177,7 @@ guide: |
       temperature=0.7, max_tokens=4096,
   )
   msg = resp.choices[0].message
-  print("reasoning:", getattr(msg, "reasoning_content", None))
+  print("reasoning:", msg.reasoning)
   print("answer:", msg.content)
   ```
 

--- a/models/mistralai/Mistral-Small-4-119B-2603.yaml
+++ b/models/mistralai/Mistral-Small-4-119B-2603.yaml
@@ -38,7 +38,7 @@ features:
       - "--tool-call-parser"
       - "mistral"
   reasoning:
-    description: "Mistral reasoning parser extracts [THINK]...[/THINK] into message.reasoning_content (emitted when reasoning_effort='high')"
+    description: "Mistral reasoning parser extracts [THINK]...[/THINK] into message.reasoning (emitted when reasoning_effort='high')"
     args:
       - "--reasoning-parser"
       - "mistral"
@@ -196,7 +196,7 @@ guide: |
       temperature=0.7, max_tokens=4096,
   )
   msg = resp.choices[0].message
-  print("reasoning:", getattr(msg, "reasoning_content", None))
+  print("reasoning:", msg.reasoning)
   print("answer:", msg.content)
   ```
 

--- a/models/poolside/Laguna-M.1.yaml
+++ b/models/poolside/Laguna-M.1.yaml
@@ -76,7 +76,7 @@ guide: |
   - **Large sparse MoE**: 70-layer transformer — the first 3 layers are dense SwiGLU, the remaining 67 are sparse MoE with **256 experts + 1 shared expert** and top-k=16 routing with auxiliary-loss-free load balancing.
   - **Global attention**: global attention across all layers with 64 Q-heads, 8 KV-heads, head dim 128, and softplus attention output gating.
   - **256K context**: RoPE with YaRN extends the context window to 262,144 tokens.
-  - **Native interleaved reasoning**: thinking blocks emitted before and between tool calls, with *preserved thinking* (returning prior `reasoning_content` in history) recommended for best agentic performance. Toggled per-request via `enable_thinking`.
+  - **Native interleaved reasoning**: thinking blocks emitted before and between tool calls, with *preserved thinking* (returning prior `reasoning` in history) recommended for best agentic performance. Toggled per-request via `enable_thinking`.
   - **Tool calling**: Poolside-specific tool-call protocol, parsed via `poolside_v1`.
 
   ## Prerequisites
@@ -106,7 +106,7 @@ guide: |
 
   ## Controlling reasoning
 
-  Reasoning is enabled at the server when you pass `--default-chat-template-kwargs '{"enable_thinking": true}'` (included above). Poolside recommends **preserved thinking** for agentic coding — return the previous assistant turn's `reasoning_content` in the message history.
+  Reasoning is enabled at the server when you pass `--default-chat-template-kwargs '{"enable_thinking": true}'` (included above). Poolside recommends **preserved thinking** for agentic coding — return the previous assistant turn's `reasoning` in the message history.
 
   ```python
   from openai import OpenAI
@@ -121,8 +121,9 @@ guide: |
   )
   for chunk in resp:
       delta = chunk.choices[0].delta
-      if getattr(delta, "reasoning_content", None):
-          print(delta.reasoning_content, end="")
+      rc = delta.reasoning
+      if rc:
+          print(rc, end="")
       if delta.content:
           print(delta.content, end="")
   ```

--- a/models/poolside/Laguna-S-2.1.yaml
+++ b/models/poolside/Laguna-S-2.1.yaml
@@ -206,7 +206,7 @@ guide: |
       top_p=1.0,
       extra_query={"top_k": 20},
   )
-  print(resp.choices[0].message.reasoning_content)
+  print(resp.choices[0].message.reasoning)
   print(resp.choices[0].message.content)
   ```
 

--- a/models/poolside/Laguna-XS-2.1.yaml
+++ b/models/poolside/Laguna-XS-2.1.yaml
@@ -172,7 +172,7 @@ guide: |
       top_p=1.0,
       extra_query={"top_k": 20},
   )
-  print(resp.choices[0].message.reasoning_content)
+  print(resp.choices[0].message.reasoning)
   print(resp.choices[0].message.content)
   ```
 

--- a/models/poolside/Laguna-XS.2.yaml
+++ b/models/poolside/Laguna-XS.2.yaml
@@ -206,7 +206,7 @@ guide: |
       top_p=1.0,
       extra_query={"top_k": 20},
   )
-  print(resp.choices[0].message.reasoning_content)
+  print(resp.choices[0].message.reasoning)
   print(resp.choices[0].message.content)
   ```
 

--- a/models/tencent/Hy3-preview.yaml
+++ b/models/tencent/Hy3-preview.yaml
@@ -267,7 +267,7 @@ guide: |
       },
   )
   output_msg = resp_think.choices[0].message
-  print(output_msg.reasoning_content)  # chain-of-thought
+  print(output_msg.reasoning)  # chain-of-thought
   print(output_msg.content)             # final answer
   ```
 

--- a/models/tencent/Hy3-preview.yaml
+++ b/models/tencent/Hy3-preview.yaml
@@ -267,7 +267,7 @@ guide: |
       },
   )
   output_msg = resp_think.choices[0].message
-  print(output_msg.reasoning)  # chain-of-thought
+  print(output_msg.reasoning)           # chain-of-thought
   print(output_msg.content)             # final answer
   ```
 

--- a/models/tencent/Hy3.yaml
+++ b/models/tencent/Hy3.yaml
@@ -339,7 +339,7 @@ guide: |
       },
   )
   output_msg = resp_think.choices[0].message
-  print(output_msg.reasoning_content)  # chain-of-thought
+  print(output_msg.reasoning)  # chain-of-thought
   print(output_msg.content)             # final answer
   ```
 

--- a/models/tencent/Hy3.yaml
+++ b/models/tencent/Hy3.yaml
@@ -339,7 +339,7 @@ guide: |
       },
   )
   output_msg = resp_think.choices[0].message
-  print(output_msg.reasoning)  # chain-of-thought
+  print(output_msg.reasoning)           # chain-of-thought
   print(output_msg.content)             # final answer
   ```
 

--- a/models/tencent/Hy4-preview.yaml
+++ b/models/tencent/Hy4-preview.yaml
@@ -170,7 +170,7 @@ guide: |
       top_p=1.0,
   )
   output_msg = response.choices[0].message
-  print(output_msg.reasoning_content)  # chain-of-thought
+  print(output_msg.reasoning)  # chain-of-thought
   print(output_msg.content)             # final answer
   ```
 

--- a/models/tencent/Hy4-preview.yaml
+++ b/models/tencent/Hy4-preview.yaml
@@ -170,7 +170,7 @@ guide: |
       top_p=1.0,
   )
   output_msg = response.choices[0].message
-  print(output_msg.reasoning)  # chain-of-thought
+  print(output_msg.reasoning)           # chain-of-thought
   print(output_msg.content)             # final answer
   ```
 


### PR DESCRIPTION
[vLLM v0.28.0](https://github.com/vllm-project/vllm/releases/tag/v0.28.0) renamed the reasoning output field from `reasoning_content` to `reasoning`. Updated 13 recipes that read the old field directly. This PR replace `reasoning_content` with `reasoning` for fresh ci across 13-models.

- Files: Mistral-Small-4-119B-2603, Ministral-3-8B-Reasoning-2512, Mistral-Medium-3.5-128B, Hy3-preview, Hy3, Hy4-preview, Laguna-XS.2, Laguna-XS-2.1, Laguna-S-2.1, Laguna-M.1, LFM2.5-8B-A1B, LFM2.5-1.2B-Thinking, Ling-3.0-flash
- Validated with `node scripts/build-recipes-api.mjs`