### PR TITLE
Bump min_vllm_version for recipes emitting --moe-backend

### DIFF
--- a/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
+++ b/models/Qwen/Qwen3-Next-80B-A3B-Instruct.yaml
@@ -18,7 +18,7 @@ meta:
 
 model:
   model_id: "Qwen/Qwen3-Next-80B-A3B-Instruct"
-  min_vllm_version: "0.10.0"
+  min_vllm_version: "0.17.0"
   architecture: moe
   parameter_count: "80B"
   active_parameters: "3B"
@@ -121,7 +121,7 @@ guide: |
     --enable-prefix-caching
   ```
 
-  On SM100, accelerate with the FP8 FlashInfer TRTLLM MoE kernel:
+  On SM100, accelerate with the FlashInfer TRTLLM MoE kernel:
   ```bash
   VLLM_USE_DEEP_GEMM=0 \
   vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \

--- a/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.yaml
@@ -18,7 +18,7 @@ meta:
 
 model:
   model_id: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
-  min_vllm_version: "0.11.2"
+  min_vllm_version: "0.17.0"
   architecture: moe
   parameter_count: "30B"
   active_parameters: "3B"
@@ -97,7 +97,7 @@ guide: |
   ## Prerequisites
 
   - Hardware: 1x H100/H200 or comparable; DGX Spark, Jetson Thor, and Intel Arc Pro B60/B70 supported
-  - vLLM >= 0.11.2 (0.28.0 recommended for full support)
+  - vLLM >= 0.17.0 (0.28.0 recommended for full support)
   - Docker with NVIDIA Container Toolkit (recommended)
 
   ### Pull Docker Image


### PR DESCRIPTION
Follow-up to #903: `--moe-backend` needs vLLM >= v0.17.0 ([vllm#33807](https://github.com/vllm-project/vllm/pull/33807), first in [v0.17.0](https://github.com/vllm-project/vllm/releases/tag/v0.17.0)), above the `min_vllm_version` on two recipes it was added to.

- `Qwen3-Next-80B-A3B-Instruct`: `0.10.0` → `0.17.0` (blackwell override)
- `NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`: `0.11.2` → `0.17.0` (fp8 variant, nvidia override)

Both bumps are recipe-wide though the flag is conditional. For Nemotron a per-variant `variants.fp8.min_vllm_version` would be tighter — happy to switch.

`node scripts/build-recipes-api.mjs` passes.
