### PR TITLE
[Model] Add Ling-3.0-tiny and extend Ling-3.0-flash with FP4 and DSpark

### DIFF
--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -2,14 +2,15 @@ meta:
   title: "Ling-3.0-flash"
   slug: "ling-3-0-flash"
   provider: "inclusionAI"
-  description: "Ling-3.0-flash MoE model with BF16, serialized block-FP8 and compressed-tensors int4 checkpoints, 124B total / 5.5B active parameters, and a 3.1B MTP layer"
-  date_updated: 2026-08-25
+  description: "Ling-3.0-flash MoE model with BF16, FP8, FP4, and INT4 checkpoints, native MTP, and an external DSpark draft model"
+  date_updated: 2026-08-31
   difficulty: advanced
   tasks:
     - text
-  performance_headline: "BF16 is validated on 4x NVIDIA H20; serialized FP8 defaults to TP2 on NVIDIA H200, with TP4+EP4 also validated"
+  performance_headline: "BF16, FP8, FP4, and INT4 support NVIDIA H20/H200; DGX Spark verified TP1 FP4/INT4"
   hardware:
     h200: verified
+    dgx_spark_gb10: verified
 
 model:
   model_id: "inclusionAI/Ling-3.0-flash"
@@ -43,10 +44,21 @@ features:
       - "--reasoning-parser"
       - "ling3"
   spec_decoding:
-    description: "Use the model's native MTP head with three speculative tokens"
-    args:
-      - "--speculative-config"
-      - '{"method":"mtp","num_speculative_tokens":3}'
+    description: "Speculative decoding with the built-in MTP head or the external Ling DSpark draft model"
+    default_mode: mtp
+    modes:
+      mtp:
+        label: "MTP"
+        description: "Use the target checkpoint's native MTP head with three speculative tokens."
+        args:
+          - "--speculative-config"
+          - '{"method":"mtp","num_speculative_tokens":3}'
+      dspark:
+        label: "DSpark"
+        description: "Use inclusionAI/Ling-3.0-flash-dspark as an external draft model with any Ling-3.0-flash target variant. K may be 1-8; this recipe recommends K7."
+        args:
+          - "--speculative-config"
+          - '{"method":"dspark","model":"inclusionAI/Ling-3.0-flash-dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic","attention_backend":"FLASH_ATTN","enable_adaptive_verification":false}'
 
 opt_in_features:
   - spec_decoding
@@ -60,15 +72,25 @@ variants:
     model_id: "inclusionAI/Ling-3.0-flash-fp8"
     precision: fp8
     vram_minimum_gb: 150
-    min_vllm_version: "0.26.0"
     tp: 2
-    description: "Serialized block-FP8 checkpoint; defaults to TP2 on NVIDIA H200, with TP4+EP4 as a validated alternative"
+    description: "Serialized block-FP8 checkpoint; defaults to TP2 on NVIDIA H20/H200, with TP4+EP4 as a validated alternative"
+  fp4:
+    model_id: "inclusionAI/Ling-3.0-flash-fp4"
+    precision: fp4
+    # The checkpoint uses block-FP8 for dense/shared projections and MXFP4 for
+    # routed experts. vLLM provides a Hopper fallback instead of requiring
+    # native Blackwell FP4 tensor cores.
+    precision_hardware:
+      brand: NVIDIA
+    vram_minimum_gb: 85
+    tp: 1
+    description: "Mixed block-FP8 and MXFP4 checkpoint; uses TP1 and supports DGX Spark"
   int4:
     model_id: "inclusionAI/Ling-3.0-flash-int4"
     precision: int4
     vram_minimum_gb: 95
     tp: 1
-    description: "compressed-tensors pack-quantized W4 (group 32) on the routed experts; fits one H200 at TP=1 and serves through vLLM's generic WNA16 Marlin MoE path"
+    description: "compressed-tensors pack-quantized W4 (group 32) on the routed experts; serves through vLLM's generic WNA16 Marlin MoE path and fits H200 or DGX Spark at TP1"
 
 compatible_strategies:
   - single_node_tp
@@ -88,13 +110,17 @@ guide: |
   model has 124.4B total and 5.5B active parameters. The checkpoint also contains
   a 3.1B MTP layer, bringing the complete checkpoint to 127.5B parameters. A
   serialized block-FP8 checkpoint is available as
