### PR TITLE
[Doc][Ascend] Fix 950PR docker run: davinci devices and full driver mount

### DIFF
--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -614,7 +614,7 @@ dependencies:
     install_modes: [docker]
   - note: "Ascend Docker path: the generated docker run covers the NPU devices and driver mounts but not the vLLM-Omni checkout this recipe overlays. Start the container with the mounts below, then run the serve command inside it. --shm-size is required — the 64 MB default cannot carry the decoded video back to the API server over shared memory."
     command: |
-      docker run --rm -it --net=host --shm-size=8g \
+      docker run --rm -it --net=host --shm-size=16g \
         --device /dev/davinci0 --device /dev/davinci_manager --device /dev/hisi_hdc \
         -v /usr/local/dcmi:/usr/local/dcmi \
         -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -612,19 +612,6 @@ dependencies:
   - note: "Docker path only: clone current vLLM-Omni main to the path mounted by the generated command so it overrides the older package in the image."
     command: "git clone --depth 1 https://github.com/vllm-project/vllm-omni.git /path/to/vllm-omni"
     install_modes: [docker]
-  - note: "Ascend Docker path: the generated docker run covers the NPU devices and driver mounts but not the vLLM-Omni checkout this recipe overlays. Start the container with the mounts below, then run the serve command inside it. --shm-size is required — the 64 MB default cannot carry the decoded video back to the API server over shared memory."
-    command: |
-      docker run --rm -it --net=host --shm-size=16g \
-        --device /dev/davinci0 --device /dev/davinci_manager --device /dev/hisi_hdc \
-        -v /usr/local/dcmi:/usr/local/dcmi \
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
-        -v /etc/ascend_install.info:/etc/ascend_install.info \
-        -v /path/to/MiniMax-H3:/path/to/MiniMax-H3:ro \
-        -v /path/to/vllm-omni:/path/to/vllm-omni:ro \
-        quay.io/ascend/vllm-omni:minimax-h3 bash
-    install_modes: [docker]
-    brand: Huawei
   - note: "pip path only: ffmpeg and ffprobe must be on PATH for reference-video preparation and MP4 video+audio muxing. The official Docker images already bundle them."
     command: "sudo apt-get install -y ffmpeg"
 

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -612,15 +612,13 @@ dependencies:
   - note: "Docker path only: clone current vLLM-Omni main to the path mounted by the generated command so it overrides the older package in the image."
     command: "git clone --depth 1 https://github.com/vllm-project/vllm-omni.git /path/to/vllm-omni"
     install_modes: [docker]
-  - note: "Ascend Docker path: the generated docker run emits --gpus all, which the NPU runtime ignores. Start the container with the CANN device and driver mounts below, then run the serve command inside it. --shm-size is required — the 64 MB default cannot carry the decoded video back to the API server over shared memory."
+  - note: "Ascend Docker path: the generated docker run covers the NPU devices and driver mounts but not the vLLM-Omni checkout this recipe overlays. Start the container with the mounts below, then run the serve command inside it. --shm-size is required — the 64 MB default cannot carry the decoded video back to the API server over shared memory."
     command: |
       docker run --rm -it --net=host --shm-size=8g \
-        --device /dev/davinci0 --device /dev/davinci_manager \
-        --device /dev/devmm_svm --device /dev/hisi_hdc \
+        --device /dev/davinci0 --device /dev/davinci_manager --device /dev/hisi_hdc \
         -v /usr/local/dcmi:/usr/local/dcmi \
         -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
