### PR TITLE
MiniMax-H3: document TRTLLM SAGE and Skip-Softmax attention

### DIFF
--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -1056,8 +1056,7 @@ guide: |
   Both optimizations trade fidelity for speed, and their effects compound. The measured B300
   speedup and LPIPS for each mode and for the combination are in the vLLM blog's
   [Quantized and Sparse Attention](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving#quantized-and-sparse-attention-in-trtllm_attn)
-  section. Take those numbers as a reference for the accuracy/speed tradeoff, then tune the
-  settings against dense output on your own prompts before adopting either. The
+  section as a reference; tune against dense output on your own prompts. The
   [TRTLLM attention guide](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
   documents every key, and the
   [Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -1056,11 +1056,9 @@ guide: |
   Both optimizations trade fidelity for speed, and their effects compound. The measured B300
   speedup and LPIPS for each mode and for the combination are in the vLLM blog's
   [Quantized and Sparse Attention](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving#quantized-and-sparse-attention-in-trtllm_attn)
-  section as a reference; tune against dense output on your own prompts. The
+  section as a reference; tune the settings according to the accuracy and speed required. The
   [TRTLLM attention guide](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
-  documents every key, and the
-  [Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)
-  explains the algorithm and how the timestep cutoff maps to dense steps.
+  documents every key.
 
   No restart is required: `extra_params.task` routes T2VA/FL2VA requests to the FL2VA
   DiT and Ref2VA requests to the Ref2VA DiT.
@@ -1448,7 +1446,6 @@ guide: |
   - [vLLM-Omni diffusion parallelism](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/parallelism/overview/)
   - [vLLM-Omni diffusion attention backends](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/)
   - [vLLM-Omni TRTLLM attention guide (SAGE, Skip-Softmax)](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
-  - [vLLM-Omni Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)
   - [MiniMax-H3 production serving on vLLM-Omni (blog)](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving)
   - [vLLM-Omni supported models](https://docs.vllm.ai/projects/vllm-omni/en/latest/models/supported_models/)
   - [vLLM-Omni GPU installation](https://docs.vllm.ai/projects/vllm-omni/en/latest/getting_started/installation/gpu/)

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -1056,9 +1056,10 @@ guide: |
   Both optimizations trade fidelity for speed, and their effects compound. The measured B300
   speedup and LPIPS for each mode and for the combination are in the vLLM blog's
   [Quantized and Sparse Attention](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving#quantized-and-sparse-attention-in-trtllm_attn)
-  section as a reference; tune the settings according to the accuracy and speed required. The
+  section as a reference; tune the settings according to the accuracy and speed required. See
+  the
   [TRTLLM attention guide](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
-  documents every key.
+  for the full configuration reference.
 
   No restart is required: `extra_params.task` routes T2VA/FL2VA requests to the FL2VA
   DiT and Ref2VA requests to the Ref2VA DiT.

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "MiniMax"
   description: "Open-weight general-purpose multimodal generation model — jointly generates 24 FPS video with native stereo audio from text, image, video, and audio references, served via vLLM-Omni"
   date_added: 2026-08-02
-  date_updated: 2026-08-10
+  date_updated: 2026-09-02
   difficulty: advanced
   tasks:
     - omni
@@ -1021,6 +1021,56 @@ guide: |
   dense BF16 `TRTLLM_ATTN`. Install `[fa4]` and add `--diffusion-attention-backend FLASH_ATTN`
   only for an explicit FA4 comparison.
 
+  ### Optional lossy attention: SAGE + Skip-Softmax
+
+  `TRTLLM_ATTN` offers two **lossy** optimizations for the long main DiT attention sequence.
+  Both work under the pure Ulysses parallelism of the four-GPU profile (`--usp 4 --ring 1`) and
+  are datacenter-Blackwell only; the RTX, DGX Spark, AMD, and Ascend routes use other backends.
+  Append the following to the four-GPU command above to enable both:
+
+  ```bash
+  --diffusion-attention-config '{
+    "default": {
+      "backend": "TRTLLM_ATTN",
+      "quant": {"dtype_qk": "fp8_e4m3", "q_block_size": 1, "k_block_size": 16},
+      "skip_softmax": {"threshold": 0.05, "disabled_until_timestep": 0.97}
+    },
+    "per_role": {
+      "minimax_h3.token_refiner": {"backend": "TRTLLM_ATTN"}
+    }
+  }'
+  ```
+
+  - **SAGE** quantizes Q/K to `fp8_e4m3` for `QK^T`; P and V are always FP8 in this kernel.
+    B200 additionally supports `int8` Q/K, which preserves accuracy better than FP8.
+  - **Skip-Softmax** skips the Softmax and `PV` work of KV tiles whose scores fall far below
+    the running row maximum. `threshold=0.05` with `disabled_until_timestep=0.97` is a
+    **conservative** setting: a low threshold skips only clearly negligible tiles, and the
+    cutoff keeps the early high-noise steps dense — H3's default video flow shift of 12 keeps
+    the normalized timestep above `0.97` for the first 14 of 49 denoiser forwards at 50 steps.
+    Raise `threshold` or lower `disabled_until_timestep` for more speedup once quality is
+    verified.
+  - The `per_role` entry keeps the short token-refiner attention dense; a per-role spec does
+    not inherit `quant` or `skip_softmax` from `default`.
+
+  Measured model-execution time on B300 against dense `TRTLLM_ATTN`, with LPIPS computed
+  against the dense output on the same prompt and seed (from the
+  [vLLM blog](https://blog.vllm.ai/2026/08/29/minimax-h3-production-serving.html)):
+
+  | Attention | Model execution | Speedup | LPIPS vs. dense |
+  |---|---:|---:|---:|
+  | Dense `TRTLLM_ATTN` | 54.246 s | 1.000x | 0 |
+  | SAGE FP8 | 44.787 s | 1.211x | 0.3697 |
+  | Skip-Softmax (0.05 / 0.97) | 50.029 s | 1.084x | 0.0917 |
+  | SAGE FP8 + Skip-Softmax | 43.867 s | **1.237x** | 0.3750 |
+
+  Skip-Softmax at this setting is close to lossless; most of the quality change in the combined
+  row comes from SAGE. Compare against dense output before adopting either. The
+  [TRTLLM attention guide](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
+  documents every key, and the
+  [Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)
+  explains the algorithm and how the timestep cutoff maps to dense steps.
+
   No restart is required: `extra_params.task` routes T2VA/FL2VA requests to the FL2VA
   DiT and Ref2VA requests to the Ref2VA DiT.
 
@@ -1345,8 +1395,9 @@ guide: |
   **GPU-attention-bound, not host-starved**: FlashAttention-4 is ~76% of `diffuse` device
   time, Ulysses send/recv is secondary, GPU utilization is 92.8–94.3% and the CPU-idle
   union inside the transformer forwards is 3.15%. Reducing DiT time further needs a change
-  in attention complexity (reference-latent pooling/pruning, block-sparse attention), which
-  is not lossless.
+  in attention cost, which is not lossless;
+  [SAGE + Skip-Softmax](#optional-lossy-attention-sage--skip-softmax) above is the supported
+  way to trade attention precision and sparsity for speed on datacenter Blackwell.
 
   Against the checkpoint's own reference implementation, the accuracy-qualified path scores
   SSIM 0.9873–0.9896, PSNR 39–42 dB, pixel cosine 0.9996+, and audio log-mel cosine
@@ -1405,6 +1456,9 @@ guide: |
   - [vLLM-Omni Video API](https://docs.vllm.ai/projects/vllm-omni/en/latest/serving/videos_api/)
   - [vLLM-Omni diffusion parallelism](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/parallelism/overview/)
   - [vLLM-Omni diffusion attention backends](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/)
+  - [vLLM-Omni TRTLLM attention guide (SAGE, Skip-Softmax)](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
+  - [vLLM-Omni Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)
+  - [MiniMax-H3 production serving on vLLM-Omni (blog)](https://blog.vllm.ai/2026/08/29/minimax-h3-production-serving.html)
   - [vLLM-Omni supported models](https://docs.vllm.ai/projects/vllm-omni/en/latest/models/supported_models/)
   - [vLLM-Omni GPU installation](https://docs.vllm.ai/projects/vllm-omni/en/latest/getting_started/installation/gpu/)
   - [ROCm H3 tracking issue](https://github.com/vllm-project/vllm-omni/issues/5697)

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -1025,8 +1025,8 @@ guide: |
 
   `TRTLLM_ATTN` offers two **lossy** optimizations for the long main DiT attention sequence.
   Both work under the pure Ulysses parallelism of the four-GPU profile (`--usp 4 --ring 1`) and
-  are datacenter-Blackwell only; the RTX, DGX Spark, AMD, and Ascend routes use other backends.
-  Append the following to the four-GPU command above to enable both:
+  are datacenter-Blackwell only. Append the following to the four-GPU command above to enable
+  both:
 
   ```bash
   --diffusion-attention-config '{

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -1056,8 +1056,8 @@ guide: |
   Both optimizations trade fidelity for speed, and their effects compound. The measured B300
   speedup and LPIPS for each mode and for the combination are in the vLLM blog's
   [Quantized and Sparse Attention](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving#quantized-and-sparse-attention-in-trtllm_attn)
-  section; use it to pick the accuracy/speed operating point for your workload, and compare
-  against dense output on your own prompts before adopting either. The
+  section. Take those numbers as a reference for the accuracy/speed tradeoff, then tune the
+  settings against dense output on your own prompts before adopting either. The
   [TRTLLM attention guide](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
   documents every key, and the
   [Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -1053,11 +1053,11 @@ guide: |
   - The `per_role` entry keeps the short token-refiner attention dense; a per-role spec does
     not inherit `quant` or `skip_softmax` from `default`.
 
-  On B300 this configuration reduced model-execution time by **1.237x** against dense
-  `TRTLLM_ATTN`; Skip-Softmax alone at this setting is close to lossless (LPIPS 0.09 against the
-  dense output), so most of the quality change comes from SAGE. The per-mode breakdown is in the
-  [vLLM blog](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving). Compare against
-  dense output on your own prompts before adopting either. The
+  Both optimizations trade fidelity for speed, and their effects compound. The measured B300
+  speedup and LPIPS for each mode and for the combination are in the vLLM blog's
+  [Quantized and Sparse Attention](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving#quantized-and-sparse-attention-in-trtllm_attn)
+  section; use it to pick the accuracy/speed operating point for your workload, and compare
+  against dense output on your own prompts before adopting either. The
   [TRTLLM attention guide](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
   documents every key, and the
   [Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)

--- a/models/MiniMaxAI/MiniMax-H3.yaml
+++ b/models/MiniMaxAI/MiniMax-H3.yaml
@@ -1053,19 +1053,11 @@ guide: |
   - The `per_role` entry keeps the short token-refiner attention dense; a per-role spec does
     not inherit `quant` or `skip_softmax` from `default`.
 
-  Measured model-execution time on B300 against dense `TRTLLM_ATTN`, with LPIPS computed
-  against the dense output on the same prompt and seed (from the
-  [vLLM blog](https://blog.vllm.ai/2026/08/29/minimax-h3-production-serving.html)):
-
-  | Attention | Model execution | Speedup | LPIPS vs. dense |
-  |---|---:|---:|---:|
-  | Dense `TRTLLM_ATTN` | 54.246 s | 1.000x | 0 |
-  | SAGE FP8 | 44.787 s | 1.211x | 0.3697 |
-  | Skip-Softmax (0.05 / 0.97) | 50.029 s | 1.084x | 0.0917 |
-  | SAGE FP8 + Skip-Softmax | 43.867 s | **1.237x** | 0.3750 |
-
-  Skip-Softmax at this setting is close to lossless; most of the quality change in the combined
-  row comes from SAGE. Compare against dense output before adopting either. The
+  On B300 this configuration reduced model-execution time by **1.237x** against dense
+  `TRTLLM_ATTN`; Skip-Softmax alone at this setting is close to lossless (LPIPS 0.09 against the
+  dense output), so most of the quality change comes from SAGE. The per-mode breakdown is in the
+  [vLLM blog](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving). Compare against
+  dense output on your own prompts before adopting either. The
   [TRTLLM attention guide](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
   documents every key, and the
   [Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)
@@ -1458,7 +1450,7 @@ guide: |
   - [vLLM-Omni diffusion attention backends](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/)
   - [vLLM-Omni TRTLLM attention guide (SAGE, Skip-Softmax)](https://docs.vllm.ai/projects/vllm-omni/en/latest/user_guide/diffusion/attention_backends/trtllm/)
   - [vLLM-Omni Skip-Softmax design](https://docs.vllm.ai/projects/vllm-omni/en/latest/design/feature/skip_softmax/)
-  - [MiniMax-H3 production serving on vLLM-Omni (blog)](https://blog.vllm.ai/2026/08/29/minimax-h3-production-serving.html)
+  - [MiniMax-H3 production serving on vLLM-Omni (blog)](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving)
   - [vLLM-Omni supported models](https://docs.vllm.ai/projects/vllm-omni/en/latest/models/supported_models/)
   - [vLLM-Omni GPU installation](https://docs.vllm.ai/projects/vllm-omni/en/latest/getting_started/installation/gpu/)
   - [ROCm H3 tracking issue](https://github.com/vllm-project/vllm-omni/issues/5697)


### PR DESCRIPTION
## Summary

Document the `TRTLLM_ATTN` lossy attention optimizations for MiniMax-H3 on datacenter Blackwell.

- New guide subsection **Optional lossy attention: SAGE + Skip-Softmax** under the four-GPU launch: the `--diffusion-attention-config` payload (FP8 SAGE, `threshold=0.05`, `disabled_until_timestep=0.97`, dense token refiner), why the Skip-Softmax setting is conservative, and a link to the vLLM blog's [Quantized and Sparse Attention](https://vllm.ai/blog/2026-09-01-minimax-h3-production-serving#quantized-and-sparse-attention-in-trtllm_attn) section for the measured B300 speedup and LPIPS per mode.
- The performance analysis previously ended with "reducing DiT time further needs a change in attention complexity, which is not lossless"; it now points at that subsection.
- References gain the TRTLLM attention guide and the blog. `date_updated` bumped.

The attention configuration mirrors the vLLM-Omni recipe (`recipes/MiniMaxAI/MiniMax-H3.md`) as refined in vllm-project/vllm-omni#6724.

## Not included

A `features` toggle for this configuration would be the natural fit, but `resolveOmniCommand` does not consume `features`/`opt_in_features` (no omni recipe declares any), so a toggle would render without emitting arguments. Wiring features into the omni command path is a site change and is left for a follow-up.

## Validation

- `node scripts/build-recipes-api.mjs` passes (`✓ JSON API: 187 models …`).
- The JSON payload in the guide parses.
