### PR TITLE
  Add DGX Spark (GB10) support to Voxtral Mini 4B Realtime recipe

### DIFF
--- a/models/mistralai/Voxtral-Mini-4B-Realtime-2602.yaml
+++ b/models/mistralai/Voxtral-Mini-4B-Realtime-2602.yaml
@@ -47,7 +47,7 @@ compatible_strategies:
   - multi_node_tp
 
 hardware_overrides: 
-  dgx_spark_gb10: {}
+  dgx_spark_gb10: verified
 
 strategy_overrides:
   single_node_tp:

--- a/models/mistralai/Voxtral-Mini-4B-Realtime-2602.yaml
+++ b/models/mistralai/Voxtral-Mini-4B-Realtime-2602.yaml
@@ -46,7 +46,8 @@ compatible_strategies:
   - single_node_tp
   - multi_node_tp
 
-hardware_overrides: {}
+hardware_overrides: 
+  dgx_spark_gb10: {}
 
 strategy_overrides:
   single_node_tp:


### PR DESCRIPTION
Run DGX spark on voxtral:
```
 VLLM_DISABLE_COMPILE_CACHE=1 vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602 --compilation_config '{"cudagraph_mode": "PIECEWISE"}'
```
with `python examples/speech_to_text/realtime/openai_realtime_client.py`:

```
No audio path provided, using default: /home/redhat-et/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg
Session created: sess-a50e9b5605ad811e
Loading audio from: /home/redhat-et/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg
Sending 125 audio chunks...
Audio sent. Waiting for transcription...

Transcription:  First words I spoke in the original phonograph. A little piece of practicalpoetry. Mary had a little lamb, it sleeps with quite a flow, and everywhere that Mary went,the lamb was sure to go.

Final transcription:  First words I spoke in the original phonograph. A little piece of practical poetry. Mary had a little lamb, it sleeps with quite a flow, and everywhere that Marywent, the lamb was sure to go.
Usage: {'prompt_tokens': 39, 'total_tokens': 249, 'completion_tokens': 210, 'prompt_tokens_details': None}
```