### PR TITLE
Update recipes for vLLM v0.28.0: bump image pins, migrate removed env vars to flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ model:
   base_args:                                      # flags always needed
     - "--trust-remote-code"
   base_env:                                       # env vars always needed
-    VLLM_USE_FLASHINFER_MOE_FP8: "1"
+    VLLM_USE_DEEP_GEMM: "0"                       # MoE kernel selection itself is done via --moe-backend args
 
 # Optional — extra install steps beyond `uv pip install -U vllm`.
 # Rendered as a code block above the vllm serve command.
@@ -128,8 +128,7 @@ variants:
     model_id: "nvidia/*-NVFP4"                    # only if the quantized checkpoint is a different HF repo
     precision: nvfp4
     vram_minimum_gb: 403
-    extra_args: ["--kv-cache-dtype", "fp8"]
-    extra_env: { VLLM_USE_FLASHINFER_MOE_FP4: "1" }
+    extra_args: ["--kv-cache-dtype", "fp8", "--moe-backend", "flashinfer_cutlass"]
 
 compatible_strategies:                            # subset of the 8 strategy ids in strategies/*.yaml
   - single_node_tp                                # always include as baseline

--- a/models/MiniMaxAI/MiniMax-M2.5.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.5.yaml
@@ -20,7 +20,7 @@ meta:
 model:
   model_id: "MiniMaxAI/MiniMax-M2.5"
   min_vllm_version: "0.20.2"
-  docker_image: "vllm/vllm-openai:v0.20.2"
+  docker_image: "vllm/vllm-openai:v0.28.0"
   architecture: moe
   parameter_count: "230B"
   active_parameters: "10B"
@@ -57,8 +57,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
   redhat_nvfp4:
     model_id: "RedHatAI/MiniMax-M2.5-NVFP4"
@@ -157,7 +155,7 @@ guide: |
     -e VLLM_USE_DEEP_GEMM=0 \
     -e VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER=0 \
     -e VLLM_FLOAT32_MATMUL_PRECISION=high \
-    vllm/vllm-openai:v0.20.2 MiniMaxAI/MiniMax-M2.5 \
+    vllm/vllm-openai:v0.28.0 MiniMaxAI/MiniMax-M2.5 \
         --tensor-parallel-size 4 \
         --max-num-seqs 512 \
         --max-num-batched-tokens 32768 \

--- a/models/MiniMaxAI/MiniMax-M2.7.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.7.yaml
@@ -81,8 +81,6 @@ variants:
           - "8192"
           - "--gpu-memory-utilization"
           - "0.95"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/MiniMaxAI/MiniMax-M2.yaml
