### PR TITLE
fix incorrect parser in NVIDIA Nemotron recipe

### DIFF
--- a/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
+++ b/models/nvidia/NVIDIA-Nemotron-Nano-9B-v2.yaml
@@ -32,7 +32,7 @@ features:
     description: "Custom Nemotron tool-call parser plugin (download: nemotron_toolcall_parser_no_streaming.py)"
     args:
       - "--enable-auto-tool-choice"
-      - "--tool-call-parser-plugin"
+      - "--tool-parser-plugin"
       - "nemotron_toolcall_parser_no_streaming.py"
       - "--tool-call-parser"
       - "nemotron_json"
@@ -104,7 +104,7 @@ guide: |
     --max-model-len 131072 \
     --tensor-parallel-size 1 \
     --enable-auto-tool-choice \
-    --tool-call-parser-plugin nemotron_toolcall_parser_no_streaming.py \
+    --tool-parser-plugin nemotron_toolcall_parser_no_streaming.py \
     --tool-call-parser nemotron_json
   ```
 


### PR DESCRIPTION
## Summary
NVIDIA Nemotron recipe is using `--tool-call-parser-plugin`. However, `--tool-call-parser-plugin` is wrong parser; vLLM uses `--tool-parser-plugin` instead.

## Test Plan
- `node scripts/build-recipes-api.mjs` — YAML parses, JSON API regenerates cleanly (187 models, no errors).