### PR TITLE
Sync Qwen3.6-27B NVFP4 configs for DGX Spark, DGX Station, RTX PRO 6000 and RTX 5090

### DIFF
--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen3.6 dense multimodal model (27B) with gated delta networks hybrid attention, MTP, and 262K context"
   date_added: 2026-04-22
-  date_updated: 2026-07-02
+  date_updated: 2026-08-31
   difficulty: beginner
   tasks:
     - multimodal
@@ -37,7 +37,7 @@ features:
     args:
       - "--enable-auto-tool-choice"
       - "--tool-call-parser"
-      - "qwen3_coder"
+      - "qwen3_xml"
   reasoning:
     description: "Enable chain-of-thought reasoning with Qwen3 parser"
     args:
@@ -48,6 +48,12 @@ features:
     args:
       - "--speculative-config"
       - '{"method":"mtp","num_speculative_tokens":3}'
+    hardware_overrides:
+      # GB10 is decode-bound at low concurrency, so a deeper draft pays off.
+      dgx_spark_gb10:
+        args:
+          - "--speculative-config"
+          - '{"method":"mtp","num_speculative_tokens":5}'
   text_only:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
@@ -114,22 +120,68 @@ variants:
           - "--load-format"
           - "fastsafetensors"
           - "--async-scheduling"
-      rtx_5090:
+      dgx_spark_gb10:
         extra_args:
-          - "--max-model-len"
-          - "131072"
-          - "--max-num-seqs"
-          - "4"
           - "--kv-cache-dtype"
           - "fp8"
           - "--attention-backend"
           - "flashinfer"
+          # GB10 shares 128 GB with the CPU, so leave half the pool to the host.
+          - "--gpu-memory-utilization"
+          - "0.5"
+          - "--max-model-len"
+          - "262144"
+          - "--max-num-seqs"
+          - "8"
+          - "--max-num-batched-tokens"
+          - "8192"
           - "--enable-chunked-prefill"
           - "--enable-prefix-caching"
+          - "--load-format"
+          - "fastsafetensors"
+          - "--async-scheduling"
+      rtx_pro_6000:
+        extra_args:
+          - "--kv-cache-dtype"
+          - "fp8"
+          - "--attention-backend"
+          - "flashinfer"
+          - "--gpu-memory-utilization"
+          - "0.9"
+          - "--max-model-len"
+          - "262144"
+          - "--max-num-seqs"
+          - "8"
+          - "--max-num-batched-tokens"
+          - "8192"
+          - "--enable-chunked-prefill"
+          - "--enable-prefix-caching"
+          - "--load-format"
+          - "fastsafetensors"
+          - "--async-scheduling"
+      rtx_5090:
+        extra_args:
+          - "--kv-cache-dtype"
+          - "fp8"
+          - "--attention-backend"
+          - "FLASHINFER"
+          - "--attention-config"
+          - '{"use_trtllm_attention": true}'
+          - "--gpu-memory-utilization"
+          - "0.93"
+          # 32 GB leaves ~9 GB for KV cache after the NVFP4 weights.
+          - "--max-model-len"
+          - "36608"
+          - "--max-num-seqs"
+          - "8"
           - "--max-num-batched-tokens"
           - "4096"
-          - "--gpu-memory-utilization"
-          - "0.95"
+          - "--enable-chunked-prefill"
+          - "--enable-prefix-caching"
+          - "--async-scheduling"
+          - "--skip-mm-profiling"
+        extra_env:
+          VLLM_HAS_FLASHINFER_CUBIN: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -225,6 +277,7 @@ guide: |
   vllm serve nvidia/Qwen3.6-27B-NVFP4 \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
+    --attention-backend flashinfer \
     --gpu-memory-utilization 0.5 \
     --max-model-len 262144 \
     --max-num-seqs 8 \
