### PR TITLE
Cap max_num_seqs for GLM-5.3-Flash on Hopper

### DIFF
--- a/models/zai-org/GLM-5.3-Flash.yaml
+++ b/models/zai-org/GLM-5.3-Flash.yaml
@@ -87,8 +87,12 @@ compatible_strategies:
 
 hardware_overrides:
   hopper:
+    # The default max_num_seqs of 1024 exceeds the Mamba cache blocks available
+    # at TP4, and startup fails. AMD already caps this below.
     extra_args:
       - "--no-enable-flashinfer-autotune"
+      - "--max-num-seqs"
+      - "512"
   blackwell:
     # FP8 KV cache only works on Blackwell for this model; Hopper runs BF16 KV.
     extra_args:


### PR DESCRIPTION
Serving `zai-org/GLM-5.3-Flash` on 4xH200 with the recipe's own NVIDIA flags never starts:

```
RuntimeError: max_num_seqs (1024) exceeds available Mamba cache blocks (512).
```

vLLM defaults `max_num_seqs` to 1024. The recipe caps it at 512 under `hardware_overrides.amd`, but `base_args` is empty and the `hopper` block only sets `--no-enable-flashinfer-autotune`, so anyone following the guide's 4xH100/H200 command hits this.

Adding the same cap to `hopper`. With it the server comes up (38.43 GiB KV cache, 3,511,589 tokens, full 1M context at 3.35x concurrency) and answers normally.

Left Blackwell alone — I only tested Hopper, and its larger memory may leave room for more Mamba cache blocks.
