### PR TITLE
[ROCm] Update MI355X recipe for K2-Horizon-375B-A23B

### DIFF
--- a/models/IFM/K2-Horizon-375B-A23B.yaml
+++ b/models/IFM/K2-Horizon-375B-A23B.yaml
@@ -41,7 +41,8 @@ default_strategy: single_node_tep
 
 # On AMD the expert-parallel dispatch is slower than replicating the experts
 # across a pure tensor-parallel shard, so the TEP strategies are opted out and
-# single-node TP is the offered path.
+# single-node TP is the offered path. multi_node_tp_pp is left available: EP
+# works there, it is just not the fast default at single-node scale.
 strategy_hardware:
   single_node_tep:
     amd: unsupported
@@ -116,6 +117,7 @@ guide: |
     --tensor-parallel-size 8 \
     --trust-remote-code \
     --dtype bfloat16 \
+    --max-model-len 131072 \
     --gpu-memory-utilization 0.9 \
     --attention-backend ROCM_AITER_UNIFIED_ATTN \
     --generation-config auto \

--- a/models/IFM/K2-Horizon-375B-A23B.yaml
+++ b/models/IFM/K2-Horizon-375B-A23B.yaml
@@ -4,20 +4,25 @@ meta:
   provider: "IFM"
   description: "Frontier-scale sparse MoE model for long-context research and high-capacity serving"
   date_added: 2026-08-31
-  date_updated: 2026-09-03
+  date_updated: 2026-09-08
   difficulty: advanced
   tasks: [text]
   performance_headline: "379.17B stored parameters including embeddings / 26.67B active parameters per token"
   related_recipes: ["IFM/K2-Horizon-MoVA-36B-A4B"]
   hardware:
     h200: verified
+    mi355x: verified
 model:
   model_id: "IFM/K2-Horizon-375B-A23B"
   architecture: moe
   parameter_count: "379.17B"
   active_parameters: "26.67B"
   context_length: 524288
-  base_args: ["--trust-remote-code", "--dtype", "bfloat16", "--max-model-len", "131072", "--enable-expert-parallel"]
+  # --enable-expert-parallel is not here: in base_args it would reach the AMD
+  # path too, which deliberately runs pure TP (see strategy_hardware). The TEP
+  # strategies emit it themselves; multi_node_tp_pp does not, so it carries its
+  # own copy in strategy_overrides below.
+  base_args: ["--trust-remote-code", "--dtype", "bfloat16", "--max-model-len", "131072"]
   base_env: {}
 features:
   reasoning:
@@ -31,12 +36,44 @@ variants:
     precision: bf16
     vram_minimum_gb: 911
     description: "BF16 serving runtime with an eight-GPU tensor-parallel baseline"
-compatible_strategies: [single_node_tep, multi_node_tep, multi_node_tp_pp]
+compatible_strategies: [single_node_tep, single_node_tp, multi_node_tep, multi_node_tp_pp]
 default_strategy: single_node_tep
-hardware_overrides: {}
+
+# On AMD the expert-parallel dispatch is slower than replicating the experts
+# across a pure tensor-parallel shard, so the TEP strategies are opted out and
+# single-node TP is the offered path.
+strategy_hardware:
+  single_node_tep:
+    amd: unsupported
+  multi_node_tep:
+    amd: unsupported
+hardware_overrides:
+  amd:
+    # AITER supplies the fused MoE and the unified attention kernel on CDNA 4.
+    # NCCL_MIN_NCHANNELS is raised because the 8-way all-reduce on the MoE
+    # output is small and latency-bound at these shapes; the default channel
+    # count leaves the interconnect underfed.
+    #
+    # Leave AITER_CONFIG_FMOE unset. A single relative value REPLACES the
+    # config list with a path resolved against the process CWD; unset, AITER
+    # globs configs/model_configs/*tuned_fmoe*.csv and merges them with the
+    # stock table, which is what picks up per-model tuned rows.
+    extra_args:
+      - "--attention-backend"
+      - "ROCM_AITER_UNIFIED_ATTN"
+      - "--gpu-memory-utilization"
+      - "0.9"
+    extra_env:
+      VLLM_ROCM_USE_AITER: "1"
+      NCCL_MIN_NCHANNELS: "112"
 strategy_overrides:
   single_node_tep:
     tp: 8
