### PR TITLE
Update Nemotron-3.5-Lightning NVFP4 DGX Spark config to the validated perf-sweep launch

### DIFF
--- a/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "NVIDIA"
   description: "NVIDIA Nemotron 3.5 Lightning hybrid Mamba-MoE (30B total / 3B active) with NVFP4 and BF16 checkpoints, 1M context, and MTP / DSpark / DFlash speculative decoding"
   date_added: 2026-08-03
-  date_updated: 2026-08-10
+  date_updated: 2026-09-02
   difficulty: intermediate
   tasks:
     - text
@@ -67,6 +67,12 @@ features:
         args:
           - "--speculative-config"
           - '{"method":"dspark","model":"nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark","num_speculative_tokens":3}'
+        hardware_overrides:
+          # GB10 is decode-bound at concurrency 1, so the sweep drafts deeper.
+          dgx_spark_gb10:
+            args:
+              - "--speculative-config"
+              - '{"method":"dspark","model":"nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark","num_speculative_tokens":7}'
       mtp:
         label: "MTP"
         description: "Built-in Multi-Token Prediction heads — no extra checkpoint to download."
@@ -121,24 +127,16 @@ variants:
           - "--max-num-batched-tokens"
           - "32768"
       dgx_spark_gb10:
+        # Validated 2026-08-31 on vLLM 0.28.1rc1.dev130+g44fe2a392 (Ubuntu
+        # 24.04.4, driver 580.159.03, CUDA 13.0). The nightly is newer than the
+        # recipe-wide v0.28.0 image, so it is pinned here.
+        docker_image: "vllm/vllm-openai:nightly"
         extra_args:
-          - "--attention-backend"
-          - "FLASHINFER"
-          - "--linear-backend"
-          - "marlin"
-          - "--attention-config"
-          - '{"use_trtllm_attention":true}'
-          - "--enable-flashinfer-autotune"
-          - "--mamba-cache-mode"
-          - "none"
-          - "--async-scheduling"
-          - "--enable-chunked-prefill"
+          # GB10 shares its 128 GB with the CPU — leave the host its share.
           - "--gpu-memory-utilization"
-          - "0.8"
+          - "0.7"
           - "--load-format"
-          - "instanttensor"
-          - "--safetensors-load-strategy"
-          - "prefetch"
+          - "fastsafetensors"
       rtx_pro_6000:
         extra_args:
           - "--attention-backend"
@@ -238,3 +236,9 @@ guide: |
 
   - **Speculative decoding**: DSpark is preferred on DGX Spark. On DGX Station, prefer
     MTP — choose it in the Speculative Decoding panel above.
+  - **DGX Spark (GB10)**: the selectable config is the one measured on 2026-08-31 with
+    aiperf 0.12.0 on vLLM `0.28.1rc1.dev130+g44fe2a392` — DSpark drafting 7 tokens at
+    `--gpu-memory-utilization 0.7`, `--mamba-cache-mode align` and fastsafetensors
+    loading, served from `vllm/vllm-openai:nightly`. On SPEED-Bench at 8K input / 256
+    output, concurrency 1, it reached 7,252 prefill tok/s and 93.3 decode tok/s at a
+    3.98 s mean end-to-end latency.


### PR DESCRIPTION
Replace the DGX Spark NVFP4 override from #879 with the configuration a perf sweep actually measured on 2026-08-31 against vLLM 0.28.1rc1.dev130+g44fe2a392 (Ubuntu 24.04.4, driver 580.159.03, CUDA 13.0): --gpu-memory-utilization 0.7, fastsafetensors loading, the recipe-wide --mamba-cache-mode align rather than none, and DSpark drafting 7 tokens instead of 3, pinned to vllm/vllm-openai:nightly since the measured build is newer than the recipe-wide v0.28.0 image. The FlashInfer/TRT-LLM attention, flashinfer autotune, marlin linear backend, async scheduling and chunked prefill flags added in #879 were not part of the measured launch and are dropped, so the generated command on GB10 is now exactly the one that produced 7,252 prefill tok/s and 93.3 decode tok/s at 3.98 s mean end-to-end latency on SPEED-Bench (8K input, 256 output, concurrency 1). Everything stays in the dgx_spark_gb10 override and a DSpark hardware override, so no other GPU changes; the RTX PRO 6000 override keeps the #879 tuning because no equivalent measured run exists for it yet.