-  `inclusionAI/Ling-3.0-flash-fp8`.
+  `inclusionAI/Ling-3.0-flash-fp8`. Lower-memory checkpoints are also available
+  as `inclusionAI/Ling-3.0-flash-fp4` and
+  `inclusionAI/Ling-3.0-flash-int4`. The external
+  `inclusionAI/Ling-3.0-flash-dspark` draft can accelerate any target variant
+  without changing which target checkpoint is served.
 
   ## Prerequisites
 
   - **vLLM:** a build containing native Bailing V3 support;
-  - **Validated hardware:** NVIDIA H20, H20-3e, and H200
-  - **Precision:** BF16 or serialized block FP8 weights with BF16 compute
+  - **Validated hardware:** NVIDIA H20, H20-3e, H200, and DGX Spark (FP4/INT4)
+  - **Precision:** BF16, serialized block FP8, mixed block-FP8/MXFP4, or compressed-tensors INT4 weights with BF16 compute
   - **Context length:** 262,144 tokens
 
   ## Launching the Server
@@ -147,21 +173,23 @@ guide: |
     --reasoning-parser ling3
   ```
 
-  The native MTP head is available with either FP8 topology by adding:
+  For the FP4 variant on one GPU, use:
 
   ```bash
-  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+  vllm serve inclusionAI/Ling-3.0-flash-fp4 \
+    --trust-remote-code \
+    --dtype bfloat16 \
+    --tensor-parallel-size 1 \
+    --gpu-memory-utilization 0.9 \
+    --enable-chunked-prefill \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser ling3 \
+    --reasoning-parser ling3
   ```
 
-  ## Single-GPU int4
-
-  `inclusionAI/Ling-3.0-flash-int4` is a `compressed-tensors` / `pack-quantized`
-  checkpoint: symmetric W4, `group_size: 32`, applied to the **routed experts
-  only** — attention, `lm_head`, the shared expert and the dense projections are
-  all in the config's `ignore` list. It is not covered by the model-specific
-  quantization plumbing in `bailing_moe_v3.py` (which handles block FP8 and
-  mxfp4); it loads through vLLM's generic `compressed-tensors` path, and that is
-  enough to serve it on a **single H200 at TP=1**:
+  For the INT4 variant on one GPU, use:
 
   ```bash
   vllm serve inclusionAI/Ling-3.0-flash-int4 \
@@ -171,8 +199,57 @@ guide: |
     --gpu-memory-utilization 0.9 \
     --enable-chunked-prefill \
     --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
-    --enable-prefix-caching
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser ling3 \
+    --reasoning-parser ling3
   ```
+
+  ## Speculative Decoding
+
+  The **Spec decoding** control exposes MTP and DSpark in the same place. They
+  are mutually exclusive modes, so the generated command contains exactly one
+  `--speculative-config`.
+
+  ### MTP
+
+  Use the target checkpoint's native MTP head with three draft tokens:
+
+  ```bash
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+  ```
+
+  ### DSpark
+
+  `inclusionAI/Ling-3.0-flash-dspark` is an external draft model. It does not
+  replace the served target checkpoint. It can be paired with any
+  Ling-3.0-flash target variant; pass the DSpark repository through
+  `--speculative-config.model` while keeping the selected target as the model
+  served by `vllm serve`.
+
+  The checkpoint was trained with query block size `Q=8`. Runtime
+  `num_speculative_tokens` (`K`) may be any integer from 1 through 8. The recipe
+  emits `K=7` as the recommended throughput/KV-capacity trade-off; change the
+  value to select another supported width. `K=8` remains valid.
+
+  ```bash
+  --speculative-config '{"method":"dspark","model":"inclusionAI/Ling-3.0-flash-dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic","attention_backend":"FLASH_ATTN","enable_adaptive_verification":false}'
+  ```
+
+  `enable_adaptive_verification` is disabled because the current Ling hybrid
+  MLA/KDA path is validated with fixed-width DSpark verification. The
+  `attention_backend` setting applies only to the external draft model; the
+  target model keeps its automatically selected attention backends.
+
+  ## Single-GPU INT4
+
+  `inclusionAI/Ling-3.0-flash-int4` is a `compressed-tensors` / `pack-quantized`
+  checkpoint: symmetric W4, `group_size: 32`, applied to the **routed experts
+  only** — attention, `lm_head`, the shared expert and the dense projections are
+  all in the config's `ignore` list. It is not covered by the model-specific
+  quantization plumbing in `bailing_moe_v3.py` (which handles block FP8 and
+  MXFP4); it loads through vLLM's generic `compressed-tensors` path and runs at
+  TP1 on H200 or DGX Spark.
 
   The engine names the mechanism at startup:
 
@@ -184,16 +261,18 @@ guide: |
   ```
 
   The vendor model card documents SGLang only, and there is no merged vLLM PR
