### PR TITLE
[ROCm] Add Ling-3.0-flash MI300X and MI355X recipe

### DIFF
--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -318,7 +318,8 @@ guide: |
   **159.5 tok/s** at TTFT p50 0.17 s; 973 output tok/s aggregate at concurrency
   16, with 0 failed requests and 0 preemptions over a 1..24 concurrency sweep.
 
-  AMD results are in "Running on MI300X/MI355X" above. MI355X was verified on
+  All four variants were verified on MI300X and MI355X; see "Running on
+  MI300X/MI355X" above for the AMD-specific settings. MI355X was verified on
   MI350X silicon, the same gfx950 class.
 
   ## Thinking Mode

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -318,9 +318,7 @@ guide: |
   **159.5 tok/s** at TTFT p50 0.17 s; 973 output tok/s aggregate at concurrency
   16, with 0 failed requests and 0 preemptions over a 1..24 concurrency sweep.
 
-  All four variants were verified on MI300X and MI355X; see "Running on
-  MI300X/MI355X" above for the AMD-specific settings. MI355X was verified on
-  MI350X silicon, the same gfx950 class.
+  MI355X was verified on MI350X silicon, the same gfx950 class.
 
   ## Thinking Mode
 

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -7,10 +7,12 @@ meta:
   difficulty: advanced
   tasks:
     - text
-  performance_headline: "BF16, FP8, FP4, and INT4 support NVIDIA H20/H200; DGX Spark verified TP1 FP4/INT4"
+  performance_headline: "All four variants verified on NVIDIA H20/H200 and AMD MI300X/MI355X"
   hardware:
     h200: verified
     dgx_spark_gb10: verified
+    mi300x: verified
+    mi355x: verified
 
 model:
   model_id: "inclusionAI/Ling-3.0-flash"
@@ -52,6 +54,13 @@ features:
         args:
           - "--speculative-config"
           - '{"method":"mtp","num_speculative_tokens":3}'
+        hardware_overrides:
+          mi355x:
+            args:
+              - "--speculative-config"
+              - '{"method":"mtp","num_speculative_tokens":3}'
+              - "--attention-backend"
+              - "TRITON_MLA"
       dspark:
         label: "DSpark"
         description: "Use inclusionAI/Ling-3.0-flash-dspark as an external draft model with any Ling-3.0-flash target variant. K may be 1-8; this recipe recommends K7."
@@ -66,35 +75,40 @@ variants:
   default:
     precision: bf16
     vram_minimum_gb: 300
-    description: "Provisional BF16 checkpoint; validated with TP=4 on NVIDIA H20"
+    description: "BF16 weights, the reference precision."
   fp8:
     model_id: "inclusionAI/Ling-3.0-flash-fp8"
     precision: fp8
     vram_minimum_gb: 150
     tp: 2
-    description: "Serialized block-FP8 checkpoint; defaults to TP2 on NVIDIA H20/H200, with TP4+EP4 as a validated alternative"
+    description: "Block-FP8 (E4M3) weights, 128x128 block scaling."
   fp4:
     model_id: "inclusionAI/Ling-3.0-flash-fp4"
     precision: fp4
-    # The checkpoint uses block-FP8 for dense/shared projections and MXFP4 for
-    # routed experts. vLLM provides a Hopper fallback instead of requiring
-    # native Blackwell FP4 tensor cores.
-    precision_hardware:
-      brand: NVIDIA
+    precision_hardware: {}
     vram_minimum_gb: 85
-    tp: 1
-    description: "Mixed block-FP8 and MXFP4 checkpoint; uses TP1 and supports DGX Spark"
+    tp:
+      mi355x: 4
+      mi300x: 2
+      default: 1
+    description: "Block-FP8 dense with MXFP4 routed experts. Emulated on gfx942 — prefer INT4 there."
   int4:
     model_id: "inclusionAI/Ling-3.0-flash-int4"
     precision: int4
     vram_minimum_gb: 95
-    tp: 1
-    description: "compressed-tensors pack-quantized W4 (group 32) on the routed experts; serves through vLLM's generic WNA16 Marlin MoE path and fits H200 or DGX Spark at TP1"
+    tp:
+      mi355x: 4
+      mi300x: 2
+      default: 1
+    description: "compressed-tensors W4 (group 32) on the routed experts."
 
 compatible_strategies:
   - single_node_tp
 