+++ b/models/MiniMaxAI/MiniMax-M2.yaml
@@ -61,8 +61,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -235,7 +233,8 @@ guide: |
 
   [`RedHatAI/MiniMax-M2-NVFP4`](https://huggingface.co/RedHatAI/MiniMax-M2-NVFP4) is an NVFP4 (4-bit)
   checkpoint — roughly half the VRAM of the native FP8 checkpoint. Select the **nvfp4** variant
-  above (it sets `VLLM_USE_FLASHINFER_MOE_FP4=1` and `--kv-cache-dtype fp8`), or pass the repo id
+  above (it sets `--kv-cache-dtype fp8`; on vLLM v0.28.0+ the FlashInfer NVFP4 MoE
+  kernels are selected automatically), or pass the repo id
   directly to `vllm serve`. NVFP4 requires a Blackwell GPU (compute capability 10.0+).
 
   ## References

--- a/models/Qwen/Qwen2.5-32B.yaml
+++ b/models/Qwen/Qwen2.5-32B.yaml
@@ -75,7 +75,7 @@ guide: |
   export HF_TOKEN=<your HF token>
   export TP=4
   export MAX_MODEL_LEN=4096
-  VLLM_USE_V1=1 vllm serve Qwen/Qwen2.5-32B \
+  vllm serve Qwen/Qwen2.5-32B \
     --seed 42 \
     --gpu-memory-utilization 0.98 \
     --max-num-batched-tokens 2048 \
@@ -95,7 +95,7 @@ guide: |
   ## Configuration Tips
 
   - `--max-model-len 4096` keeps memory in check on a 4-chip v6e slice; native context is 128K — raise it if you have headroom.
-  - `VLLM_USE_V1=1` selects the V1 engine (default on recent vLLM; explicit here to match the upstream TPU recipe).
+  - vLLM has been V1-engine-only for a long time, so no `VLLM_USE_V1=1` export is needed even though the upstream TPU recipe still shows it.
   - vLLM uses 90% of device memory by default; the TPU recipe pushes `--gpu-memory-utilization 0.98` to maximize KV cache.
   - `--max-num-batched-tokens` and `--max-num-seqs` tune batch throughput vs latency.
 

--- a/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
+++ b/models/Qwen/Qwen3-235B-A22B-Instruct-2507.yaml
@@ -57,8 +57,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Coder-480B-A35B-Instruct.yaml
@@ -62,8 +62,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -61,8 +61,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -75,13 +73,13 @@ compatible_strategies:
 
 hardware_overrides:
   blackwell:
-    extra_args: []
+    extra_args:
+      - "--moe-backend"
+      - "flashinfer_trtllm"
+      - "--attention-backend"
+      - "FLASH_ATTN"
     extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
-      VLLM_FLASHINFER_MOE_BACKEND: "latency"
       VLLM_USE_DEEP_GEMM: "0"
-      VLLM_USE_TRTLLM_ATTENTION: "0"
-      VLLM_ATTENTION_BACKEND: "FLASH_ATTN"
 
 strategy_overrides: {}
 
@@ -125,13 +123,11 @@ guide: |
 
   On SM100, accelerate with the FP8 FlashInfer TRTLLM MoE kernel:
   ```bash
-  VLLM_USE_FLASHINFER_MOE_FP8=1 \
-  VLLM_FLASHINFER_MOE_BACKEND=latency \
   VLLM_USE_DEEP_GEMM=0 \
-  VLLM_USE_TRTLLM_ATTENTION=0 \
-  VLLM_ATTENTION_BACKEND=FLASH_ATTN \
   vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
-    --tensor-parallel-size 4
+    --tensor-parallel-size 4 \
+    --moe-backend flashinfer_trtllm \
+    --attention-backend FLASH_ATTN
   ```
 
   ### MTP (Multi-Token Prediction)

--- a/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-235B-A22B-Instruct.yaml
@@ -29,7 +29,7 @@ model:
   base_args: []
   base_env: {}
   docker_image:
-    amd: "vllm/vllm-openai-rocm:v0.22.1"
+    amd: "vllm/vllm-openai-rocm:v0.28.0"
 
 
 dependencies:
@@ -71,8 +71,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -236,13 +234,11 @@ guide: |
   export SAFETENSORS_FAST_GPU="1"
   export HIP_FORCE_DEV_KERNARG="1"
   export HIP_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"
-  export VLLM_USE_V1="1"
   export VLLM_WORKER_MULTIPROC_METHOD="spawn"
   export VLLM_ROCM_USE_AITER="1"
   export VLLM_ROCM_USE_AITER_MHA="1"
   export VLLM_ROCM_USE_AITER_RMSNORM="0"
   export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT="0"
-  export VLLM_RPC_TIMEOUT="300000"
 
   vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
     --tensor-parallel-size 8 \

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -28,10 +28,11 @@ model:
   context_length: 262144
   base_args:
     - "--trust-remote-code"
+    - "--moe-backend"
+    - "flashinfer_trtllm"
   base_env:
     VLLM_DEEP_GEMM_WARMUP: "skip"
     VLLM_USE_DEEP_GEMM: "0"
-    VLLM_FLASHINFER_MOE_BACKEND: "latency"
 
 features:
   tool_calling:
@@ -76,8 +77,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
   gptq_int4:
     model_id: "Qwen/Qwen3.5-397B-A17B-GPTQ-Int4"
     precision: int4

--- a/models/Qwen/Qwen3.5-397B-A17B.yaml
+++ b/models/Qwen/Qwen3.5-397B-A17B.yaml
@@ -28,8 +28,6 @@ model:
   context_length: 262144
   base_args:
     - "--trust-remote-code"
-    - "--moe-backend"
-    - "flashinfer_trtllm"
   base_env:
     VLLM_DEEP_GEMM_WARMUP: "skip"
     VLLM_USE_DEEP_GEMM: "0"
@@ -93,7 +91,13 @@ compatible_strategies:
   - multi_node_tep
   - pd_cluster
 
-hardware_overrides: {}
+hardware_overrides:
+  # FlashInfer TRTLLM MoE kernels are NVIDIA-only; pin them per-brand so AMD
+  # keeps auto-selection (AITER on ROCm).
+  nvidia:
+    extra_args:
+      - "--moe-backend"
+      - "flashinfer_trtllm"
 
 strategy_overrides:
   pd_cluster:

--- a/models/arcee-ai/Trinity-Large-Thinking.yaml
+++ b/models/arcee-ai/Trinity-Large-Thinking.yaml
@@ -50,8 +50,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -68,8 +68,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -82,14 +80,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
-  blackwell:
-    extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
   amd:
     extra_args: []
     extra_env:
@@ -163,13 +153,9 @@ guide: |
 
   ### 4xB200 (FP4)
 
-  Enable FlashInfer MoE kernels before launching:
-  ```bash
-  # For FP4 (recommended on Blackwell)
-  export VLLM_USE_FLASHINFER_MOE_FP4=1
-  # For FP8 on Blackwell
-  export VLLM_USE_FLASHINFER_MOE_FP8=1
-  ```
+  On vLLM v0.28.0 and later, the FlashInfer MoE kernels are selected automatically
+  for both FP4 and FP8 on Blackwell — no environment variables are needed. To pin
+  the backend explicitly, pass `--moe-backend flashinfer_trtllm`.
 
   Tensor Parallel + Expert Parallel (TP4+EP):
   ```bash

--- a/models/deepseek-ai/DeepSeek-V3.1.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.1.yaml
@@ -61,8 +61,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2-Exp.yaml
@@ -80,7 +80,6 @@ hardware_overrides:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
       SAFETENSORS_FAST_GPU: "1"
-      VLLM_RPC_TIMEOUT: "18000000"
 
 strategy_overrides: {}
 
@@ -143,7 +142,6 @@ guide: |
   export SAFETENSORS_FAST_GPU=1
   export VLLM_ROCM_USE_AITER=1
   export VLLM_ROCM_USE_AITER_MOE=1
-  export VLLM_RPC_TIMEOUT=18000000
 
   vllm serve deepseek-ai/DeepSeek-V3.2-Exp \
     --tensor-parallel-size 8 \

--- a/models/deepseek-ai/DeepSeek-V3.2.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.2.yaml
@@ -70,8 +70,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -60,8 +60,6 @@ variants:
     precision: fp4
     vram_minimum_gb: 403
     description: "NVIDIA FP4 quantized weights for Blackwell (e.g. 4xB200)"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -74,14 +72,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  hopper:
-    extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
-  blackwell:
-    extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
   amd:
     extra_args: []
     extra_env:
@@ -155,13 +145,9 @@ guide: |
 
   ### 4xB200 (FP4)
 
-  Enable FlashInfer MoE kernels before launching:
-  ```bash
-  # For FP4 (recommended on Blackwell)
-  export VLLM_USE_FLASHINFER_MOE_FP4=1
-  # For FP8 on Blackwell
-  export VLLM_USE_FLASHINFER_MOE_FP8=1
-  ```
+  On vLLM v0.28.0 and later, the FlashInfer MoE kernels are selected automatically
+  for both FP4 and FP8 on Blackwell — no environment variables are needed. To pin
+  the backend explicitly, pass `--moe-backend flashinfer_trtllm`.
 
   Tensor Parallel + Expert Parallel (TP4+EP):
   ```bash

--- a/models/deepseek-ai/DeepSeek-V4-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash.yaml
@@ -126,7 +126,7 @@ variants:
     # pills cannot load this checkpoint's draft module.
     supported_hardware: [h200, b200, gb200, b300, gb300, dgx_station_gb300, dgx_spark_gb10, rtx_pro_6000_8x, mi300x, mi325x, mi355x]
     min_vllm_version: "0.25.0"
-    docker_image: "vllm/vllm-openai:v0.25.0"
+    docker_image: "vllm/vllm-openai:v0.28.0"
     default_modes:
       spec_decoding: dspark
     hardware_overrides:
@@ -977,11 +977,10 @@ guide: |
     -e TILELANG_CLEANUP_TEMP_FILES=1 \
     -e VLLM_DISABLE_COMPILE_CACHE=1 \
     -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
-    -e VLLM_RPC_TIMEOUT=600000 \
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_MOONCAKE_BOOTSTRAP_PORT=8998 \
     -e CUDA_VISIBLE_DEVICES=0,1,2,3 \
-    vllm/vllm-openai:v0.25.0 \
+    vllm/vllm-openai:v0.28.0 \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
@@ -1010,11 +1009,10 @@ guide: |
     -e TILELANG_CLEANUP_TEMP_FILES=1 \
     -e VLLM_DISABLE_COMPILE_CACHE=1 \
     -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
-    -e VLLM_RPC_TIMEOUT=600000 \
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_MOONCAKE_BOOTSTRAP_PORT=9889 \
     -e CUDA_VISIBLE_DEVICES=4,5,6,7 \
-    vllm/vllm-openai:v0.25.0 \
+    vllm/vllm-openai:v0.28.0 \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
@@ -1064,11 +1062,10 @@ guide: |
     -e TILELANG_CLEANUP_TEMP_FILES=1 \
     -e VLLM_DISABLE_COMPILE_CACHE=1 \
     -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
-    -e VLLM_RPC_TIMEOUT=600000 \
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_NIXL_SIDE_CHANNEL_PORT=5557 \
     -e CUDA_VISIBLE_DEVICES=0,1,2,3 \
-    vllm/vllm-openai:v0.25.0 \
+    vllm/vllm-openai:v0.28.0 \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
@@ -1097,11 +1094,10 @@ guide: |
     -e TILELANG_CLEANUP_TEMP_FILES=1 \
     -e VLLM_DISABLE_COMPILE_CACHE=1 \
     -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
-    -e VLLM_RPC_TIMEOUT=600000 \
     -e VLLM_LOG_STATS_INTERVAL=1 \
     -e VLLM_NIXL_SIDE_CHANNEL_PORT=5558 \
     -e CUDA_VISIBLE_DEVICES=4,5,6,7 \
-    vllm/vllm-openai:v0.25.0 \
+    vllm/vllm-openai:v0.28.0 \
     deepseek-ai/DeepSeek-V4-Flash \
     --trust-remote-code \
     --kv-cache-dtype fp8 \

--- a/models/inclusionAI/Ling-2.6-1T.yaml
+++ b/models/inclusionAI/Ling-2.6-1T.yaml
@@ -79,7 +79,7 @@ guide: |
     --device=/dev/dri \
     --group-add video \
     -e VLLM_ROCM_USE_AITER=1 \
-    vllm/vllm-openai-rocm:v0.20.2 \
+    vllm/vllm-openai-rocm:v0.28.0 \
       inclusionAI/Ling-2.6-1T \
       --tensor-parallel-size 8 \
       --trust-remote-code

--- a/models/inclusionAI/Ling-2.6-flash.yaml
+++ b/models/inclusionAI/Ling-2.6-flash.yaml
@@ -78,7 +78,7 @@ guide: |
     --device=/dev/dri \
     --group-add video \
     -e VLLM_ROCM_USE_AITER=1 \
-    vllm/vllm-openai-rocm:v0.20.2 \
+    vllm/vllm-openai-rocm:v0.28.0 \
       inclusionAI/Ling-2.6-flash \
       --tensor-parallel-size 2 \
       --trust-remote-code

--- a/models/inclusionAI/Ring-2.6-1T.yaml
+++ b/models/inclusionAI/Ring-2.6-1T.yaml
@@ -83,7 +83,7 @@ guide: |
     --device=/dev/dri \
     --group-add video \
     -e VLLM_ROCM_USE_AITER=1 \
-    vllm/vllm-openai-rocm:v0.20.2 \
+    vllm/vllm-openai-rocm:v0.28.0 \
       inclusionAI/Ring-2.6-1T \
       --tensor-parallel-size 8 \
       --trust-remote-code

--- a/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -58,8 +58,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp
@@ -90,8 +88,6 @@ hardware_overrides:
       - "8192"
       - "--compilation-config"
       - '{"pass_config":{"fuse_allreduce_rms":true,"eliminate_noops":true}}'
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "1"
   amd:
     # 8 GPUs required for 17B×16E MoE. AITER JIT-compiles on first launch.
     extra_args:

--- a/models/mindlab-research/Macaron-V1-Coding-Venti.yaml
+++ b/models/mindlab-research/Macaron-V1-Coding-Venti.yaml
@@ -18,7 +18,7 @@ model:
   model_id: "mindlab-research/Macaron-V1-Coding-Venti"
   min_vllm_version: "0.25.0"
   docker_image:
-    nvidia: "vllm/vllm-openai:v0.25.0"
+    nvidia: "vllm/vllm-openai:v0.28.0"
     amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
   architecture: moe
   parameter_count: "743B"
@@ -151,7 +151,7 @@ guide: |
     --ipc=host \
     --network host \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai:v0.25.0 mindlab-research/Macaron-V1-Coding-Venti \
+    vllm/vllm-openai:v0.28.0 mindlab-research/Macaron-V1-Coding-Venti \
       --tensor-parallel-size 16 \
       --nnodes 2 \
       --node-rank 0 \

--- a/models/moonshotai/Kimi-K2-Thinking.yaml
+++ b/models/moonshotai/Kimi-K2-Thinking.yaml
@@ -58,8 +58,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/moonshotai/Kimi-K2.5.yaml
+++ b/models/moonshotai/Kimi-K2.5.yaml
@@ -81,8 +81,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
   mxfp4:
     model_id: "amd/Kimi-K2.5-MXFP4"
     precision: mxfp4

--- a/models/moonshotai/Kimi-K2.6.yaml
+++ b/models/moonshotai/Kimi-K2.6.yaml
@@ -85,8 +85,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -64,9 +64,9 @@ variants:
       - "fp8"
     hardware_overrides:
       nvidia:
-        extra_env:
-          VLLM_USE_FLASHINFER_MOE_FP8: "1"
-          VLLM_FLASHINFER_MOE_BACKEND: "throughput"
+        extra_args:
+          - "--moe-backend"
+          - "flashinfer_cutlass"
 
 compatible_strategies:
   - single_node_tp
@@ -97,14 +97,14 @@ guide: |
   ## Prerequisites
 
   - Hardware: 1x H100/H200 or comparable; DGX Spark, Jetson Thor, and Intel Arc Pro B60/B70 supported
-  - vLLM >= 0.11.2 (0.12.0 recommended for full support)
+  - vLLM >= 0.11.2 (0.28.0 recommended for full support)
   - Docker with NVIDIA Container Toolkit (recommended)
 
   ### Pull Docker Image
 
   ```bash
-  docker pull --platform linux/amd64 vllm/vllm-openai:v0.12.0
-  docker tag vllm/vllm-openai:v0.12.0 vllm/vllm-openai:deploy
+  docker pull --platform linux/amd64 vllm/vllm-openai:v0.28.0
+  docker tag vllm/vllm-openai:v0.28.0 vllm/vllm-openai:deploy
   ```
 
   DGX Spark users can build from source (see README) or use the NGC image:
@@ -130,14 +130,12 @@ guide: |
   FP8 with FlashInfer MoE backend (Blackwell/Hopper):
 
   ```bash
-  export VLLM_USE_FLASHINFER_MOE_FP8=1
-  export VLLM_FLASHINFER_MOE_BACKEND=throughput
-
   vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 \
     --trust-remote-code \
     --async-scheduling \
     --kv-cache-dtype fp8 \
-    --tensor-parallel-size 1
+    --tensor-parallel-size 1 \
+    --moe-backend flashinfer_cutlass
   ```
 
   BF16 (with reasoning + tool parsers — typical for Spark/Thor):

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16.yaml
@@ -91,13 +91,13 @@ guide: |
   ## Prerequisites
 
   - Hardware: 1x H100/H200/B200, DGX Spark, Jetson Thor, or Intel Arc Pro B60/B70
-  - vLLM >= 0.11.2 (0.12.0 recommended)
+  - vLLM >= 0.11.2 (0.28.0 recommended)
   - Docker with NVIDIA Container Toolkit (recommended)
 
   ### Pull Docker Image
 
   ```bash
-  docker pull --platform linux/amd64 vllm/vllm-openai:v0.12.0
+  docker pull --platform linux/amd64 vllm/vllm-openai:v0.28.0
   ```
 
   Jetson Thor:

--- a/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.yaml
@@ -178,7 +178,7 @@ guide: |
   ### DGX Spark (GB10)
 
   The NVFP4 variant runs on a single DGX Spark (GB10) at TP=1 inside the
-  `vllm/vllm-openai:v0.24.0-ubuntu2404` container. The command below is the optimal
+  `vllm/vllm-openai:v0.28.0-ubuntu2404` container. The command below is the optimal
   config tuned end-to-end on DGX Spark: the full 262144-token context fits with an FP8
   KV cache and a float32 Mamba SSM cache (`VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` allows the
   long context, `VLLM_FLOAT32_MATMUL_PRECISION=high` keeps the Mamba scan numerically
@@ -189,7 +189,7 @@ guide: |
   latency:
 
   ```bash
-  # Use container: vllm/vllm-openai:v0.24.0-ubuntu2404
+  # Use container: vllm/vllm-openai:v0.28.0-ubuntu2404
 
   VLLM_FLOAT32_MATMUL_PRECISION="high" \
   VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
@@ -221,7 +221,7 @@ guide: |
   - **Set `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1`** to allow the model to use the full context length.
 
   ```bash
-  # Use container: vllm/vllm-openai:v0.24.0-ubuntu2404
+  # Use container: vllm/vllm-openai:v0.28.0-ubuntu2404
 
   VLLM_FLOAT32_MATMUL_PRECISION="high" \
   VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \

--- a/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16.yaml
@@ -17,7 +17,7 @@ meta:
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
   min_vllm_version: "0.22.0"
-  docker_image: "vllm/vllm-openai:v0.22.0"
+  docker_image: "vllm/vllm-openai:v0.28.0"
   architecture: moe
   parameter_count: "550B"
   active_parameters: "55B"

--- a/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
@@ -19,7 +19,7 @@ meta:
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
   min_vllm_version: "0.27.1"
-  docker_image: "vllm/vllm-openai:v0.27.1"
+  docker_image: "vllm/vllm-openai:v0.28.0"
   architecture: moe
   parameter_count: "30B"
   active_parameters: "3B"
@@ -193,7 +193,7 @@ guide: |
 
   ## Prerequisites
 
-  - **vLLM:** 0.27.1 or newer — `vllm/vllm-openai:v0.27.1`
+  - **vLLM:** 0.27.1 or newer — `vllm/vllm-openai:v0.28.0`
   - **Hardware:** 1x H100, 1x DGX Spark (GB10), or 1x DGX Station (GB300)
   - **Speculative decoding:** **MTP** (built into the checkpoint), **DSpark** (hybrid
     autoregressive + diffusion) and **DFlash** (diffusion) are all supported. DSpark

--- a/models/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16.yaml
+++ b/models/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16.yaml
@@ -22,8 +22,8 @@ model:
   min_vllm_version: "0.20.0"
   install:
     pip:
-      command: 'uv pip install "vllm[audio]==0.20.0"'
-      note: "Pinned to 0.20.0 with the audio extra (required for audio + use_audio_in_video)."
+      command: 'uv pip install "vllm[audio]==0.28.0"'
+      note: "Pinned to 0.28.0 with the audio extra (required for audio + use_audio_in_video)."
   architecture: moe
   parameter_count: "31B"
   active_parameters: "3B"

--- a/models/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16.yaml
+++ b/models/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16.yaml
@@ -107,8 +107,8 @@ guide: |
 
   ## Prerequisites
 
-  - vLLM **0.20.0** (pinned: `pip install vllm[audio]==0.20.0`,
-    or pull `vllm/vllm-openai:v0.20.0`)
+  - vLLM **0.28.0** (pinned: `pip install vllm[audio]==0.28.0`,
+    or pull `vllm/vllm-openai:v0.28.0`)
   - Hardware: 1× B200 / H200 / H100 (single-GPU TP1 is the documented profile)
   - The `audio` extra is required for any audio input, including
     `use_audio_in_video=true`
@@ -117,9 +117,9 @@ guide: |
 
   ```bash
   # CUDA 13:
-  docker pull vllm/vllm-openai:v0.20.0
+  docker pull vllm/vllm-openai:v0.28.0
   # CUDA 12.9:
-  docker pull vllm/vllm-openai:v0.20.0-cu129
+  docker pull vllm/vllm-openai:v0.28.0-cu129
   ```
 
   ## Launch command

--- a/models/openai/gpt-oss-120b.yaml
+++ b/models/openai/gpt-oss-120b.yaml
@@ -64,9 +64,6 @@ compatible_strategies:
   - multi_node_dep
 
 hardware_overrides:
-  blackwell:
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: "1"
   amd:
     # vLLM 0.17.0+ replaces the old VLLM_ROCM_USE_AITER_* env knobs with
     # --attention-backend ROCM_AITER_UNIFIED_ATTN. HSA_NO_SCRATCH_RECLAIM is
@@ -137,12 +134,12 @@ guide: |
   Blackwell (B200) with FlashInfer MXFP4+MXFP8 MoE:
 
   ```bash
-  export VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1
-
   vllm serve openai/gpt-oss-120b --config GPT-OSS_Blackwell.yaml --tensor-parallel-size 1
   ```
 
-  Hopper (H100/H200): same as Blackwell without `kv-cache-dtype` and without the env var.
+  On vLLM v0.28.0+ the FlashInfer TRTLLM MXFP4 MoE path is selected automatically on Blackwell; it can be pinned explicitly with `--moe-backend flashinfer_trtllm --quantization-config.moe.activation mxfp8`.
+
+  Hopper (H100/H200): same as Blackwell without `kv-cache-dtype` and without the FlashInfer MoE flags.
 
   TPU v7 (Ironwood), verified on a `tpu7x-standard-4t` host (topology `2x2x1`, TP=2 × DP=4). Served via the OpenAI API-server entrypoint from the nightly TPU image (e.g. `vllm/vllm-tpu:nightly-20260316-e778980-57a314d`):
 
@@ -232,7 +229,7 @@ guide: |
 
   ## Troubleshooting
 
-  - **Attention sinks dtype error on Blackwell:** ensure env vars above are set.
+  - **Attention sinks dtype error on Blackwell:** pass `--quantization-config.moe.activation mxfp8` and `--kv-cache-dtype fp8`.
   - **`tl.language not defined`:** make sure no extra Triton (e.g., pytorch-triton) is installed.
   - **H100 TP1 OOM:** `--gpu-memory-utilization 0.95 --max-num-batched-tokens 1024`.
   - **Harmony vocab download failure:** pre-download tiktoken files and set `TIKTOKEN_ENCODINGS_BASE`.

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -58,9 +58,6 @@ hardware_overrides:
       - "16384"
       - "--gpu-memory-utilization"
       - "0.8"
-  blackwell:
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: "1"
   amd:
     extra_args:
       - "--attention-backend"
@@ -172,12 +169,12 @@ guide: |
   Blackwell (B200) with FlashInfer MXFP4+MXFP8 MoE:
 
   ```bash
-  export VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1
-
   vllm serve openai/gpt-oss-20b
   ```
 
-  Hopper (H100/H200): same as Blackwell minus `--kv-cache-dtype fp8` and the FlashInfer env var.
+  On vLLM v0.28.0+ the FlashInfer TRTLLM MXFP4 MoE path is selected automatically on Blackwell; it can be pinned explicitly with `--moe-backend flashinfer_trtllm --quantization-config.moe.activation mxfp8`.
+
+  Hopper (H100/H200): same as Blackwell minus `--kv-cache-dtype fp8` and the FlashInfer MoE flags.
 
   AMD MI300X/MI325X/MI355X:
 
@@ -242,7 +239,7 @@ guide: |
 
   ## Troubleshooting
 
-  - **Attention sinks dtype error on Blackwell:** ensure `VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1` and `--kv-cache-dtype fp8`.
+  - **Attention sinks dtype error on Blackwell:** pass `--quantization-config.moe.activation mxfp8` and `--kv-cache-dtype fp8`.
   - **`tl.language not defined`:** make sure no extra Triton (e.g., `pytorch-triton`) is installed alongside vLLM's bundled Triton.
   - **Harmony vocab download failure:** pre-download tiktoken files and set `TIKTOKEN_ENCODINGS_BASE`.
 

--- a/models/stepfun-ai/Step-3.5-Flash.yaml
+++ b/models/stepfun-ai/Step-3.5-Flash.yaml
@@ -84,10 +84,6 @@ compatible_strategies:
   - pd_cluster
 
 hardware_overrides:
-  blackwell:
-    extra_args: []
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP8: "0"
   amd:
     # Step-3.5 uses a custom SWIGLUSTEP activation that AITER MoE doesn't
     # support in vLLM 0.17.1 — keep AITER on for attention, MoE off.
@@ -186,9 +182,8 @@ guide: |
   - **MoE kernel tuning:** See [tune-moe-kernel](https://github.com/vllm-project/recipes/blob/main/Qwen/Qwen3-Next.md#tune-moe-kernel)
     to tune Triton kernels for your hardware.
   - **FP8 DeepGEMM:** For FP8, install DeepGEMM via [install_deepgemm.sh](https://github.com/vllm-project/vllm/blob/v0.16.0rc0/tools/install_deepgemm.sh).
-  - **B200 FlashInfer FP8 MoE error:** If you see
-    `routing_logits must be bfloat16` when serving FP8 on B200, set
-    `export VLLM_USE_FLASHINFER_MOE_FP8=0` as a workaround.
+  - **B200 FlashInfer FP8 MoE error:** The `routing_logits must be bfloat16`
+    error on B200 was fixed in vLLM v0.28.0 — no workaround is needed.
   - **FP8 + TP4 incompatibility:** Use DP4+EP instead.
 
   ## References

--- a/models/zai-org/GLM-4.7.yaml
+++ b/models/zai-org/GLM-4.7.yaml
@@ -74,8 +74,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp

--- a/models/zai-org/GLM-5.1.yaml
+++ b/models/zai-org/GLM-5.1.yaml
@@ -74,8 +74,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
   mxfp4:
     model_id: "amd/GLM-5.1-MXFP4"
     precision: mxfp4

--- a/models/zai-org/GLM-5.2.yaml
+++ b/models/zai-org/GLM-5.2.yaml
@@ -22,7 +22,7 @@ model:
   model_id: "zai-org/GLM-5.2"
   min_vllm_version: "0.23.0"
   docker_image:
-    nvidia: "vllm/vllm-openai:v0.23.0"
+    nvidia: "vllm/vllm-openai:v0.28.0"
     amd: "vllm/vllm-openai-rocm:nightly-4c626633159887b0f2c962058c17c78f1434556d"
   architecture: moe
   parameter_count: "743B"

--- a/models/zai-org/GLM-5.yaml
+++ b/models/zai-org/GLM-5.yaml
@@ -66,8 +66,6 @@ variants:
     extra_args:
       - "--kv-cache-dtype"
       - "fp8"
-    extra_env:
-      VLLM_USE_FLASHINFER_MOE_FP4: "1"
 
 compatible_strategies:
   - single_node_tp


### PR DESCRIPTION
## Summary

Brings the YAML recipes in line with the vLLM **v0.28.0** release (`vllm/vllm-openai:v0.28.0`, verified on Docker Hub along with `-ubuntu2404`, `-cu129`, and `vllm-openai-rocm:v0.28.0`).

### Image bumps (generic release pins only)

Model-specific tags (`glm51`, `stepfun37`, `minimax27`, `qwen38*`, …), `:latest`/`:nightly`, and non-vLLM images (`eugr/*`, `quay.io/ascend/*`) are untouched.

- `vllm/vllm-openai:v0.28.0` — DeepSeek-V4-Flash, Macaron-V1-Coding-Venti, MiniMax-M2.5, Nemotron-3-Ultra, Nemotron-3.5-Lightning, GLM-5.2, Nemotron-3-Nano-30B/4B guides (previously pinned as far back as v0.12.0)
- `vllm/vllm-openai:v0.28.0-ubuntu2404` — Nemotron-3-Super-120B
- `vllm/vllm-openai:v0.28.0-cu129` — Nemotron-3-Nano-Omni (pip pin `vllm[audio]` bumped to match)
- `vllm/vllm-openai-rocm:v0.28.0` — Ring-2.6-1T, Ling-2.6-flash, Ling-2.6-1T, Qwen3-VL-235B (amd)

### Env vars removed upstream → migrated to flags (now no-ops on v0.28.0)

- `VLLM_USE_FLASHINFER_MOE_FP4` / `VLLM_USE_FLASHINFER_MOE_FP8=1` — **dropped** (14 recipes: DeepSeek V3/V3.1/V3.2/R1, Kimi-K2.5/K2.6/K2-Thinking, Trinity, Qwen3 family, GLM-4.7/5/5.1, MiniMax M2/M2.5/M2.7, Llama-4-Scout). In v0.28.0 the MoE auto-selection already prefers the FlashInfer kernels these forced; guides now note the optional explicit pin `--moe-backend flashinfer_trtllm`.
- `VLLM_FLASHINFER_MOE_BACKEND=latency` → `--moe-backend flashinfer_trtllm` (Qwen3-Next, Qwen3.5); `=throughput` → `--moe-backend flashinfer_cutlass` (Nemotron-3-Nano-30B) — same mapping upstream used in its own eval configs (vllm-project/vllm#43148, vllm-project/vllm#44992).
- `VLLM_ATTENTION_BACKEND=FLASH_ATTN` → `--attention-backend FLASH_ATTN`; `VLLM_USE_TRTLLM_ATTENTION=0` dropped as redundant (Qwen3-Next).
- `VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8` (gpt-oss-20b/120b) — dropped; auto-selected on Blackwell now. Troubleshooting advice updated to `--quantization-config.moe.activation mxfp8`, matching upstream's gpt-oss eval configs.
- `VLLM_USE_FLASHINFER_MOE_FP8=0` B200 workaround dropped (Step-3.5-Flash) — the `routing_logits must be bfloat16` assertion no longer exists in v0.28.0.
- `VLLM_RPC_TIMEOUT` (dead code, removed in vllm-project/vllm#44128) and `VLLM_USE_V1` removed from DeepSeek-V3.2-Exp, DeepSeek-V4-Flash, Qwen3-VL-235B, Qwen2.5-32B.
- `CONTRIBUTING.md` schema example no longer uses a removed env var.

Not touched: legacy top-level Markdown guides (per recent maintenance convention, e.g. #896) and `min_vllm_version` minimum-version statements.

## Validation

`node scripts/build-recipes-api.mjs` → `✓ JSON API: 180 models … 9 strategies` with no errors.
