### PR TITLE
Add MiniCPM5-2B vLLM deployment guide

### DIFF
--- a/models/openbmb/MiniCPM5-2B.yaml
+++ b/models/openbmb/MiniCPM5-2B.yaml
@@ -1,0 +1,124 @@
+meta:
+  title: "MiniCPM5-2B"
+  slug: "minicpm5-2b"
+  provider: "MiniCPM (OpenBMB)"
+  description: "MiniCPM5-2B — dense 2B LLM with hybrid Think/No-Think reasoning, native 128K context, and native tool calling support, built on the standard Llama architecture"
+  date_added: 2026-09-07
+  date_updated: 2026-09-07
+  difficulty: beginner
+  tasks:
+    - text
+  performance_headline: "2B-class open-source model with strong reasoning and tool use"
+  related_recipes:
+    - openbmb/MiniCPM5-1B
+    - openbmb/MiniCPM-V-4.6
+
+model:
+  model_id: "openbmb/MiniCPM5-2B"
+  min_vllm_version: "0.21.0"
+  architecture: dense
+  parameter_count: "2B"
+  active_parameters: "2B"
+  context_length: 131072
+  base_args: []
+  base_env: {}
+
+features:
+  reasoning:
+    description: "Enable hybrid deep-thinking mode — the chat template wraps a <think> block before the answer. Recommended sampling shifts to temperature=0.9, top_p=0.95. Leave off for fast No-Think responses (temperature=0.7)."
+    args:
+      - "--default-chat-template-kwargs"
+      - '{"enable_thinking": true}'
+  tool_calling:
+    description: "Enable native tool calling with the MiniCPM5 XML parser (merged in vLLM PR #43175)."
+    args:
+      - "--enable-auto-tool-choice"
+      - "--tool-call-parser"
+      - "minicpm5"
+
+opt_in_features:
+  - reasoning
+
+variants:
+  default:
+    precision: bf16
+    vram_minimum_gb: 5
+    description: "BF16 weights (~2B params) — fits on a single consumer GPU"
+
+compatible_strategies:
+  - single_node_tp
+  - multi_node_tp
+
+strategy_overrides:
+  single_node_tp:
+    tp: 1
+
+guide: |
+  ## Overview
+
+  **MiniCPM5-2B** is the 2B checkpoint in OpenBMB's MiniCPM5 series — a dense
+  model built for on-device and resource-constrained deployment, with strong
+  performance on agentic tool use, code generation, and reasoning tasks.
+  It uses the **standard `LlamaForCausalLM` architecture**, so vLLM loads it
+  natively with no custom kernels or model-code fork.
+
+  Its headline feature is **hybrid reasoning**: a single checkpoint serves as
+  both a fast assistant (No-Think) and a deliberate reasoner (Think), toggled by
+  the chat template's `enable_thinking` flag.
+
+  ## Prerequisites
+
+  - **vLLM ≥ 0.21.0** — MiniCPM5-2B is supported natively as of the v0.21.0
+    release.
+
+  ## Launch command
+
+  Use the command builder above. The baseline is simply:
+
+  ```bash
+  vllm serve openbmb/MiniCPM5-2B --port 8000
+  ```
+
+  At ~2B params the model fits on a single GPU (TP=1). It supports the full
+  native 128K context; drop `--max-model-len` to `8192` / `32768` to free KV
+  cache on small GPUs.
+
+  ## Reasoning modes
+
+  Toggle the **Reasoning** feature to serve with deep-thinking on by default
+  (`--default-chat-template-kwargs '{"enable_thinking": true}'`). You can also
+  flip it per request via `chat_template_kwargs`:
+
+  ```bash
+  curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "openbmb/MiniCPM5-2B",
+      "messages": [{"role": "user", "content": "Explain GQA in one sentence."}],
+      "temperature": 0.9, "top_p": 0.95, "max_tokens": 1024,
+      "chat_template_kwargs": {"enable_thinking": true}
+    }'
+  ```
+
+  | Mode | `enable_thinking` | `temperature` | `top_p` |
+  | --- | --- | --- | --- |
+  | Think | `true` | 0.9 | 0.95 |
+  | No-Think | `false` | 1.0 | 0.95 |
+
+  ## Tool calling
+
+  MiniCPM5-2B emits **XML-style** tool calls. The `minicpm5` parser
+  ([PR #43175](https://github.com/vllm-project/vllm/pull/43175)) is natively
+  supported in vLLM. Enable it with:
+
+  ```bash
+  vllm serve openbmb/MiniCPM5-2B --port 8000 \
+    --enable-auto-tool-choice \
+    --tool-call-parser minicpm5
+  ```
+
+  ## References
+
+  - [Model card](https://huggingface.co/openbmb/MiniCPM5-2B)
+  - [vLLM deployment cookbook](https://github.com/OpenBMB/MiniCPM/blob/main/docs/deployment/vllm.md)
+  - [MiniCPM Tech Report](https://arxiv.org/pdf/2506.07900)


### PR DESCRIPTION
Add MiniCPM/MiniCPM5-2B.md with instructions for deploying MiniCPM5-2B as an OpenAI-compatible HTTP server using vLLM. Covers installation, Docker, validation, tool calling, configuration tips, benchmarking, and Python client example.