@@ -232,10 +285,10 @@ guide: |
     --enable-chunked-prefill \
     --async-scheduling \
     --enable-prefix-caching \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":5}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_coder \
+    --tool-call-parser qwen3_xml \
     --enable-auto-tool-choice
   ```
 
@@ -287,7 +340,7 @@ guide: |
     --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_coder \
+    --tool-call-parser qwen3_xml \
     --enable-auto-tool-choice \
     --tensor-parallel-size 2 \
     --nnodes 2 \
@@ -327,7 +380,7 @@ guide: |
     --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_coder \
+    --tool-call-parser qwen3_xml \
     --enable-auto-tool-choice \
     --tensor-parallel-size 2 \
     --nnodes 2 \
@@ -350,6 +403,7 @@ guide: |
   vllm serve nvidia/Qwen3.6-27B-NVFP4 \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
+    --attention-backend flashinfer \
     --gpu-memory-utilization 0.9 \
     --max-model-len 262144 \
     --max-num-seqs 8 \
@@ -360,7 +414,61 @@ guide: |
     --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_coder \
+    --tool-call-parser qwen3_xml \
+    --enable-auto-tool-choice
+  ```
+
+  ### DGX Station GB300 NVFP4
+
+  A single GB300 has 252 GB, so the full 262K context runs at high memory
+  utilization with no batch-size cap.
+
+  ```bash
+  # Use container: vllm/vllm-openai:nightly
+
+  vllm serve nvidia/Qwen3.6-27B-NVFP4 \
+    --trust-remote-code \
+    --kv-cache-dtype fp8 \
+    --attention-backend flashinfer \
+    --gpu-memory-utilization 0.92 \
+    --max-model-len 262144 \
+    --max-num-batched-tokens 8192 \
+    --enable-chunked-prefill \
+    --async-scheduling \
+    --enable-prefix-caching \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+    --load-format fastsafetensors \
+    --reasoning-parser qwen3 \
+    --tool-call-parser qwen3_xml \
+    --enable-auto-tool-choice
+  ```
+
+  ### RTX 5090 NVFP4
+
+  32 GB leaves roughly 9 GB for KV cache once the NVFP4 weights are resident,
+  so the context is capped at 36,608 tokens and the TRT-LLM attention kernel is
+  used instead of the default FlashInfer path.
+
+  ```bash
+  # Use container: vllm/vllm-openai:nightly
+  export VLLM_HAS_FLASHINFER_CUBIN=1
+
+  vllm serve nvidia/Qwen3.6-27B-NVFP4 \
+    --trust-remote-code \
+    --kv-cache-dtype fp8 \
+    --attention-backend FLASHINFER \
+    --attention-config '{"use_trtllm_attention": true}' \
+    --gpu-memory-utilization 0.93 \
+    --max-model-len 36608 \
+    --max-num-seqs 8 \
+    --max-num-batched-tokens 4096 \
+    --enable-chunked-prefill \
+    --enable-prefix-caching \
+    --async-scheduling \
+    --skip-mm-profiling \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+    --reasoning-parser qwen3 \
+    --tool-call-parser qwen3_xml \
     --enable-auto-tool-choice
   ```
 