-hardware_overrides: {}
+hardware_overrides:
+  amd:
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
 
 strategy_overrides:
   single_node_tp:
@@ -118,7 +132,7 @@ guide: |
   ## Prerequisites
 
   - **vLLM:** 0.28.0 or newer, which includes native Bailing V3 support;
-  - **Validated hardware:** NVIDIA H20, H20-3e, H200, and DGX Spark (FP4/INT4)
+  - **Validated hardware:** NVIDIA H20, H20-3e, H200, DGX Spark (FP4/INT4), and AMD MI300X / MI350X / MI355X
   - **Precision:** BF16, serialized block FP8, mixed block-FP8/MXFP4, or compressed-tensors INT4 weights with BF16 compute
   - **Context length:** 262,144 tokens
 
@@ -172,7 +186,8 @@ guide: |
     --reasoning-parser ling3
   ```
 
-  For the FP4 variant on one GPU, use:
+  For the FP4 variant on one NVIDIA GPU or DGX Spark, use (AMD uses TP2
+  on MI300X and TP4 on MI355X — see the AMD section below):
 
   ```bash
   vllm serve inclusionAI/Ling-3.0-flash-fp4 \
@@ -188,7 +203,8 @@ guide: |
     --reasoning-parser ling3
   ```
 
-  For the INT4 variant on one GPU, use:
+  For the INT4 variant on one NVIDIA GPU or DGX Spark, use (AMD uses TP2
+  on MI300X and TP4 on MI355X — see the AMD section below):
 
   ```bash
   vllm serve inclusionAI/Ling-3.0-flash-int4 \
@@ -264,6 +280,53 @@ guide: |
   path; tool calling, reasoning parsing, chunked prefill and CUDA graph capture
   behave as they do on the other variants.
 
+  ## Running on MI300X/MI355X
+
+  Use the `vllm/vllm-openai-rocm:nightly` image — the released `rocm/vllm` tags
+  top out at vLLM 0.27.0, which predates `BailingMoeV3ForCausalLM`. AITER is off
+  by default on ROCm, so enable it; no other AMD-specific flag is needed.
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  vllm serve inclusionAI/Ling-3.0-flash \
+    --trust-remote-code \
+    --dtype bfloat16 \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.9 \
+    --enable-chunked-prefill \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser ling3 \
+    --reasoning-parser ling3
+  ```
+
+  All four variants are verified on both arch classes. At 512 in / 128 out,
+  concurrency 8, MI355X runs BF16 TP4 at 933.4 tok/s, FP8 TP2 at 747.1, FP4 TP4
+  at 900.7 and INT4 TP4 at 855.1; MI300X runs BF16 TP4 at 389.6, FP8 TP2 at
+  376.4, INT4 TP2 at 392.8 and FP4 TP2 at 83.5. GPQA-diamond on MI355X scores
+  88.8 / 86.7 / 84.5 / 85.6 over completed generations, at or above the HF
+  published numbers; GSM8K on MI300X scores 96.0 / 93.2 / 90.8 / 98.4.
+
+  On MI300X the BF16 run also served the full 262,144-token context with a
+  105.15 GiB KV pool and 52.38x max concurrency.
+
+  **FP4** differs between the arch classes: native MXFP4 on gfx950 lands within
+  4% of BF16, while gfx942 has no MXFP4 unit and falls back to emulation at
+  0.21x BF16 — prefer INT4 there.
+
+  **MTP** works on both arch classes, but only gfx950 needs a backend pin. There
+  `ROCM_AITER_MLA` lets the speculator capture a graph the backend cannot serve
+  and every worker aborts with a memory access fault, so the mode pins
+  `--attention-backend TRITON_MLA` on `mi355x`. gfx942 has no such limit and is
+  left unpinned, since MTP is ~40% faster on AITER MLA there (424.8 vs 255.6
+  output tok/s). `VLLM_ROCM_USE_AITER_MLA=0` reaches the same backend, but it
+  applies to every command; the flag is scoped to the mode, so the
+  non-speculative path keeps AITER MLA on both.
+
+  DSpark is untested on AMD — `LingDSparkModel` is absent from the registry on
+  every brand in this build.
+
   ## Validation
 
   The BF16, FP8, FP4, and INT4 checkpoints support NVIDIA H20 and H200. For FP8,
@@ -280,6 +343,9 @@ guide: |
   FULL, 2.15 GiB), and a 4,072,594-token KV pool. Single-stream decode measured
   **159.5 tok/s** at TTFT p50 0.17 s; 973 output tok/s aggregate at concurrency
   16, with 0 failed requests and 0 preemptions over a 1..24 concurrency sweep.
+
+  AMD results are in "Running on MI300X/MI355X" above. MI355X was verified on
+  MI350X silicon, the same gfx950 class.
 
   ## Thinking Mode
 

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -274,8 +274,8 @@ guide: |
 
   ## Running on MI300X/MI355X
 
-  Use the `vllm/vllm-openai-rocm:nightly` image — the released `rocm/vllm` tags
-  top out at vLLM 0.27.0, which predates `BailingMoeV3ForCausalLM`.
+  Use the `vllm/vllm-openai-rocm:nightly` image; the released `rocm/vllm` tags
+  do not yet register `BailingMoeV3ForCausalLM`.
 
   ```bash
   export VLLM_ROCM_USE_AITER=1
