### PR TITLE
[ROCm] Pin MiniMax-M3 MI355X image and full-decode graphs

### DIFF
--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -208,7 +208,7 @@ variants:
     tp: 8
     hardware_overrides:
       mi355x:
-        docker_image: "vllm/vllm-openai-rocm:nightly"
+        docker_image: "vllm/vllm-openai-rocm:nightly-8a728663c1c3eeace834a95f5654fa653cc1998c"
         extra_args:
           - "--trust-remote-code"
           # Keep the multimodal encoder loaded and run it data-parallel on MI355X.

--- a/models/MiniMaxAI/MiniMax-M3.yaml
+++ b/models/MiniMaxAI/MiniMax-M3.yaml
@@ -211,6 +211,8 @@ variants:
         docker_image: "vllm/vllm-openai-rocm:nightly-8a728663c1c3eeace834a95f5654fa653cc1998c"
         extra_args:
           - "--trust-remote-code"
+          - "--compilation-config"
+          - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
           # Keep the multimodal encoder loaded and run it data-parallel on MI355X.
           - "--mm-encoder-tp-mode"
           - "data"


### PR DESCRIPTION
## Summary

- Pin the MiniMax-M3 MXFP4 recipe on MI355X to `vllm/vllm-openai-rocm:nightly-8a728663c1c3eeace834a95f5654fa653cc1998c`.
- Add `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` to the generated MXFP4/MI355X server command while keeping breakable CUDA graphs disabled.
- This resolves the fail-closed piecewise-graph validation introduced by vllm-project/vllm#54782 and retains full CUDA graphs for uniform decode.
- The image contains the optimized BF16 MiniMax-M3 indexer from vllm-project/vllm#54682 and the gfx950 routed GEMM from vllm-project/vllm#54845.

The change is scoped to one recipe YAML and the MXFP4/MI355X variant. Other variants, hardware, environment variables, topology, and recipe text are unchanged.

The pin matches SemiAnalysisAI/InferenceX#2825. Its corrected full sweep is https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33889796302.

## Duplicate-work check

No open Recipes PR uses this immutable image tag or adds this scoped compatibility setting. This is distinct from #886, which documented the AgentX reproduction recipe but did not pin this optimized nightly.

## Validation

- `node scripts/build-recipes-api.mjs` — passed: `✓ JSON API: 187 models ... 9 strategies`.
- Confirmed the generated recommended and MI355X-specific MXFP4 commands contain `--compilation-config` followed by `{"cudagraph_mode":"FULL_DECODE_ONLY"}`.
- Confirmed the generated MI355X MXFP4 image resolves to the immutable tag.
- YAML parsing and `git diff --check` — passed.
- Generated `public/` files are not committed.

AI assistance was used to diagnose, implement, and validate this change. The human submitter must review every changed line and linked benchmark evidence before merge.