-  specific to Ling int4 — this variant is recorded because the generic path
-  works, not because there is model-specific support behind it. Tool-call and
-  reasoning parsers, chunked prefill and CUDA graph capture behave as they do on
-  the other variants.
+  specific to Ling INT4. This variant works through the generic quantization
+  path; tool calling, reasoning parsing, chunked prefill and CUDA graph capture
+  behave as they do on the other variants.
 
   ## Validation
 
-  Both the default FP8 TP2 path and the TP4+EP4 path were validated on NVIDIA
-  H200. TP2 remains the recommended default because it uses fewer GPUs; TP4+EP4
-  is an alternative for deployments that prefer expert parallelism.
+  The BF16, FP8, FP4, and INT4 checkpoints support NVIDIA H20 and H200. For FP8,
+  TP2 remains the recommended multi-GPU default; TP4+EP4 is a validated H200
+  alternative for deployments that prefer expert parallelism. DGX Spark is
+  limited to the TP1 FP4 and INT4 variants because the BF16 and FP8 checkpoints
+  are too large for its 128 GB unified memory. DSpark is external and works with
+  any target variant that fits the selected hardware.
 
   The `int4` variant was verified on **1x H200 (SM90), TP=1**, on a `main` build
   reporting `0.26.1rc1.dev1133+gf94666b60`, serving at `--max-model-len 32768`:
@@ -223,11 +302,13 @@ guide: |
   print(response.choices[0].message.content)
   ```
 
-  When serving the FP8 variant, set `model="inclusionAI/Ling-3.0-flash-fp8"`
-  in the client request.
+  When serving a quantized variant, set `model` in the client request to the
+  corresponding FP8, FP4, or INT4 checkpoint ID.
 
   ## References
 
   - [Ling-3.0-flash on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-flash)
   - [Ling-3.0-flash-fp8 on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-flash-fp8)
+  - [Ling-3.0-flash-dspark on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-flash-dspark)
+  - [Ling-3.0-flash-fp4 on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-flash-fp4)
   - [Ling-3.0-flash-int4 on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-flash-int4)

--- a/models/inclusionAI/Ling-3.0-tiny.yaml
+++ b/models/inclusionAI/Ling-3.0-tiny.yaml
@@ -1,0 +1,165 @@
+meta:
+  title: "Ling-3.0-tiny"
+  slug: "ling-3-0-tiny"
+  provider: "inclusionAI"
+  description: "Ling-3.0-tiny lightweight hybrid-reasoning MoE with BF16, block-FP8, and compressed-tensors INT4 checkpoints"
+  date_added: 2026-08-31
+  date_updated: 2026-08-31
+  difficulty: intermediate
+  tasks:
+    - text
+  performance_headline: "7.9B total / 1.3B active parameters with a 3:1 KDA-MLA stack; all three official checkpoints run with TP1"
+  related_recipes:
+    - inclusionAI/Ling-3.0-flash
+  hardware:
+    h200: verified
+
+model:
+  model_id: "inclusionAI/Ling-3.0-tiny"
+  min_vllm_version: "0.25.0"
+  nightly_required: true
+  architecture: moe
+  parameter_count: "7.9B"
+  active_parameters: "1.3B"
+  context_length: 131072
+  base_args:
+    - "--trust-remote-code"
+    - "--dtype"
+    - "bfloat16"
+    - "--gpu-memory-utilization"
+    - "0.85"
+    - "--enable-prefix-caching"
+
+features:
+  tool_calling:
+    description: "Enable Ling 3 automatic tool calling"
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "ling3"
+  reasoning:
+    description: "Split Ling 3 thinking traces into reasoning_content"
+    args:
+      - "--reasoning-parser"
+      - "ling3"
+
+opt_in_features: []
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 18
+    tp: 1
+    description: "Official BF16 checkpoint; approximately 15.8 GB of repository weights and served with TP1"
+  fp8:
+    model_id: "inclusionAI/Ling-3.0-tiny-fp8"
+    precision: fp8
+    vram_minimum_gb: 11
+    tp: 1
+    description: "Official serialized block-FP8 checkpoint with dynamic activations and 128x128 weight blocks; served with TP1"
+  int4:
+    model_id: "inclusionAI/Ling-3.0-tiny-int4"
+    precision: int4
+    vram_minimum_gb: 8
+    tp: 1
+    description: "Official compressed-tensors group-wise INT4 checkpoint; served with TP1"
+
+compatible_strategies:
+  - single_node_tp
+
+hardware_overrides: {}
+
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  `inclusionAI/Ling-3.0-tiny` is the lightweight member of the Ling 3.0
+  family. It has 7.9B total parameters and activates 1.3B parameters per token.
+  Its 24-layer hybrid stack repeats three Kimi Delta Attention (KDA) layers and
+  one Multi-Head Latent Attention (MLA) layer, while each sparse MoE block
+  selects 8 of 128 routed experts plus one shared expert.
+
+  The official release provides three served checkpoints:
+
+  - `inclusionAI/Ling-3.0-tiny`: BF16;
+  - `inclusionAI/Ling-3.0-tiny-fp8`: serialized block FP8;
+  - `inclusionAI/Ling-3.0-tiny-int4`: compressed-tensors INT4.
+
+  All three use the same `BailingMoeV3ForCausalLM` architecture and a native
+  131,072-token context window. Select the corresponding Variant above; the
+  served model ID changes automatically.
+
+  ## Prerequisites
+
+  - **vLLM:** use a nightly/source build containing Ling 3.0 / Bailing V3
+    hybrid-attention support;
+  - **Parallelism:** TP1 is recommended for all three checkpoints;
+  - **Thinking mode:** enabled per request by the chat template.
+
+  ## Launching the Server
+
+  BF16 on one GPU:
+
+  ```bash
+  vllm serve inclusionAI/Ling-3.0-tiny \
+    --trust-remote-code \
+    --dtype bfloat16 \
+    --tensor-parallel-size 1 \
+    --gpu-memory-utilization 0.85 \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser ling3 \
+    --reasoning-parser ling3
+  ```
+
+  For FP8 or INT4, keep the same arguments and replace the served checkpoint:
+
+  ```bash
+  # Serialized block FP8
+  vllm serve inclusionAI/Ling-3.0-tiny-fp8 \
+    --trust-remote-code --dtype bfloat16 --tensor-parallel-size 1 \
+    --gpu-memory-utilization 0.85 --enable-prefix-caching --enable-auto-tool-choice \
+    --tool-call-parser ling3 --reasoning-parser ling3
+
+  # Compressed-tensors INT4
+  vllm serve inclusionAI/Ling-3.0-tiny-int4 \
+    --trust-remote-code --dtype bfloat16 --tensor-parallel-size 1 \
+    --gpu-memory-utilization 0.85 --enable-prefix-caching --enable-auto-tool-choice \
+    --tool-call-parser ling3 --reasoning-parser ling3
+  ```
+
+  ## Thinking Mode
+
+  Thinking is controlled per request. The model card recommends
+  `temperature=1.0`, `top_p=0.95`, and `top_k=20` when thinking is enabled:
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  response = client.chat.completions.create(
+      model="inclusionAI/Ling-3.0-tiny",
+      messages=[{"role": "user", "content": "Solve the problem step by step."}],
+      temperature=1.0,
+      top_p=0.95,
+      extra_body={
+          "top_k": 20,
+          "chat_template_kwargs": {"enable_thinking": True},
+      },
+  )
+  print(response.choices[0].message.reasoning_content)
+  print(response.choices[0].message.content)
+  ```
+
+  Set `enable_thinking` to `false` for direct answers. When using a quantized
+  variant, set the client `model` to its FP8 or INT4 checkpoint ID.
+
+  ## References
+
+  - [Ling 3.0 collection](https://huggingface.co/collections/inclusionAI/ling-30)
+  - [Ling-3.0-tiny on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-tiny)
+  - [Ling-3.0-tiny-fp8 on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-tiny-fp8)
+  - [Ling-3.0-tiny-int4 on Hugging Face](https://huggingface.co/inclusionAI/Ling-3.0-tiny-int4)


### PR DESCRIPTION
## Summary

This PR expands the inclusionAI Ling 3.0 deployment recipes.

### Ling-3.0-tiny

Add a new recipe for `inclusionAI/Ling-3.0-tiny` with three official variants:

- BF16: `inclusionAI/Ling-3.0-tiny`
- FP8: `inclusionAI/Ling-3.0-tiny-fp8`
- INT4: `inclusionAI/Ling-3.0-tiny-int4`

All three variants use TP1 and include the Ling 3 tool-calling and reasoning
parsers.

### Ling-3.0-flash

Extend the existing recipe with:

- the official mixed block-FP8/MXFP4 checkpoint
- updated INT4 deployment metadata for TP1 serving
- selectable MTP and DSpark speculative-decoding modes
- the external `inclusionAI/Ling-3.0-flash-dspark` draft model
- DSpark support for `K=1..8`, with `K=7` as the recommended default
- updated launch examples, hardware information, and model references