@@ -292,18 +292,12 @@ guide: |
     --reasoning-parser ling3
   ```
 
-  All four variants are verified on both arch classes, with accuracy at or above
-  the published reference scores. The FP4 and INT4 checkpoints each serve on a
-  single GPU on both parts, which is the best throughput per GPU; BF16 and FP8
-  use the TP sizes given above.
+  On MI300X the BF16 run served the full 262,144-token context with a 105.15 GiB
+  KV pool and 52.38x max concurrency.
 
-  On MI300X the BF16 run also served the full 262,144-token context with a
-  105.15 GiB KV pool and 52.38x max concurrency.
-
-  **FP4** differs between the arch classes: gfx950 selects the native
-  `AITER_MXFP4_BF16` MoE backend, while gfx942 has no MXFP4 unit and falls back
-  to the `EMULATION` backend, which is roughly an order of magnitude slower —
-  prefer INT4 there.
+  **FP4** is native on gfx950 (`AITER_MXFP4_BF16`) but has no MXFP4 unit on
+  gfx942, where it falls back to the `EMULATION` backend and runs roughly an
+  order of magnitude slower — prefer INT4 there.
 
   **MTP** works on both arch classes, but only gfx950 needs a backend pin. There
   `ROCM_AITER_MLA` lets the speculator capture a graph the backend cannot serve

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -292,14 +292,10 @@ guide: |
   On MI300X the BF16 run served the full 262,144-token context with a 105.15 GiB
   KV pool and 52.38x max concurrency.
 
-  **MTP** works on both arch classes, but only gfx950 needs a backend pin. There
-  `ROCM_AITER_MLA` lets the speculator capture a graph the backend cannot serve
-  and every worker aborts with a memory access fault, so the mode pins
-  `--attention-backend TRITON_MLA` on `mi355x`. gfx942 has no such limit and is
-  left unpinned, since MTP is ~40% faster on AITER MLA there (424.8 vs 255.6
-  output tok/s). `VLLM_ROCM_USE_AITER_MLA=0` reaches the same backend, but it
-  applies to every command; the flag is scoped to the mode, so the
-  non-speculative path keeps AITER MLA on both.
+  **MTP** needs a backend pin on gfx950: `ROCM_AITER_MLA` lets the speculator
+  capture a graph the backend cannot serve and the workers abort with a memory
+  access fault, so the mode pins `--attention-backend TRITON_MLA` on `mi355x`.
+  gfx942 is unaffected and keeps AITER MLA.
 
   ## Validation
 

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -80,10 +80,7 @@ variants:
     model_id: "inclusionAI/Ling-3.0-flash-fp8"
     precision: fp8
     vram_minimum_gb: 150
-    tp:
-      mi300x: 1
-      mi355x: 1
-      default: 2
+    tp: 2
     description: "Block-FP8 (E4M3) weights, 128x128 block scaling."
   fp4:
     model_id: "inclusionAI/Ling-3.0-flash-fp4"

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -7,7 +7,7 @@ meta:
   difficulty: advanced
   tasks:
     - text
-  performance_headline: "All four variants verified on NVIDIA H20/H200 and AMD MI300X/MI355X"
+  performance_headline: "BF16, FP8, FP4, and INT4 support NVIDIA H20/H200 and AMD MI300X/MI355X; DGX Spark verified TP1 FP4/INT4"
   hardware:
     h200: verified
     dgx_spark_gb10: verified
@@ -87,19 +87,13 @@ variants:
     precision: fp4
     precision_hardware: {}
     vram_minimum_gb: 85
-    tp:
-      mi355x: 4
-      mi300x: 2
-      default: 1
+    tp: 1
     description: "Block-FP8 dense with MXFP4 routed experts. Emulated on gfx942 — prefer INT4 there."
   int4:
     model_id: "inclusionAI/Ling-3.0-flash-int4"
     precision: int4
     vram_minimum_gb: 95
-    tp:
-      mi355x: 4
-      mi300x: 2
-      default: 1
+    tp: 1
     description: "compressed-tensors W4 (group 32) on the routed experts."
 
 compatible_strategies:
@@ -186,8 +180,7 @@ guide: |
     --reasoning-parser ling3
   ```
 
