### PR TITLE
Pin stale nightly recipes to v0.28.0

### DIFF
--- a/models/dots-studio/dots3-note-prev.yaml
+++ b/models/dots-studio/dots3-note-prev.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Dots"
   description: "Multimodal MoE model available in BF16 and native FP8, with hybrid DSA and SWA, 512K context, and MTP speculative decoding."
   date_added: 2026-08-13
-  date_updated: 2026-08-14
+  date_updated: 2026-09-09
   difficulty: advanced
   tasks:
     - multimodal
@@ -23,7 +23,6 @@ meta:
 model:
   model_id: "dots-studio/dots3-note-prev"
   min_vllm_version: "0.28.0"
-  nightly_required: true
   architecture: moe
   parameter_count: "288B"
   active_parameters: "17B"
@@ -128,7 +127,7 @@ guide: |
     memory for the runtime and KV cache; the recipe budgets 692 GB aggregate VRAM.
   - A recent CUDA environment. Native FP8 uses DeepGEMM, while unquantized BF16
     uses the Triton MoE backend.
-  - A vLLM nightly containing native dots3-note-prev support.
+  - vLLM 0.28.0 or newer, which includes native dots3-note-prev support.
 
   ## Launch commands
 

--- a/models/inclusionAI/Ling-3.0-flash.yaml
+++ b/models/inclusionAI/Ling-3.0-flash.yaml
@@ -3,7 +3,7 @@ meta:
   slug: "ling-3-0-flash"
   provider: "inclusionAI"
   description: "Ling-3.0-flash MoE model with BF16, FP8, FP4, and INT4 checkpoints, native MTP, and an external DSpark draft model"
-  date_updated: 2026-08-31
+  date_updated: 2026-09-09
   difficulty: advanced
   tasks:
     - text
@@ -14,8 +14,7 @@ meta:
 
 model:
   model_id: "inclusionAI/Ling-3.0-flash"
-  min_vllm_version: "0.25.0"
-  nightly_required: true
+  min_vllm_version: "0.28.0"
   architecture: moe
   parameter_count: "124B"
   active_parameters: "5.5B"
@@ -118,7 +117,7 @@ guide: |
 
   ## Prerequisites
 
-  - **vLLM:** a build containing native Bailing V3 support;
+  - **vLLM:** 0.28.0 or newer, which includes native Bailing V3 support;
   - **Validated hardware:** NVIDIA H20, H20-3e, H200, and DGX Spark (FP4/INT4)
   - **Precision:** BF16, serialized block FP8, mixed block-FP8/MXFP4, or compressed-tensors INT4 weights with BF16 compute
   - **Context length:** 262,144 tokens

--- a/models/inclusionAI/Ling-3.0-tiny.yaml
+++ b/models/inclusionAI/Ling-3.0-tiny.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "inclusionAI"
   description: "Ling-3.0-tiny lightweight hybrid-reasoning MoE with BF16, block-FP8, and compressed-tensors INT4 checkpoints"
   date_added: 2026-08-31
-  date_updated: 2026-08-31
+  date_updated: 2026-09-09
   difficulty: intermediate
   tasks:
     - text
@@ -16,8 +16,7 @@ meta:
 
 model:
   model_id: "inclusionAI/Ling-3.0-tiny"
-  min_vllm_version: "0.25.0"
-  nightly_required: true
+  min_vllm_version: "0.28.0"
   architecture: moe
   parameter_count: "7.9B"
   active_parameters: "1.3B"
@@ -94,7 +93,7 @@ guide: |
 
   ## Prerequisites
 
-  - **vLLM:** use a nightly/source build containing Ling 3.0 / Bailing V3
+  - **vLLM:** 0.28.0 or newer, which includes Ling 3.0 / Bailing V3
     hybrid-attention support;
   - **Parallelism:** TP1 is recommended for all three checkpoints;
   - **Thinking mode:** enabled per request by the chat template.

--- a/models/tencent/Hy3.yaml
+++ b/models/tencent/Hy3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Hy (Tencent)"
   description: "Tencent Hy3 — scaled-up MoE language model (295B total / 21B active) with a 3.8B MTP layer for speculative decoding, 256K context, and hy_v3 tool/reasoning parsers"
   date_added: 2026-07-06
-  date_updated: 2026-07-06
+  date_updated: 2026-09-09
   difficulty: intermediate
   tasks:
     - text
@@ -18,16 +18,15 @@ meta:
 
 model:
   model_id: "tencent/Hy3"
-  min_vllm_version: "0.26.0"
+  min_vllm_version: "0.28.0"
   docker_image:
     nvidia: "vllm/vllm-openai:hy3"
     amd: "vllm/vllm-openai-rocm:nightly-cbe9c40f998f13975b967773ac7e7920e115387f"
-  nightly_required: true
   install:
     docker:
-      note: "Use the dedicated hy3 image until changes land in vllm:latest."
+      note: "Recommended: the dedicated image ships the Hy3 runtime and dependencies."
     pip:
-      note: "Hy3's latest optimizations (vLLM #47433) aren't in a stable release yet — use nightly wheels or build from source."
+      note: "vLLM 0.28.0 includes Hy3 support and the optimizations from vLLM #47433."
   architecture: moe
   parameter_count: "295B"
   active_parameters: "21B"
@@ -122,10 +121,10 @@ guide: |
 
   Hy3 uses the same model code as
   [Hy3-preview](https://huggingface.co/tencent/Hy3-preview), so any vLLM build that
-  serves Hy3-preview also serves Hy3. The latest optimizations — Tencent's HPC-Ops
-  attention and MoE backends — require a newer vLLM that includes
-  [#47433](https://github.com/vllm-project/vllm/pull/47433) plus the separately-built
-  HPC-Ops kernels (see the HPC-Ops backends section below).
+  serves Hy3-preview also serves Hy3. vLLM 0.28.0 includes
+  [#47433](https://github.com/vllm-project/vllm/pull/47433), which adds Tencent's
+  HPC-Ops attention and MoE backends. The HPC-Ops kernels are still built and
+  installed separately (see the HPC-Ops backends section below).
 
   ## Setup
 


### PR DESCRIPTION
## Summary

- remove stale `nightly_required` flags from four recipes whose support shipped in vLLM v0.28.0
- correct the minimum vLLM version for the Ling 3.0 recipes
- update the Hy3 installation guidance now that vLLM #47433 is in a stable release
- refresh `date_updated` for the affected recipes

## Testing

- `node scripts/build-recipes-api.mjs`
- `git diff --check`

Closes #944