+  # multi_node_tp_pp emits no EP flag of its own, and this recipe has always
+  # run it with expert parallel on. Restored here rather than in base_args so
+  # it stays off the AMD single-node TP path.
+  multi_node_tp_pp:
+    extra_args: ["--enable-expert-parallel"]
 guide: |
   ## Overview
 
@@ -61,6 +98,27 @@ guide: |
     --dtype bfloat16 \
     --max-model-len 131072 \
     --enable-expert-parallel \
+    --reasoning-parser k2_horizon \
+    --enable-auto-tool-choice \
+    --tool-call-parser k2_horizon
+  ```
+
+  ### AMD MI355X
+
+  Verified on an 8-GPU MI355X (gfx950) node. AITER supplies the fused MoE and
+  the unified attention backend:
+
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export NCCL_MIN_NCHANNELS=112
+
+  vllm serve IFM/K2-Horizon-375B-A23B \
+    --tensor-parallel-size 8 \
+    --trust-remote-code \
+    --dtype bfloat16 \
+    --gpu-memory-utilization 0.9 \
+    --attention-backend ROCM_AITER_UNIFIED_ATTN \
+    --generation-config auto \
     --reasoning-parser k2_horizon \
     --enable-auto-tool-choice \
     --tool-call-parser k2_horizon

--- a/models/IFM/K2-Horizon-375B-A23B.yaml
+++ b/models/IFM/K2-Horizon-375B-A23B.yaml
@@ -50,15 +50,6 @@ strategy_hardware:
     amd: unsupported
 hardware_overrides:
   amd:
-    # AITER supplies the fused MoE and the unified attention kernel on CDNA 4.
-    # NCCL_MIN_NCHANNELS is raised because the 8-way all-reduce on the MoE
-    # output is small and latency-bound at these shapes; the default channel
-    # count leaves the interconnect underfed.
-    #
-    # Leave AITER_CONFIG_FMOE unset. A single relative value REPLACES the
-    # config list with a path resolved against the process CWD; unset, AITER
-    # globs configs/model_configs/*tuned_fmoe*.csv and merges them with the
-    # stock table, which is what picks up per-model tuned rows.
     extra_args:
       - "--attention-backend"
       - "ROCM_AITER_UNIFIED_ATTN"


### PR DESCRIPTION
### Summary

Adds a verified AMD MI355X profile to the K2-Horizon-375B-A23B recipe, and opts the model's expert-parallel strategies out on AMD.

BF16 serving was validated end-to-end on an 8-GPU MI355X (gfx950) node at both TP=8 and TP=4, using AITER's fused MoE and the `ROCM_AITER_UNIFIED_ATTN` backend.

### Changes

- `meta.hardware`: `mi355x: verified`.
- `hardware_overrides.amd`: `--attention-backend ROCM_AITER_UNIFIED_ATTN`, `--gpu-memory-utilization 0.9`, `VLLM_ROCM_USE_AITER=1`, `NCCL_MIN_NCHANNELS=112`.
- `strategy_hardware`: `single_node_tep` and `multi_node_tep` marked `amd: unsupported`; `single_node_tp` added to `compatible_strategies` as the AMD path.
- `--enable-expert-parallel` moved out of `model.base_args` and into `strategy_overrides.multi_node_tp_pp` (the TEP strategies already emit it themselves; TP+PP does not).
- Guide: new `### AMD MI355X` section with the launch command and the sweep-tuning notes.

This PR should be merged after:
https://github.com/vllm-project/vllm/pull/55368
https://github.com/vllm-project/vllm/pull/55335
https://github.com/ROCm/aiter/pull/5275