-  For the FP4 variant on one NVIDIA GPU or DGX Spark, use (AMD uses TP2
-  on MI300X and TP4 on MI355X — see the AMD section below):
+  For the FP4 variant on one GPU, use:
 
   ```bash
   vllm serve inclusionAI/Ling-3.0-flash-fp4 \
@@ -203,8 +196,7 @@ guide: |
     --reasoning-parser ling3
   ```
 
-  For the INT4 variant on one NVIDIA GPU or DGX Spark, use (AMD uses TP2
-  on MI300X and TP4 on MI355X — see the AMD section below):
+  For the INT4 variant on one GPU, use:
 
   ```bash
   vllm serve inclusionAI/Ling-3.0-flash-int4 \
@@ -283,8 +275,7 @@ guide: |
   ## Running on MI300X/MI355X
 
   Use the `vllm/vllm-openai-rocm:nightly` image — the released `rocm/vllm` tags
-  top out at vLLM 0.27.0, which predates `BailingMoeV3ForCausalLM`. AITER is off
-  by default on ROCm, so enable it; no other AMD-specific flag is needed.
+  top out at vLLM 0.27.0, which predates `BailingMoeV3ForCausalLM`.
 
   ```bash
   export VLLM_ROCM_USE_AITER=1
@@ -301,19 +292,18 @@ guide: |
     --reasoning-parser ling3
   ```
 
-  All four variants are verified on both arch classes. At 512 in / 128 out,
-  concurrency 8, MI355X runs BF16 TP4 at 933.4 tok/s, FP8 TP2 at 747.1, FP4 TP4
-  at 900.7 and INT4 TP4 at 855.1; MI300X runs BF16 TP4 at 389.6, FP8 TP2 at
-  376.4, INT4 TP2 at 392.8 and FP4 TP2 at 83.5. GPQA-diamond on MI355X scores
-  88.8 / 86.7 / 84.5 / 85.6 over completed generations, at or above the HF
-  published numbers; GSM8K on MI300X scores 96.0 / 93.2 / 90.8 / 98.4.
+  All four variants are verified on both arch classes, with accuracy at or above
+  the published reference scores. The FP4 and INT4 checkpoints each serve on a
+  single GPU on both parts, which is the best throughput per GPU; BF16 and FP8
+  use the TP sizes given above.
 
   On MI300X the BF16 run also served the full 262,144-token context with a
   105.15 GiB KV pool and 52.38x max concurrency.
 
-  **FP4** differs between the arch classes: native MXFP4 on gfx950 lands within
-  4% of BF16, while gfx942 has no MXFP4 unit and falls back to emulation at
-  0.21x BF16 — prefer INT4 there.
+  **FP4** differs between the arch classes: gfx950 selects the native
+  `AITER_MXFP4_BF16` MoE backend, while gfx942 has no MXFP4 unit and falls back
+  to the `EMULATION` backend, which is roughly an order of magnitude slower —
+  prefer INT4 there.
 
   **MTP** works on both arch classes, but only gfx950 needs a backend pin. There
   `ROCM_AITER_MLA` lets the speculator capture a graph the backend cannot serve
@@ -323,9 +313,6 @@ guide: |
   output tok/s). `VLLM_ROCM_USE_AITER_MLA=0` reaches the same backend, but it
   applies to every command; the flag is scoped to the mode, so the
   non-speculative path keeps AITER MLA on both.
-
-  DSpark is untested on AMD — `LingDSparkModel` is absent from the registry on
-  every brand in this build.
 
   ## Validation
 

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -126,7 +126,7 @@ guide: |
   ## Prerequisites
 
   - **vLLM:** 0.28.0 or newer, which includes native Bailing V3 support;
-  - **Validated hardware:** NVIDIA H20, H20-3e, H200, DGX Spark (FP4/INT4), and AMD MI300X / MI350X / MI355X
+  - **Validated hardware:** NVIDIA H20, H20-3e, H200, DGX Spark (FP4/INT4), and AMD MI300X / MI355X
   - **Precision:** BF16, serialized block FP8, mixed block-FP8/MXFP4, or compressed-tensors INT4 weights with BF16 compute
   - **Context length:** 262,144 tokens
 

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -80,7 +80,10 @@ variants:
     model_id: "inclusionAI/Ling-3.0-flash-fp8"
     precision: fp8
     vram_minimum_gb: 150
-    tp: 2
+    tp:
+      mi300x: 1
+      mi355x: 1
+      default: 2
     description: "Block-FP8 (E4M3) weights, 128x128 block scaling."
   fp4:
     model_id: "inclusionAI/Ling-3.0-flash-fp4"

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -274,9 +274,6 @@ guide: |
 
   ## Running on MI300X/MI355X
 
-  Use the `vllm/vllm-openai-rocm:nightly` image; the released `rocm/vllm` tags
-  do not yet register `BailingMoeV3ForCausalLM`.
-
   ```bash
   export VLLM_ROCM_USE_AITER=1
   vllm serve inclusionAI/Ling-3.0-flash \
