### PR TITLE
Muse Glimmer: pin to stable v0.28.0 and restore the pip install tab

### DIFF
--- a/models/meta-models/Muse-Glimmer-30B.yaml
+++ b/models/meta-models/Muse-Glimmer-30B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Muse (Meta)"
   description: "Dense 29.6B vision-language model with a ViT-G/14 perception encoder and 128K context, distilled from Muse Spark for local agentic use. Emits channel-scoped reasoning and XML-style ATEM tool calls rather than JSON, so it needs the dedicated `muse_glimmer` tool-call and reasoning parsers."
   date_added: 2026-08-09
-  date_updated: 2026-08-23
+  date_updated: 2026-09-09
   difficulty: advanced
   tasks:
     - text
@@ -30,14 +30,12 @@ meta:
 
 model:
   model_id: "meta-models/Muse-Glimmer-30B"
-  # Muse Glimmer landed after v0.27.1 and is available in nightly.
-  min_vllm_version: "nightly"
-  docker_image: "vllm/vllm-openai:nightly"
-  nightly_required: true
+  # Muse Glimmer support merged in vllm-project/vllm#51655 and shipped in v0.28.0.
+  min_vllm_version: "0.28.0"
+  docker_image: "vllm/vllm-openai:v0.28.0"
   install:
     docker:
-      note: "Muse Glimmer support is available in the official vLLM nightly image and has not shipped in a stable release yet."
-    pip: false
+      note: "Recommended: the pinned image ships all dependencies"
   architecture: dense
   # Model card states ~29.6B total including the perception encoder. Measured from
   # safetensors metadata: total_size 59,553,253,376 bytes at BF16 = 29.78B. No expert
@@ -162,7 +160,7 @@ guide: |
   ## Prerequisites
 
   - **Hardware**: DGX Spark. FP4 weights might also run on 5090.
-  - **Image**: `vllm/vllm-openai:nightly`.
+  - **Image**: `vllm/vllm-openai:v0.28.0`.
 
   ## Checkpoints
 


### PR DESCRIPTION
## Summary

The Muse Glimmer recipe still declares `min_vllm_version: "nightly"` and sets `install.pip: false`, so the Install block hides the pip tab and tells users the model "has not shipped in a stable release yet". That stopped being true on 2026-08-26.

Support merged in vllm-project/vllm#51655 on 2026-08-14 and shipped in **v0.28.0**. The recipe's `date_updated` is 2026-08-23, three days before the release, which is why it was missed.

## Evidence

| Check | Result |
|---|---|
| vllm-project/vllm#51655 | merged 2026-08-14, +4333/-16 across 21 files |
| merge commit `6adad08` vs tag `v0.28.0` | `behind_by: 0`, so the commit is contained in the tag |
| `vllm/model_executor/models/muse_glimmer.py` at `v0.28.0` | present |
| `vllm/vllm-openai:v0.28.0` on Docker Hub | exists, 9.7 GB, pushed 2026-08-26T09:20Z |

## Changes

* `min_vllm_version`: `"nightly"` to `"0.28.0"`
* `docker_image`: `vllm/vllm-openai:nightly` to `vllm/vllm-openai:v0.28.0`
* drop `nightly_required`, which pointed the generated pip command at the nightly wheel index
* drop `install.pip: false`, which hid the pip tab entirely
* update the guide's Prerequisites image reference to match
* bump `date_updated`

The user-visible effect is that `/meta-models/Muse-Glimmer-30B` now offers a working pip install path (`uv pip install -U vllm --torch-backend auto`) alongside Docker, instead of Docker only.

## Deliberately not changed

The ROCm section still references `vllm/vllm-openai-rocm:nightly`. Per CONTRIBUTING, the string form of `docker_image` pins NVIDIA only and AMD keeps its brand default, and I did not verify stable ROCm support for this model, so that line is left alone. Happy to include it if a maintainer can confirm.

## Validation

```
$ node scripts/build-recipes-api.mjs
✓ JSON API: 188 models (163 with recommended_command, 784 default-hw alternatives,
  1468 per-hw renderings), 189 promoted variants, 9 strategies,
  2 kv-store deployments, 2 platforms (7 variant collisions skipped)
$ echo $?
0
```

Regenerated `public/meta-models/Muse-Glimmer-30B.json` confirms `model.install.pip` is now populated rather than absent, and `docker_image` reads `vllm/vllm-openai:v0.28.0` in both `model` and `recommended_command`.