-        -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-        -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
         -v /etc/ascend_install.info:/etc/ascend_install.info \
         -v /path/to/MiniMax-H3:/path/to/MiniMax-H3:ro \
         -v /path/to/vllm-omni:/path/to/vllm-omni:ro \

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -305,6 +305,7 @@ function dockerize(command, argv, env, dockerMeta, port = 8000) {
   return {
     docker_command: buildDockerRun({
       command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, port,
+      isNpu: dockerMeta.isNpu,
     }),
     docker_argv: buildDockerArgv({ argv, env, meta: dockerMeta, port }),
   };

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -3122,7 +3122,7 @@ function SingleCommandBlock({ command, env, companions, verifyCmd, benchCmd, sta
     ? ["source /opt/intel/oneapi/setvars.sh", preludeBase].filter(Boolean).join("\n")
     : preludeBase;
   const displayCommand = isDocker
-    ? buildDockerRun({ command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags })
+    ? buildDockerRun({ command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isNpu: dockerMeta.isNpu })
     : command;
   // A companion process may ride along (`companions[]` from resolveCommand —
   // a feature's `companion:` or the active kv_offload option's, e.g.
@@ -3237,7 +3237,7 @@ function InstallBlock({ recipe, variant, dockerMeta, installMode, setInstallMode
   const pipHidden = pipCfg === false;
   const dockerHidden = dockerCfg === false;
   const [open, setOpen] = useState(false);
-  const { isAmd, isTpu, isXpu, isIntel, image: dockerImage, brandKey, cudaMap } = dockerMeta;
+  const { isAmd, isTpu, isXpu, isIntel, isNpu, image: dockerImage, brandKey, cudaMap } = dockerMeta;
   // Intel CPU is a first-class backend in computeDockerMeta. Keep XPU
   // distinct even though it is also Intel hardware.
   const isCpu = isIntel && !isXpu;
@@ -3321,6 +3321,8 @@ uv pip install -U vllm --torch-backend auto`;
     ? "TPU builds are published by vllm-project/tpu-inference. See the Trillium and Ironwood tpu-recipes for pinned image tags and exact deployment flags."
     : isXpu
       ? "Intel XPU image. The entrypoint initializes oneAPI automatically."
+    : isNpu
+      ? "Ascend NPU image. The generated docker run bind-mounts `/dev/davinci*` and the host driver at `/usr/local/Ascend/driver` (including HCCL topo files)."
     : isAmd
       ? undefined
     : isCpu
@@ -3342,6 +3344,7 @@ uv pip install -U vllm --torch-backend auto`;
   // toggle either — the note explains the one published build instead.
   const showCudaSelector =
     brandKey === "nvidia" &&
+    !isNpu &&
     !singleCudaBuild &&
     !dockerCfg?.command &&
     // Only upstream publishes paired `-cu129` / `cu129-nightly` tags. On a
@@ -3355,7 +3358,7 @@ uv pip install -U vllm --torch-backend auto`;
   // Intel XPU is validated via the official `vllm-openai-xpu` Docker image;
   // `hwInstall.pip: false` is the per-GPU form of the same statement.
   const effectivePipHidden = pipHidden || isTpu || isXpu || hwInstall?.pip === false;
-  const dockerLabel = isTpu ? "Docker (TPU)" : isXpu ? "Docker (XPU)" : isAmd ? "Docker (ROCm)" : isCpu ? "Docker (CPU)" : "Docker";
+  const dockerLabel = isTpu ? "Docker (TPU)" : isXpu ? "Docker (XPU)" : isNpu ? "Docker (Ascend)" : isAmd ? "Docker (ROCm)" : isCpu ? "Docker (CPU)" : "Docker";
   const tabs = [
     !effectivePipHidden && {
       id: "pip",
@@ -3383,7 +3386,7 @@ uv pip install -U vllm --torch-backend auto`;
         <Package size={12} className="text-[var(--command-fg)]/50 shrink-0" />
         <span className="text-[11px] font-semibold text-[var(--command-fg)]/70 uppercase tracking-widest">Install</span>
         <span className="text-[11px] text-[var(--command-fg)]/40 font-mono">
-          vLLM {minV}+{isOmni ? " · vLLM-Omni nightly" : ""} · {isTpu ? "TPU" : isXpu ? "XPU" : isAmd ? "ROCm" : isCpu ? "CPU" : "CUDA"}
+          vLLM {minV}+{isOmni ? " · vLLM-Omni nightly" : ""} · {isTpu ? "TPU" : isXpu ? "XPU" : isNpu ? "Ascend" : isAmd ? "ROCm" : isCpu ? "CPU" : "CUDA"}
         </span>
         {nightlyRequired && (
           <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30 uppercase tracking-wider">
@@ -3504,7 +3507,7 @@ function MultiNodeBlock({ result, verifyCmd, benchCmd, statusHeader, installMode
   const isDocker = installMode === "docker";
   const wrap = (cmd) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env: result.env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu })
+      ? buildDockerRun({ command: cmd, env: result.env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu, isNpu: dockerMeta.isNpu })
       : cmd;
   // One tab per node: Head (rank 0) then every follower rank, each with its own
   // --node-rank / --data-parallel-start-rank. `workerCommands` carries them all;
@@ -3571,7 +3574,7 @@ function PdClusterBlock({ result, verifyCmd, benchCmd, statusHeader, onRankChang
   // it stays as-is with its pip-install hint regardless of install mode.
   const wrap = (cmd, env) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu })
+      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu, isNpu: dockerMeta.isNpu })
       : cmd;
   // Mooncake composed into PD (result.mooncake): a "Mooncake Config" tab
   // (launch step 0) writes the shared config file(s) once — every
@@ -3704,7 +3707,7 @@ function KvStoreLbBlock({ result, verifyCmd, benchCmd, statusHeader, onInstanceC
   const isDocker = installMode === "docker";
   const wrap = (cmd, env) =>
     isDocker
-      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu })
+      ? buildDockerRun({ command: cmd, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, isXpu: dockerMeta.isXpu, isNpu: dockerMeta.isNpu })
       : cmd;
 
   const instances = result.instances || 2;

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -593,6 +593,47 @@ export function pickDefaultHardware(hwProfiles, variant, recipe) {
 // Exact variant+hardware overrides may also set
 //   variants.<key>.hardware_overrides.<hw_id>.docker_image
 //
+// Host paths every Ascend container needs. `/usr/local/Ascend/driver` goes in
+// whole rather than as the `lib64` + `version.info` pair the older A2/A3
+// guides use: 950-class drivers keep the HCCL topology descriptors under
+// `driver/topo`, and without them `hcclCommInitRootInfoConfig` rejects the
+// communicator with EI0014 before the first forward pass.
+const ASCEND_HOST_MOUNTS = [
+  "/usr/local/Ascend/driver:/usr/local/Ascend/driver",
+  "/etc/ascend_install.info:/etc/ascend_install.info",
+  "/usr/local/dcmi:/usr/local/dcmi",
+  "/usr/local/bin/npu-smi:/usr/local/bin/npu-smi",
+];
+
+// Ascend has no `--gpus`-style flag: each NPU is its own `/dev/davinci<N>`
+// node, and `davinci_manager` plus `hisi_hdc` carry device management and the
+// host-device channel.
+function ascendDeviceNodes(deviceCount) {
+  return [
+    ...Array.from({ length: deviceCount }, (_, i) => `/dev/davinci${i}`),
+    "/dev/davinci_manager",
+    "/dev/hisi_hdc",
+  ];
+}
+
+// Four devices per line keeps a 16-NPU node readable without wrapping.
+function ascendDockerFlags(deviceCount) {
+  const devices = ascendDeviceNodes(deviceCount).map((node) => `--device ${node}`);
+  const lines = [];
+  for (let i = 0; i < devices.length; i += 4) {
+    lines.push(devices.slice(i, i + 4).join(" "));
+  }
+  lines.push(...ASCEND_HOST_MOUNTS.map((mount) => `-v ${mount}`));
+  return lines.join(" \\\n  ");
+}
+
+function ascendDockerArgv(deviceCount) {
+  const argv = [];
+  for (const node of ascendDeviceNodes(deviceCount)) argv.push("--device", node);
+  for (const mount of ASCEND_HOST_MOUNTS) argv.push("-v", mount);
+  return argv;
+}
+
 // When a CUDA map is in play, `cudaMap` is returned so the caller can pick by
 // the user's `dockerCudaVariant` toggle instead of appending `-cu129`/`-cu130`.
 export function computeDockerMeta(recipe, variant, hwProfile, hwId = null) {
@@ -618,6 +659,11 @@ export function computeDockerMeta(recipe, variant, hwProfile, hwId = null) {
   const isTpu = hwProfile?.generation === "tpu";
   const isXpu = hwProfile?.generation === "xpu";
   const isIntel = hwProfile?.generation === "cpu" || isXpu || hwProfile?.brand === "Intel";
+  const isNpu = hwProfile?.generation === "npu";
+  const npuDeviceCount = isNpu ? hwProfile?.gpu_count ?? 1 : 0;
+  // Ascend deliberately has no `brandKey` of its own: vLLM publishes no NPU
+  // image, so every Ascend recipe pins one through `hardware_overrides`, which
+  // `exactHardwareOverride` resolves before the brand defaults are consulted.
   const brandKey = isTpu ? "tpu" : isAmd ? "amd" : isIntel ? "intel" : "nvidia";
   // Exact variant+hardware image overrides win over variant-wide and
   // model-wide images (for example, an MI355X-only ROCm nightly).
@@ -667,10 +713,25 @@ export function computeDockerMeta(recipe, variant, hwProfile, hwId = null) {
       ? "--device=/dev/kfd --device=/dev/dri \\\n  --security-opt seccomp=unconfined --group-add video"
     : isXpu
       ? "--device /dev/dri \\\n  -v /dev/dri/by-path:/dev/dri/by-path --shm-size=16g"
+    : isNpu
+      ? ascendDockerFlags(npuDeviceCount)
     : isIntel
       ? "--shm-size=16g"	
       : "--gpus all";
-  return { image, gpuFlags, brandKey, isAmd, isTpu, isXpu, isIntel, pinned, cudaMap, nightlyRequired };
+  return {
+    image,
+    gpuFlags,
+    brandKey,
+    isAmd,
+    isTpu,
+    isXpu,
+    isIntel,
+    isNpu,
+    npuDeviceCount,
+    pinned,
+    cudaMap,
+    nightlyRequired,
+  };
 }
 
 // argv form of the brand-specific GPU flags from computeDockerMeta. Mirrors
@@ -687,6 +748,9 @@ function dockerGpuArgv(meta) {
   }
   if (meta.isXpu) {
     return ["--device", "/dev/dri", "-v", "/dev/dri/by-path:/dev/dri/by-path", "--shm-size", "16g"];
+  }
+  if (meta.isNpu) {
+    return ascendDockerArgv(meta.npuDeviceCount);
   }
   if (meta.isIntel) {
     return ["--shm-size", "16g"];
@@ -720,7 +784,7 @@ function localModelMount(modelId) {
 // Wrap a `vllm serve MODEL <args>` command in `docker run`. The vllm/vllm-openai
 // image's entrypoint is `vllm serve`, so we pass MODEL and the trailing args as
 // CMD. Env vars become `-e KEY=VAL` inside the container.
-export function buildDockerRun({ command, env, image, gpuFlags, port = 8000 }) {
+export function buildDockerRun({ command, env, image, gpuFlags, port = 8000, isNpu = false }) {
   const envFlags = Object.entries(env || {})
     .map(([k, v]) => `-e ${k}=${v}`)
     .join(" \\\n  ");
@@ -739,8 +803,13 @@ export function buildDockerRun({ command, env, image, gpuFlags, port = 8000 }) {
     ? `# ${modelId} must already exist on the host — bind-mounted read-only below.\n`
     : "";
   const serveBody = command.replace(/^vllm serve \S+\s*\\?\n?\s*/, "");
+  // Ascend uses host networking and an explicit shm size; `-p` is a no-op
+  // under `--net=host` and hid the required `--shm-size` on 950PR.
+  const runtimeFlags = isNpu
+    ? "--privileged --net=host --shm-size=16g"
+    : `--privileged --ipc=host -p ${port}:${port}`;
   const base = `${prereq}docker run ${gpuFlags} \\
-  --privileged --ipc=host -p ${port}:${port} \\
+  ${runtimeFlags} \\
   -v ~/.cache/huggingface:/root/.cache/huggingface \\${mountFlags ? `\n  ${mountFlags} \\` : ""}${envFlags ? `\n  ${envFlags} \\` : ""}`;
   return `${base}
   ${image} ${modelId}${serveBody ? ` \\\n  ${serveBody}` : ""}`;
@@ -761,11 +830,13 @@ export function buildDockerArgv({ argv, env, meta, port = 8000 }) {
   for (const m of [...localModelMount(cmdArgs[0]), ...configPathMounts(env)]) {
     mountFlags.push("-v", m);
   }
+  const runtimeFlags = meta.isNpu
+    ? ["--privileged", "--net=host", "--shm-size", "16g"]
+    : ["--privileged", "--ipc=host", "-p", `${port}:${port}`];
   const base = [
     "docker", "run",
     ...dockerGpuArgv(meta),
-    "--privileged", "--ipc=host",
-    "-p", `${port}:${port}`,
+    ...runtimeFlags,
     "-v", "~/.cache/huggingface:/root/.cache/huggingface",
     ...mountFlags,
     ...envFlags,


### PR DESCRIPTION
## Summary
- Generated `docker run` for Huawei NPU hardware (`ascend_950pr`, `ascend_950pr_8x`, `ascend_950dt_8x`) no longer emits `--gpus all`, which the NPU runtime ignores.
- The command now bind-mounts `/dev/davinci*` plus `/usr/local/Ascend/driver` as a whole directory (not just `lib64`/`version.info`), so HCCL can read `driver/topo` files. Mounting only `lib64` failed communicator init with EI0014 (`atlas_350_3.json` missing).
- Runtime flags on NPU use `--net=host --shm-size=16g --privileged`, matching the Atlas A5 launch verified on 8x950PR. NVIDIA/AMD/TPU/XPU paths are unchanged.
- MiniMax-H3's handwritten Ascend docker snippet is updated the same way (full driver mount, drop `devmm_svm`).

This covers every recipe that lists 950PR in `meta.hardware` (GLM-5.3, DeepSeek-V4-Flash, Qwen3.8-27B, MiniMax-H3) because they all go through `computeDockerMeta`.

## Test plan
- [ ] Open GLM-5.3, pick **Ascend 950PR 8x**, copy the Docker command: 8×`davinci`, full `/usr/local/Ascend/driver` mount, `--net=host --shm-size=16g`
- [ ] Open Qwen3.8-27B W8A8 / MiniMax-H3 on **Ascend 950PR**: only `davinci0` plus manager/hdc
- [ ] Open any NVIDIA recipe: still `--gpus all` and `-p 8000:8000`