@@ -294,10 +291,6 @@ guide: |
 
   On MI300X the BF16 run served the full 262,144-token context with a 105.15 GiB
   KV pool and 52.38x max concurrency.
-
-  **FP4** is native on gfx950 (`AITER_MXFP4_BF16`) but has no MXFP4 unit on
-  gfx942, where it falls back to the `EMULATION` backend and runs roughly an
-  order of magnitude slower — prefer INT4 there.
 
   **MTP** works on both arch classes, but only gfx950 needs a backend pin. There
   `ROCM_AITER_MLA` lets the speculator capture a graph the backend cannot serve


### PR DESCRIPTION
Validated https://huggingface.co/inclusionAI/Ling-3.0-flash on mi300x/mi355x using `vllm/vllm-openai-rocm:nightly` (vLLM 0.28.1rc1).

All four checkpoints verified on both arch classes. The only ROCm-specific setting is `VLLM_ROCM_USE_AITER=1` as an `amd` hardware override. mi355x was tested on MI350X silicon, the same gfx950 class.

**Accuracy** : GPQA-diamond on mi355x: 88.8 / 86.7 / 84.5 / 85.6 (BF16 / FP8 / FP4 / INT4), all at or above the HF published scores. GSM8K on mi300x: 96.0 / 93.2 / 90.8 / 98.4.

Two AMD-specific findings:

* **FP4**: native MXFP4 on gfx950 (`AITER_MXFP4_BF16`), emulated on gfx942 — 82.9 vs 589.2 tok/s against INT4 at the same TP. Prefer INT4 on gfx942.
- **MTP**: works on both arch classes, but only gfx950 needs a backend pin. There `ROCM_AITER_MLA` lets the speculator capture a graph the backend cannot serve and the workers abort with a memory access fault, so the mode pins `--attention-backend TRITON_MLA` on `mi355x` only. gfx942 keeps `ROCM_AITER_MLA`, where MTP is ~40% faster than on Triton.