### PR TITLE
[DeepSeek] V4.1-Flash: correct the parameter counts

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
@@ -3,14 +3,14 @@ meta:
   title: "DeepSeek-V4.1-Flash"
   slug: "deepseek-v4.1-flash"
   provider: "DeepSeek"
-  description: "DeepSeek V4.1 Flash vision-language MoE (769B total / 15.5B active) combining sliding-window plus compressed sparse attention with a two-level indexer, engram n-gram memory, hyper-connections, and a DSpark multi-token draft head."
+  description: "DeepSeek V4.1 Flash vision-language MoE (522B total; 8B active per prompt token, 16B per output token) combining sliding-window plus compressed sparse attention with a two-level indexer, engram n-gram memory, hyper-connections, and a DSpark multi-token draft head."
   date_added: 2026-09-09
   date_updated: 2026-09-10
   difficulty: advanced
   tasks:
     - text
     - multimodal
-  performance_headline: "1M context at 15.5B active parameters, with engram n-gram memory"
+  performance_headline: "1M context at 8-16B active parameters, with engram n-gram memory"
   related_recipes:
     - "deepseek-ai/DeepSeek-V4-Flash"
     - "deepseek-ai/DeepSeek-V4-Pro"
@@ -27,8 +27,9 @@ model:
   docker_image:
     nvidia: "vllm/vllm-openai:deepseekv41-flash-0909"
     amd: "vllm/vllm-openai-rocm:deepseekv41-flash-0909"
-  parameter_count: "769B"
-  active_parameters: "15.5B"
+  architecture: moe
+  parameter_count: "522B"
+  active_parameters: "8-16B"
   context_length: 1048576
   base_args:
     - "--tokenizer-mode"
@@ -124,9 +125,10 @@ strategy_overrides:
 guide: |
   ## Overview
 
-  DeepSeek-V4.1 is a vision-language Mixture-of-Experts model: **769B total parameters,
-  15.5B active per token**, 40 transformer layers at hidden size 5120, with a 32-layer
-  ViT and aligner in front of the text stack. Five things distinguish it from V4:
+  DeepSeek-V4.1 is a vision-language Mixture-of-Experts model: **522B total parameters,
+  8B active per prompt token and 16B per output token**, 40 transformer layers at hidden
+  size 5120, with a 32-layer ViT and aligner in front of the text stack. Five things
+  distinguish it from V4:
 
   - **Two-tier sparse attention.** Every layer attends over a 128-token sliding window.
     Layers that carry a compression ratio add compressed KV latents reaching further


### PR DESCRIPTION
## What

DeepSeek-V4.1-Flash was published with the wrong size: it is **522B total** parameters with **8B active per prompt token and 16B per output token**, not 769B / 15.5B. This corrects the figures and makes every place that quotes them agree.

- `meta.description`, `meta.performance_headline` and the guide's Overview now use one phrasing. The headline was the stalest of the three — it still read `15.5B active parameters`.
- `model.active_parameters` is `"8-16B"` rather than `"8B/16B"`. The card grid and browse list render the size chip as `` `${parameter_count}/${active_parameters}` `` (`RecipeCardGrid.jsx:89`, `BrowseList.jsx:624`), so a slash inside the value came out as `522B/8B/16B`. The prompt-vs-output split is spelled out in the description and the guide instead.
- Adds the missing `model.architecture: moe`. This recipe was the only one of 190 without it; the detail page rendered an empty architecture badge, and the card/browse size chips are gated on `architecture === "moe"`, so the active-parameter figure was not being shown at all.

## Still open

The guide's **Memory** table is unchanged and still reflects the old breakdown — its rows sum to ~762.8B (`Routed + DSpark experts` alone is 557.2B, more than the new 522B total). The stored-size column is consistent with the real checkpoint (511 GB on disk, and `vram_minimum_gb: 614` derives from that), so only the parameter column needs a recount against the checkpoint. Happy to push that as a follow-up commit here once the per-component numbers are confirmed.

## Validation

`node scripts/build-recipes-api.mjs` → `✓ JSON API: 190 models ... 9 strategies, 2 kv-store deployments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)