### PR TITLE
Allow 2 recipes per provider in homepage "Latest recipes"

### DIFF
--- a/src/components/recipes/RecipeCardGrid.jsx
+++ b/src/components/recipes/RecipeCardGrid.jsx
@@ -9,6 +9,11 @@ import { compareRecipesByDateAdded } from "@/lib/recipe-utils";
 const TASK_ICON = { text: Type, multimodal: Eye, omni: Sparkles, embedding: Hash };
 
 const LATEST_COUNT = 8;
+// At most 2 per provider: one org landing several recipes on the same day
+// shouldn't take the whole row, but a cap of 1 hid genuinely new recipes behind
+// a sibling that landed a day later, and back-filled the row with much older
+// ones from other orgs.
+const LATEST_PER_ORG = 2;
 
 export function RecipeCardGrid({ recipes }) {
   const byOrg = useMemo(() => {
@@ -27,12 +32,13 @@ export function RecipeCardGrid({ recipes }) {
     // "Latest recipes" means newly added to this catalog, not the HF repo's
     // createdAt (a model repo may exist privately long before launch).
     const sorted = [...recipes].sort(compareRecipesByDateAdded);
-    const seen = new Set();
+    const perOrg = new Map();
     const out = [];
     for (const r of sorted) {
       const org = r.hf_org || "unknown";
-      if (seen.has(org)) continue;
-      seen.add(org);
+      const taken = perOrg.get(org) || 0;
+      if (taken >= LATEST_PER_ORG) continue;
+      perOrg.set(org, taken + 1);
       out.push(r);
       if (out.length >= LATEST_COUNT) break;
     }


### PR DESCRIPTION
## Problem

The homepage "Latest recipes" row keeps only **one** recipe per provider (`RecipeCardGrid.jsx`), which makes its own "newest 8" label inaccurate. To fill 8 distinct orgs it reaches back to recipes 18 days old, while hiding a 4-day-old one behind a sibling that landed a day later.

Concretely, as of 2026-08-31 `zai-org/GLM-5.3-Flash` (added 2026-08-27) never appears, because `zai-org/GLM-5.3` (2026-08-28) takes the org's only slot:

```
cap=1 (current)                        cap=2 (this PR)
2026-08-28 tencent/Hy4-preview         2026-08-28 tencent/Hy4-preview
2026-08-28 zai-org/GLM-5.3             2026-08-28 zai-org/GLM-5.3
2026-08-19 ibm-granite/granite-3.2…    2026-08-27 zai-org/GLM-5.3-Flash   <--
2026-08-19 meta-llama/Llama-3.1-8B     2026-08-19 ibm-granite/granite-3.2…
2026-08-19 microsoft/Phi-4-multimodal  2026-08-19 meta-llama/Llama-3.1-8B
2026-08-19 openai/whisper-large-v3     2026-08-19 microsoft/Phi-4-multimodal
2026-08-17 Qwen/QwQ-32B                2026-08-19 microsoft/Phi-4-reasoning
2026-08-13 dots-studio/dots3-note-prev 2026-08-19 openai/whisper-large-v3
```

GLM-5.3 and GLM-5.3-Flash are distinct models (flagship vs. 320B-total / 18B-active MoE), not near-duplicates, so there is no reason for one to suppress the other.

## Change

Raise the per-provider cap from 1 to 2, keeping `LATEST_COUNT = 8`.

The cap is not removed: it exists so that an org landing several recipes on the same day cannot take the whole row (Qwen added 4 on 2026-08-14, meta-llama 3 on 2026-08-18). At 2 it occupies at most half a row of the 4-column grid.

Worth noting that with the current catalog, `cap=2` and *no cap at all* produce an identical top 8 — the dedupe only starts binding further down the list, which is evidence that 2 is a conservative floor rather than a behavior change.

## Test plan

- No YAML/schema change, so the JSON API is untouched; `node scripts/build-recipes-api.mjs` is unaffected.
- Verified the resulting ordering against every `models/**/*.yaml` `date_added` (table above).
- `/browse` and the ⌘K search "Latest" dropdown (`SearchBox.jsx`, no per-org dedupe) were already listing the recipe correctly and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)