### PR TITLE
[ROCm] Correct DeepSeek-V4-Pro shared-expert fusion note

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -645,12 +645,14 @@ guide: |
   ### Shared-expert fusion requires a recent build
 
   `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` is a request, not a guarantee:
-  vLLM gates the fused shared-expert path on its own eligibility check. Until
-  [vllm-project/vllm#53161](https://github.com/vllm-project/vllm/pull/53161) that
-  check rejected this mixed FP4+FP8 checkpoint outright, so on any build older
-  than `de69e821` the flag is inert and the fusion self-disables at startup. That
-  PR adds the heterogeneous path that fuses the native-FP8 shared expert into the
-  MXFP4 routed-expert kernel, which is what makes the flag take effect.
+  vLLM gates the fused shared-expert path on its own eligibility check.
+  [vllm-project/vllm#53161](https://github.com/vllm-project/vllm/pull/53161),
+  merged as `de69e821`, added the heterogeneous path that fuses the native-FP8
+  shared expert into the MXFP4 routed-expert kernel. Current `:nightly` images
+  include it, so the flag takes effect. On any build older than `de69e821` the
+  check rejects this mixed FP4+FP8 checkpoint outright and the fusion
+  self-disables at startup — including the immutable tag pinned in the
+  reproduction table above, which predates the fix.
 
   On a build that includes it, the fusion additionally requires gfx950 (MI355X),
   tensor parallelism 8, data parallelism 1, no expert parallelism and no EPLB,
@@ -658,8 +660,15 @@ guide: |
   shared-expert quantization config. Both arms here satisfy this. Data-parallel
   attention does not, and keeps the unfused path.
 
+  Eligibility is also re-checked per invocation against AITER's tuned-config
+  coverage for the number of MoE input rows. Decode-sized batches are covered and
+  take the fused kernel; large prefill chunks fall back to the unfused path, so an
+  8K-input workload runs fused during decode and unfused during prefill.
+
   Failures are silent and logged at debug level, so check the server log before
-  assuming the fused path executed rather than inferring it from the flag.
+  assuming the fused path executed rather than inferring it from the flag. The
+  line to look for is `Using AITER DeepSeek V4 heterogeneous MoE for CSV-covered
+  MoE input rows`.
 
   ### How this differs from the Agentic sweep above
 

--- a/models/deepseek-ai/DeepSeek-V4-Pro.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Pro.yaml
@@ -567,8 +567,8 @@ guide: |
   ```bash
   export VLLM_ROCM_USE_AITER=1
   export VLLM_ROCM_USE_AITER_MOE=1
-  # Kept explicit for parity with the upstream ROCm recipe knobs. See the
-  # shared-expert note below — vLLM may self-disable this fusion.
+  # Fuses the FP8 shared expert into the MXFP4 routed-expert AITER kernel.
+  # See the shared-expert note below for the build and eligibility requirements.
   export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
   export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
@@ -642,14 +642,24 @@ guide: |
   are not byte-identical to what the command above produces. Use the chat endpoint
   for any MTP acceptance measurement regardless.
 
-  ### Shared-expert fusion may self-disable
+  ### Shared-expert fusion requires a recent build
 
-  `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` is exported for parity with the
-  ROCm recipe, but it is a request, not a guarantee. vLLM gates the fused
-  shared-expert path on its own eligibility check, and for this mixed FP4+FP8
-  checkpoint that check does not currently pass, so the fusion self-disables at
-  startup. Treat the flag as harmless recipe parity and check the server log
-  before assuming the fused path executed.
+  `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` is a request, not a guarantee:
+  vLLM gates the fused shared-expert path on its own eligibility check. Until
+  [vllm-project/vllm#53161](https://github.com/vllm-project/vllm/pull/53161) that
+  check rejected this mixed FP4+FP8 checkpoint outright, so on any build older
+  than `de69e821` the flag is inert and the fusion self-disables at startup. That
+  PR adds the heterogeneous path that fuses the native-FP8 shared expert into the
+  MXFP4 routed-expert kernel, which is what makes the flag take effect.
+
+  On a build that includes it, the fusion additionally requires gfx950 (MI355X),
+  tensor parallelism 8, data parallelism 1, no expert parallelism and no EPLB,
+  `--moe-backend aiter`, BF16 model dtype, and the DeepSeek-V4 block-128 FP8
+  shared-expert quantization config. Both arms here satisfy this. Data-parallel
+  attention does not, and keeps the unfused path.
+
+  Failures are silent and logged at debug level, so check the server log before
+  assuming the fused path executed rather than inferring it from the flag.
 
   ### How this differs from the Agentic sweep above
 


### PR DESCRIPTION
## What

The DSv4-Pro recipe currently tells readers that the shared-expert fusion always self-disables on MI355X:

> vLLM gates the fused shared-expert path on its own eligibility check, and for this mixed FP4+FP8 checkpoint that check does not currently pass, so the fusion self-disables at startup. Treat the flag as harmless recipe parity.

That was accurate when written, but [vllm-project/vllm#53161](https://github.com/vllm-project/vllm/pull/53161) (merged as `de69e821`) adds the heterogeneous path that fuses the DeepSeek-V4 native-FP8 shared expert into the MXFP4 routed-expert AITER kernel. `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` is no longer inert, so "harmless recipe parity" now steers people away from a real optimization.

## Changes

Rewrites the note to state the build requirement (`de69e821` or newer, which current `:nightly` images satisfy) instead of a blanket failure, and lists the conditions vLLM actually gates on: gfx950, TP8, DP1, no expert parallelism, no EPLB, `--moe-backend aiter`, BF16 dtype, and the block-128 FP8 shared-expert quant config. Also notes that DP-attention does not qualify and keeps the unfused path, and that rejection is logged at debug level so the server log is the only reliable check.

Two further points the note now makes explicit:

- The immutable tag pinned in the 8K/1K reproduction table (`nightly-7c5dc571`, 2026-09-01) predates `de69e821`, so on that specific pin the flag remains inert. That pin is deliberately left unchanged — it documents the build those measurements were taken on.
- Eligibility is re-checked per invocation against AITER's tuned-config coverage for the number of MoE input rows, not just once at startup. Decode-sized batches are covered and take the fused kernel; large prefill chunks fall back. For an 8K-input workload that means fused decode and unfused prefill, which is worth knowing before attributing a result to the fusion.

The inline comment above the STP export is updated to match. No flags, launch commands, or pinned images change.

## Testing

Documentation only; no runtime behaviour changes. `models/deepseek-ai/DeepSeek-V4-Pro.yaml` parses cleanly:

```
python3 -c "import yaml; yaml.safe_load(open('models/deepseek-ai/DeepSeek-V4-Pro.yaml'))"
```

The eligibility conditions were read off `_heterogeneous_shared_expert_enabled()` in `vllm/models/deepseek_v4/amd/model.py` at the merge commit rather than copied from the PR description. The per-invocation coverage behaviour was confirmed by probing `aiter.fhmoe.supports_dsv4_i384_fhmoe` directly on an MI355X node, and the startup log line quoted in the note was taken from a real server log rather than from source.

The corresponding InferenceX repin, which moves all three DSv4 MI355X vLLM entries onto the first nightly containing `de69e821`, is [SemiAnalysisAI/InferenceX#2851](https://github.com/SemiAnalysisAI/InferenceX/pull/2851). A full benchmark sweep on that branch completed with 50 jobs and no failures.

> AI assistance was used to prepare this PR.
