### PR TITLE
Record the measured DGX Spark NVFP4 results for Qwen3.6-35B-A3B

### DIFF
--- a/models/Qwen/Qwen3.6-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.6-35B-A3B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Smaller Qwen3.6 multimodal MoE model (35B total / 3B active) with BF16, FP8, and NVIDIA NVFP4 variants"
   date_added: 2026-04-16
-  date_updated: 2026-06-03
+  date_updated: 2026-09-02
   difficulty: beginner
   tasks:
     - multimodal
@@ -261,6 +261,16 @@ guide: |
   Datacenter Blackwell (B200/GB200/B300/GB300) intentionally carries no
   overrides — it runs vLLM's own NVFP4 defaults, which select the native FP4
   path rather than the Marlin W4A16 kernel the workstation parts need.
+
+  ### Measured on DGX Spark (GB10)
+
+  The GB10 profile above was re-measured on 2026-08-31 with aiperf 0.12.0 on
+  vLLM 0.28.0 (Ubuntu 24.04.4, driver 580.159.03, CUDA 13.0), one GB10 at TP1,
+  serving from `vllm/vllm-openai:v0.28.0`. On SPEED-Bench at 8K input / 256
+  output tokens and concurrency 1, it sustained 6,265 prefill tok/s and 97.7
+  decode tok/s at a 3.95 s mean end-to-end latency. The flag set is unchanged —
+  the sweep confirms the tuning rather than revising it, so the command the
+  builder emits for GB10 is the one that produced these numbers.
 
   ### Docker (Intel XPU B60 / B70)
 


### PR DESCRIPTION
A perf sweep on 2026-08-31 re-ran the GB10 NVFP4 profile from #854 with aiperf 0.12.0 on vLLM 0.28.0 (Ubuntu 24.04.4, driver 580.159.03, CUDA 13.0), one GB10 at TP1 from vllm/vllm-openai:v0.28.0, and it sustained 6,265 prefill tok/s and 97.7 decode tok/s at a 3.95 s mean end-to-end latency on SPEED-Bench with 8K input, 256 output and concurrency 1. The sweep confirmed the existing flag set rather than revising it, so no override changes here — this just records the stack and the numbers in the guide so readers know the GB10 command is measured rather than merely plausible, and I re-verified that all four workstation profiles still generate exactly the launch commands they were tuned from.