--- a/models/Qwen/Qwen3.6-27B.yaml
+++ b/models/Qwen/Qwen3.6-27B.yaml
@@ -263,39 +263,28 @@ guide: |
     --enable-prefix-caching
   ```
 
-  ### DGX Spark GB10 NVFP4
+  ### NVFP4 on Blackwell
 
-  The NVIDIA ModelOpt NVFP4 checkpoint is served from
-  [`nvidia/Qwen3.6-27B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4)
-  and requires vLLM 0.28.0+ (currently nightly) for the XQA decode path.
+  The [`nvidia/Qwen3.6-27B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4)
+  checkpoint is NVIDIA's ModelOpt re-quantization: MLP linears drop to NVFP4
+  (W4A16) while the attention linears and KV cache stay FP8, so the ~22 GB
+  weights fit a single Blackwell GPU. vLLM auto-detects the ModelOpt
+  quantization from the checkpoint, so no `--quantization` flag is needed, but
+  it does need vLLM 0.28.0+ (currently nightly) for FlashInfer's XQA decode path
+  on SM120. NVIDIA reports near-lossless accuracy versus the FP8 baseline.
 
-  #### **Single node (TP1)**
+  Select the NVFP4 variant in the command builder above and switch the hardware
+  pill for the validated single-node launch on DGX Spark (GB10), DGX Station
+  (GB300), RTX PRO 6000 or RTX 5090. Memory utilization, context length, batch
+  size, attention backend and MTP depth all differ per box and are encoded per
+  hardware, so the generated command is the tested one.
 
-  ```bash
-  # Use container: vllm/vllm-openai:nightly
+  #### **2× DGX Spark (TP2)**
 
-  vllm serve nvidia/Qwen3.6-27B-NVFP4 \
-    --trust-remote-code \
-    --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
-    --gpu-memory-utilization 0.5 \
-    --max-model-len 262144 \
-    --max-num-seqs 8 \
-    --max-num-batched-tokens 8192 \
-    --enable-chunked-prefill \
-    --async-scheduling \
-    --enable-prefix-caching \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":5}' \
-    --load-format fastsafetensors \
-    --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_xml \
-    --enable-auto-tool-choice
-  ```
-
-  #### **Multi-node (TP2)**
-
-  Download the checkpoint on all nodes. Start the worker nodes first and then the head node.
-  The head node coordinates the others, so they need to be ready to connect when it comes up.
+  Two Sparks joined over ConnectX is the one layout the builder can't render, so
+  it is spelled out here. Download the checkpoint on all nodes. Start the worker
+  node first and then the head node — the head coordinates the others, so they
+  need to be ready to connect when it comes up.
 
   ```bash
   # COMMON variables example values — same on all nodes
@@ -332,12 +321,12 @@ guide: |
     --attention-backend flashinfer \
     --gpu-memory-utilization 0.5 \
     --max-model-len 262144 \
-    --max-num-seqs 10 \
+    --max-num-seqs 8 \
     --max-num-batched-tokens 8192 \
     --enable-chunked-prefill \
     --async-scheduling \
     --enable-prefix-caching \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":5,"draft_tensor_parallel_size":2}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen3_xml \
@@ -372,12 +361,12 @@ guide: |
     --attention-backend flashinfer \
     --gpu-memory-utilization 0.5 \
     --max-model-len 262144 \
-    --max-num-seqs 10 \
+    --max-num-seqs 8 \
     --max-num-batched-tokens 8192 \
     --enable-chunked-prefill \
     --async-scheduling \
     --enable-prefix-caching \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":5,"draft_tensor_parallel_size":2}' \
     --load-format fastsafetensors \
     --reasoning-parser qwen3 \
     --tool-call-parser qwen3_xml \
@@ -390,104 +379,6 @@ guide: |
     --headless
   ```
 
-
-  ### RTX Pro 6000 NVFP4
-
-  The NVIDIA ModelOpt NVFP4 checkpoint is served from
-  [`nvidia/Qwen3.6-27B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4)
-  and requires vLLM 0.28.0+ (currently nightly) for the XQA decode path.
-
-  ```bash
-  # Use container: vllm/vllm-openai:nightly
-
-  vllm serve nvidia/Qwen3.6-27B-NVFP4 \
-    --trust-remote-code \
-    --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
-    --gpu-memory-utilization 0.9 \
-    --max-model-len 262144 \
-    --max-num-seqs 8 \
-    --max-num-batched-tokens 8192 \
-    --enable-chunked-prefill \
-    --async-scheduling \
-    --enable-prefix-caching \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
-    --load-format fastsafetensors \
-    --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_xml \
-    --enable-auto-tool-choice
-  ```
-
-  ### DGX Station GB300 NVFP4
-
-  A single GB300 has 252 GB, so the full 262K context runs at high memory
-  utilization with no batch-size cap.
-
-  ```bash
-  # Use container: vllm/vllm-openai:nightly
-
-  vllm serve nvidia/Qwen3.6-27B-NVFP4 \
-    --trust-remote-code \
-    --kv-cache-dtype fp8 \
-    --attention-backend flashinfer \
-    --gpu-memory-utilization 0.92 \
-    --max-model-len 262144 \
-    --max-num-batched-tokens 8192 \
-    --enable-chunked-prefill \
-    --async-scheduling \
-    --enable-prefix-caching \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
-    --load-format fastsafetensors \
-    --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_xml \
-    --enable-auto-tool-choice
-  ```
-
-  ### RTX 5090 NVFP4
-
-  32 GB leaves roughly 9 GB for KV cache once the NVFP4 weights are resident,
-  so the context is capped at 36,608 tokens and the TRT-LLM attention kernel is
-  used instead of the default FlashInfer path.
-
-  ```bash
-  # Use container: vllm/vllm-openai:nightly
-  export VLLM_HAS_FLASHINFER_CUBIN=1
-
-  vllm serve nvidia/Qwen3.6-27B-NVFP4 \
-    --trust-remote-code \
-    --kv-cache-dtype fp8 \
-    --attention-backend FLASHINFER \
-    --attention-config '{"use_trtllm_attention": true}' \
-    --gpu-memory-utilization 0.93 \
-    --max-model-len 36608 \
-    --max-num-seqs 8 \
-    --max-num-batched-tokens 4096 \
-    --enable-chunked-prefill \
-    --enable-prefix-caching \
-    --async-scheduling \
-    --skip-mm-profiling \
-    --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
-    --reasoning-parser qwen3 \
-    --tool-call-parser qwen3_xml \
-    --enable-auto-tool-choice
-  ```
-
-  ### NVFP4 on Blackwell
-
-  The [`nvidia/Qwen3.6-27B-NVFP4`](https://huggingface.co/nvidia/Qwen3.6-27B-NVFP4)
-  checkpoint is NVIDIA's ModelOpt re-quantization: MLP linears drop to NVFP4
-  (W4A16) while the attention linears and KV cache stay FP8, so the ~22 GB
-  weights fit a single Blackwell GPU. vLLM auto-detects the ModelOpt
-  quantization from the checkpoint, so no `--quantization` flag is needed — just
-  use a recent vLLM (NVIDIA recommends nightly or a source build with ModelOpt
-  W4A16/NVFP4 support). NVIDIA reports near-lossless accuracy versus the FP8
-  baseline.
-
-  ```bash
-  vllm serve nvidia/Qwen3.6-27B-NVFP4 \
-    --max-model-len 262144 \
-    --reasoning-parser qwen3
-  ```
 
   ### Docker (Intel XPU B60 / B70)
 

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -1274,9 +1274,10 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
 
     // 7. Features last — tool_calling, reasoning, mtp, etc.
     //    A feature can declare per-generation overrides under
-    //    `hardware_overrides.<gen>.args`; when present they REPLACE the
-    //    feature's default args (not merged), so a recipe can ship different
-    //    spec-decoding configs for hopper vs blackwell without dedupe gymnastics.
+    //    `hardware_overrides.<key>.args` keyed by exact GPU id, generation or
+    //    brand; when present they REPLACE the feature's default args (not
+    //    merged), so a recipe can ship different spec-decoding configs for
+    //    hopper vs blackwell — or for one GB10 box — without dedupe gymnastics.
     for (const f of enabledFeatures || []) {
       const feat = recipe.features?.[f];
       if (!feat) continue;
@@ -1300,8 +1301,7 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
         }
         continue;
       }
-      const featHo = feat.hardware_overrides?.[gen]
-        || (isNvidia ? feat.hardware_overrides?.nvidia : null);
+      const featHo = hardwareKeyedValue(feat.hardware_overrides, hwProfile, hwProfileId);
       const featArgs = featHo?.args ?? feat.args;
       if (featArgs) args.push(...featArgs);
     }


### PR DESCRIPTION
Bring the Qwen3.6-27B NVFP4 variant in line with the configurations we validated on the four local Blackwell systems: DGX Spark GB10 (0.5 memory utilization, MTP=5), DGX Station GB300 (0.92, no batch cap), RTX PRO 6000 (0.9, 8 sequences) and RTX 5090, which needs the TRT-LLM attention kernel plus VLLM_HAS_FLASHINFER_CUBIN=1 and a 36,608-token context to fit 32 GB. The tool-call parser also moves from qwen3_coder to qwen3_xml to match the tested launches and the Qwen3.6-35B-A3B recipe. Since the Spark's deeper draft is a per-box rather than per-generation setting, feature-level hardware_overrides now resolve through the same exact-GPU-id > generation > brand > default lookup already used for variant tp and mode overrides.