### PR TITLE
Add deepseek-ai/DeepSeek-V4-Flash-Vision-Exp recipe

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.yaml
@@ -1,0 +1,287 @@
+meta:
+  title: "DeepSeek-V4-Flash-Vision-Exp"
+  slug: "deepseek-v4-flash-vision-exp"
+  provider: "DeepSeek"
+  description: "DeepSeek's first experimental multimodal V4 model — the V4-Flash MoE backbone plus a 32-layer vision tower, 1M context, and a fused DSpark draft module."
+  date_added: 2026-09-01
+  date_updated: 2026-09-01
+  difficulty: advanced
+  tasks:
+    - text
+    - multimodal
+  performance_headline: "First multimodal V4 — 285B/13B MoE scoring 83.5% on OCRBench from a single GB200 NVL4 tray"
+  related_recipes:
+    - "deepseek-ai/DeepSeek-V4-Flash"
+    - "deepseek-ai/DeepSeek-V4-Pro"
+  # The vision path is unreleased — it lives in the open support PR
+  # vllm-project/vllm#54566 (see model.install below). GB200 is the only
+  # hardware with a published end-to-end run on that branch: TP4 + EP on one
+  # NVL4 tray, FP8 KV cache, block size 256, DSpark k=3, full 1000-sample
+  # OCRBench at 83.5% with zero request errors.
+  default_hardware: gb200
+  hardware:
+    gb200: verified
+
+model:
+  model_id: "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp"
+  # Support targets the next release; nothing has shipped yet, so the pinned
+  # image below is the only runnable path.
+  min_vllm_version: "0.29.0"
+  nightly_required: true
+  docker_image: "vllm/vllm-openai:deepseekv4-flash-vision"
+  install:
+    # Docker first so it is the default tab. The official wheel can't run this
+    # checkpoint: released vLLM routes it to the text-only
+    # DeepseekV4ForCausalLM, which then fails on the vision/aligner tensors.
+    docker:
+      note: "Use the dedicated DeepSeek-V4-Flash-Vision image until support lands in the standard vLLM image."
+    pip: false
+  architecture: moe
+  parameter_count: "285B"
+  active_parameters: "13B"
+  context_length: 1048576
+  flashinfer_autotune: true
+  base_args:
+    - "--kv-cache-dtype"
+    - "fp8"
+    - "--block-size"
+    - "256"
+
+features:
+  tool_calling:
+    description: "DeepSeek V4 tool-call parsing with automatic tool choice."
+    args:
+      - "--tool-call-parser"
+      - "deepseek_v4"
+      - "--enable-auto-tool-choice"
+  reasoning:
+    description: "Enable reasoning/thinking mode with the DeepSeek V4 reasoning parser."
+    args:
+      - "--reasoning-parser"
+      - "deepseek_v4"
+      - "--reasoning-config"
+      - '{"reasoning_parser":"deepseek_v4","reasoning_start_str":"","reasoning_end_str":""}'
+  # Single method, so the boolean form (not `modes`): the checkpoint's fused
+  # DSpark module is the only drafter with a published run on this branch. Left
+  # OUT of opt_in_features on purpose — the verified GB200 configuration had
+  # DSpark on, and DeepSeek's own model card enables it too, so the default
+  # builder state reproduces the tested command. The checkpoint also carries
+  # 3 MTP layers (`num_nextn_predict_layers: 3`); that path is untested here.
+  spec_decoding:
+    description: "DSpark self-drafting from the checkpoint's fused draft module — 3 draft tokens, probabilistic sampling, adaptive verification. Mean acceptance length 2.99 tokens/forward on mixed text+image traffic."
+    args:
+      - "--speculative-config"
+      - '{"method":"dspark","model":"deepseek-ai/DeepSeek-V4-Flash-Vision-Exp","num_speculative_tokens":3,"draft_sample_method":"probabilistic","enable_adaptive_verification":true}'
+
+variants:
+  default:
+    precision: fp8
+    # Mixed FP4 experts + FP8 remainder, so the bytes-per-param table
+    # underestimates: sized from the real checkpoint (167.8 GB x 1.2).
+    vram_minimum_gb: 202
+    description: "Native FP4+FP8 mixed checkpoint (MoE experts FP4, attention/norm/router FP8) with a BF16 vision tower, aligner, and the fused DSpark draft module."
+
+compatible_strategies:
+  - single_node_tp
+  - single_node_tep
+  - single_node_dep
+  - multi_node_tep
+  - multi_node_dep
+
+# TP + EP is the verified layout (TP4 + EP on one GB200 NVL4 tray).
+default_strategy: single_node_tep
+
+guide: |
+  ## Overview
+
+  DeepSeek-V4-Flash-Vision-Exp is DeepSeek's first multimodal model in the V4 family.
+  It keeps the DeepSeek-V4-Flash language backbone — 43 layers, 256 routed experts with
+  6 active per token, Compressed Sparse Attention plus manifold-constrained
+  hyper-connections, a 1,048,576-token context window — and adds a 32-layer / 1024-dim
+  ViT with a two-layer aligner (~0.5B parameters on top of the 284B backbone). Weights
+  are **FP4+FP8 mixed**: MoE experts in FP4, the remaining attention / norm / router
+  params in FP8, vision tower in BF16. The checkpoint is 48 shards / ~168 GB and carries
+  the fused **DSpark** draft module.
+
+  DeepSeek reports it beats DeepSeek-V4-Flash-0731 on multimodal agent benchmarks
+  (ApexBench 36.5 vs 26.2, Agents' Last Exam 27.3 vs 25.2) while holding text-agent
+  parity (Terminal Bench 2.1 at 83.9, DeepSWE at 59.3).
+
+  ## Prerequisites
+
+  Vision support is not in a stable vLLM release yet — it lives in
+  [vllm-project/vllm#54566](https://github.com/vllm-project/vllm/pull/54566). Until that
+  lands, use the pinned `vllm/vllm-openai:deepseekv4-flash-vision` image; the official
+  wheel routes this checkpoint to the text-only class and fails on the vision tensors.
+
+  - **Weights:** ~168 GB on disk (48 shards). Budget ~202 GB of VRAM before KV cache.
+  - **Hardware:** NVIDIA only — the ROCm and XPU builds have no vision implementation.
+  - **Tokenizer / chat template:** nothing to pass. The repo ships no Jinja template
+    (prompt encoding lives in `encoding/`); vLLM resolves `--tokenizer-mode` to
+    `deepseek_v4` automatically, which is what turns OpenAI content blocks into
+    `<｜deepseek_image｜>` placeholders.
+
+  ## Launching the server
+
+  ### Verified configuration — one GB200 NVL4 tray (TP4 + EP)
+
+  ```bash
+  export VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS="trtllm_fp4_block_scale_moe,flashinfer::trtllm_fp4_block_scale_moe"
+
+  vllm serve deepseek-ai/DeepSeek-V4-Flash-Vision-Exp \
+    --tensor-parallel-size 4 \
+    --enable-expert-parallel \
+    --kv-cache-dtype fp8 \
+    --block-size 256 \
+    --max-model-len 32768 \
+    --speculative-config '{"method":"dspark","model":"deepseek-ai/DeepSeek-V4-Flash-Vision-Exp","num_speculative_tokens":3,"draft_sample_method":"probabilistic","enable_adaptive_verification":true}' \
+    --allowed-local-media-path /mnt/lustre
+  ```
+
+  Three things there are environment-specific, which is why the builder above leaves
+  them out:
+
+  - `VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS` excludes the FP4 block-scale MoE op from
+    FlashInfer's startup autotuning. Export it if autotuning that op fails or costs more
+    startup time than it earns back on your FlashInfer build; it is a tuning knob, not a
+    requirement. The Advanced row's `--no-enable-flashinfer-autotune` turns autotuning
+    off wholesale instead.
+  - `--max-model-len 32768` bounds KV cache for the benchmark. The checkpoint advertises
+    1M tokens; that is **not** what was measured, and 1M-token KV needs far more memory
+    than the weights do. Raise it deliberately, or use the Advanced row's
+    `--max-model-len auto`.
+  - `--allowed-local-media-path` is only needed for `file://` image URLs. Drop it if
+    clients send `http(s)://` or base64 data URLs.
+
+  ### 8-GPU nodes (H200 / B200 / B300)
+
+  Same **Tensor + Expert Parallel** strategy; the builder emits
+  `--tensor-parallel-size 8 --enable-expert-parallel`. The language backbone is the one
+  the [DeepSeek-V4-Flash](/deepseek-ai/DeepSeek-V4-Flash) recipe already runs there, but
+  the vision path has no published run on those GPUs — expect to tune
+  `--gpu-memory-utilization` and `--max-num-seqs`. The Blackwell
+  `--attention_config.use_fp4_indexer_cache` / `--moe-backend deep_gemm_mega_moe` tweaks
+  the text recipe applies are deliberately not set here: the verified vision run did not
+  use them.
+
+  ## Reasoning modes
+
+  Same three-tier control as the rest of the V4 family, driven from
+  `chat_template_kwargs` rather than a flag — `encoding/encoding_dsv4.py` names the
+  effort levels `low` / `high` / `max`. DeepSeek evaluated this model at
+  `reasoning_effort: "max"` with `temperature = 1.0, top_p = 0.95`.
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+  model = "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp"
+
+  resp = client.chat.completions.create(
+      model=model,
+      messages=[{"role": "user", "content": "What is 17*19? Return only the final integer."}],
+      temperature=1.0,
+      top_p=0.95,
+      extra_body={
+          "chat_template_kwargs": {"thinking": True, "reasoning_effort": "max"},
+      },
+  )
+  print(resp.choices[0].message.reasoning)
+  print(resp.choices[0].message.content)
+  ```
+
+  ## Client usage — image input
+
+  Standard OpenAI multi-part content. Multiple images per request are allowed with no
+  cap, so the practical limit is `--max-model-len`.
+
+  ```python
+  from openai import OpenAI
+
+  client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+  resp = client.chat.completions.create(
+      model="deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+      messages=[{
+          "role": "user",
+          "content": [
+              {"type": "image_url", "image_url": {"url": "https://example.com/chart.png"}},
+              {"type": "text", "text": "Read the y-axis label and the highest bar's value."},
+          ],
+      }],
+      max_tokens=512,
+  )
+  print(resp.choices[0].message.content)
+  ```
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+      "messages": [{
+        "role": "user",
+        "content": [
+          {"type": "image_url", "image_url": {"url": "https://example.com/chart.png"}},
+          {"type": "text", "text": "Describe the image."}
+        ]
+      }],
+      "max_tokens": 512
+    }'
+  ```
+
+  Image preprocessing is fixed by the checkpoint config (the processor takes no kwargs):
+  each image costs at most 387 prompt tokens (`vision_max_n_token: 384` plus the
+  compressor-alignment pad), images below `vision_min_pixels: 147456` are upscaled, and
+  aspect ratios beyond 8:1 are cropped. An image's exact token count depends on where it
+  sits in the prompt, since the compressor pads each image to a 4-token block boundary.
+
+  ## Speculative decoding
+
+  DSpark drafts from the module fused into the checkpoint, so `--speculative-config`
+  names the target repo as its own `model` — there is no separate draft repo to download.
+  Measured over the full OCRBench run on GB200 (mixed text+image traffic): **2.99**
+  tokens/forward mean acceptance length, **66.3%** overall acceptance
+  (83.9% / 66.5% / 50.7% by draft position). Image tokens in the prompt do not degrade
+  acceptance — the drafter reads image content through the target's hidden states.
+
+  Stay at `num_speculative_tokens: 3` unless you verify acceptance yourself; the
+  checkpoint's trained DSpark block width is 5, but 3 is the depth with published
+  numbers.
+
+  ## Benchmarking
+
+  OCRBench, full 1000 samples, on the verified GB200 configuration: **835/1000
+  (83.5%)**, 0 request errors, 312.6 s (~3.2 samples/s). Strongest categories are Key
+  Information Extraction (92.5%), Doc-oriented VQA (90.0%) and Scene Text VQA (89.5%);
+  weakest are handwritten math (49.0%) and handwriting recognition (58.0%).
+
+  For throughput:
+
+  ```bash
+  vllm bench serve \
+    --model deepseek-ai/DeepSeek-V4-Flash-Vision-Exp \
+    --dataset-name random \
+    --random-input-len 4096 \
+    --random-output-len 1024 \
+    --num-prompts 200
+  ```
+
+  ## Limitations
+
+  - **Pre-release.** Flags and defaults can change before #54566 lands; re-check before
+    deploying, and keep the image pinned.
+  - **NVIDIA only.** ROCm and XPU raise `NotImplementedError` at model construction.
+  - **GB200 is the only hardware with a published vision run.** Every other pill is the
+    repo's fail-open default, not a tested claim.
+  - **PD disaggregation is not offered**, and the CPU/filesystem KV-offload pills stay
+    off — neither has a verified run to record. The Mooncake KV-store pills follow the
+    repo's fail-open default and are offered, but untested here.
+  - **1M context is advertised, not measured.** The reference run used 32K.
+
+  ## References
+
+  - [Model card](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp)
+  - [vLLM support PR #54566](https://github.com/vllm-project/vllm/pull/54566)
+  - [DeepSeek-V4-Flash recipe](/deepseek-ai/DeepSeek-V4-Flash) — the text-only sibling
+  - [DeepSpec (DSpark)](https://github.com/deepseek-ai/DeepSpec)


### PR DESCRIPTION
## Summary

Adds a recipe for [`deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp) — DeepSeek's first multimodal model in the V4 family. It keeps the DeepSeek-V4-Flash language backbone (284B total / 13B active, 43 layers, 256 routed experts with 6 active per token, 1M context) and adds a 32-layer / 1024-dim ViT plus a two-layer aligner. Weights are FP4+FP8 mixed with a BF16 vision tower: 48 shards, ~168 GB.

DeepSeek reports it beating DeepSeek-V4-Flash-0731 on multimodal agent benchmarks (ApexBench 36.5 vs 26.2, Agents' Last Exam 27.3 vs 25.2) while holding text-agent parity (Terminal Bench 2.1 at 83.9, DeepSWE at 59.3).

## Support status

**vLLM support for the vision path is not in a stable release yet.** The checkpoint declares `architectures: ["DeepseekV4ForCausalLM"]` — the same string as the text-only model — so released vLLM routes it to the text class and then fails on the vision/aligner tensors. Support is in [vllm-project/vllm#54566](https://github.com/vllm-project/vllm/pull/54566), which adds `DeepseekV4ForConditionalGeneration` and selects it automatically when `vision_n_layers > 0` (no `--hf-overrides` needed).

The recipe therefore pins `vllm/vllm-openai:deepseekv4-flash-vision` and sets `install.pip: false`, with `min_vllm_version: 0.29.0` + `nightly_required: true` — the same shape as the GLM-5.3-Flash recipe. The Install block's Docker tab is first so it is the default.

## Evidence behind the claims

| Field | Source |
|---|---|
| `gb200: verified`, `default_hardware: gb200` | #54566's published run — TP4 + EP on one NVL4 tray, FP8 KV cache, block size 256, DSpark k=3 → OCRBench 835/1000 (83.5%), 0 request errors |
| `base_args` / `spec_decoding` args | copied from that run's command, so the default builder state reproduces it |
| `mi300x` / `mi325x` / `mi355x: unsupported` | the support branch's `vl_stub.py` raises `NotImplementedError` for the vision class on ROCm and XPU — only `nvidia/vl_model.py` exists |
| `parameter_count: 285B` | 284B backbone + ~0.47B vision tower and aligner, consistent with the 167.8 GB vs 166.9 GB delta against the 0731 checkpoint |
| `vram_minimum_gb: 202` | mixed FP4/FP8, so sized from the real checkpoint (167.8 GB × 1.2) rather than the bytes-per-param table |
| `context_length: 1048576` | `max_position_embeddings`; the guide states plainly that the reference run used 32K |

`spec_decoding` is deliberately **not** in `opt_in_features`: the verified run had DSpark on, and DeepSeek's own model card enables it too, so the default command matches what was measured.

## Deliberately left out

- **`pd_cluster`** — atomic image-span prefill and the per-request image ranges threaded into the sparse-SWA metadata builder have no evidence under a split prefill/decode deployment.
- **`kv_offload_support`** — no verified run to record, so the CPU/filesystem pills stay off. The Mooncake pills follow the repo's fail-open default.
- **MTP as a spec-decoding mode** — the checkpoint carries 3 MTP layers, but only DSpark has published numbers, so the boolean feature form is used instead of `modes`.
- **DGX Spark / RTX PRO 6000** — the one RTX PRO 6000 run I found was on a different implementation, not this branch.
- **`VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS`** — the reference run exports it, but skipping FlashInfer autotune for the FP4 block-scale MoE op is a per-environment tuning knob rather than a requirement for serving this model, so it is documented in the guide instead of `base_env`. The Advanced row already offers `--no-enable-flashinfer-autotune` for turning autotuning off wholesale.
- **Blackwell `--attention_config.use_fp4_indexer_cache` / `--moe-backend deep_gemm_mega_moe`** — the text sibling applies these, but the verified vision run did not, and adding them would make the generated command diverge from what was tested.

## Validation

- `node scripts/build-recipes-api.mjs` → `✓ JSON API: 181 models (156 with recommended_command, 757 default-hw alternatives, 1402 per-hw renderings), 185 promoted variants, 9 strategies`
- Generated command on the default GB200 / Tensor + Expert Parallel selection matches the reference command, modulo `VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS`, `--max-model-len 32768` and `--allowed-local-media-path` (all environment-specific, documented in the guide instead of baked into the recipe).
- Checked the alternate renderings (H200 / B200 / B300 / GB300 / H100 × TP, TEP, DEP, multi-node TEP/DEP) and the AMD profiles are correctly absent from the per-hardware output.
- `git diff --check` clean; only the recipe YAML is staged (no `public/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
