### PR TITLE
[DeepSeek] V4-Flash-Vision-Exp: add Ascend 950PR/950DT 8x

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.yaml
@@ -19,9 +19,9 @@ meta:
   # on one NVL4 tray, FP8 KV cache, block size 256, DSpark k=3, full
   # 1000-sample OCRBench at 83.5% with zero request errors.
   # Atlas A5 8-card mixed serving of the native FP4+FP8 Vision-Exp checkpoint
-  # (DP4+EP, TP=1, DSpark k=3). 950PR verified 2026-09-10 on vLLM Ascend;
-  # 950DT uses the same command (4 of 8 NPUs). See the hardware note for the
-  # required hash-router bias fix.
+  # (DP4+EP, TP=1, no speculative decoding). 950PR verified 2026-09-10 on
+  # vLLM Ascend; 950DT uses the same command (4 of 8 NPUs). See the hardware
+  # note for the required hash-router bias fix.
   default_hardware: gb200
   hardware:
     gb200: verified
@@ -85,14 +85,19 @@ features:
     args:
       - "--speculative-config"
       - '{"method":"dspark","model":"deepseek-ai/DeepSeek-V4-Flash-Vision-Exp","num_speculative_tokens":3,"draft_sample_method":"probabilistic","enable_adaptive_verification":true}'
-    # vLLM Ascend does not implement probabilistic draft sampling or adaptive
-    # verification. k=3 matches the checkpoint's n_predict; the draft stays
-    # eager while the target keeps FULL_DECODE_ONLY.
+    # 950 has no working MTP or DSpark path yet. Empty args so a toggle-on
+    # still emits no --speculative-config. Default-off via
+    # hardware_opt_in_features below — GB200 keeps DSpark on.
     hardware_overrides:
       npu:
-        args:
-          - "--speculative-config"
-          - '{"method":"dspark","num_speculative_tokens":3,"enforce_eager":true}'
+        args: []
+
+# Spec decoding stays default-on everywhere except the A5 8-card pills.
+hardware_opt_in_features:
+  ascend_950pr_8x:
+    - spec_decoding
+  ascend_950dt_8x:
+    - spec_decoding
 
 variants:
   default:
@@ -307,14 +312,13 @@ guide: |
     --additional-config '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "enable_shared_expert_dp": true}' \
     --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice \
-    --reasoning-parser deepseek_v4 \
-    --speculative-config '{"method":"dspark","num_speculative_tokens":3,"enforce_eager":true}'
+    --reasoning-parser deepseek_v4
   ```
 
   `--max-model-len 8192` is the verified bound. Raise it only after checking
   free HBM — the checkpoint advertises 1M tokens, which will not fit on 4
-  NPUs. DSpark stays at `num_speculative_tokens: 3` so it is divisible by
-  the checkpoint's `n_predict`.
+  NPUs. Do not pass `--speculative-config`: MTP and DSpark are not supported
+  on 950 for this checkpoint yet.
 
   ### Huawei Ascend 950DT 8x
 

--- a/models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "DeepSeek"
   description: "DeepSeek's first experimental multimodal V4 model — the V4-Flash MoE backbone plus a 32-layer vision tower, 1M context, and a fused DSpark draft module."
   date_added: 2026-09-01
-  date_updated: 2026-09-01
+  date_updated: 2026-09-10
   difficulty: advanced
   tasks:
     - text
@@ -15,12 +15,18 @@ meta:
     - "deepseek-ai/DeepSeek-V4-Pro"
   # The vision path is unreleased — it lives in the open support PR
   # vllm-project/vllm#54566 (see model.install below). GB200 is the only
-  # hardware with a published end-to-end run on that branch: TP4 + EP on one
-  # NVL4 tray, FP8 KV cache, block size 256, DSpark k=3, full 1000-sample
-  # OCRBench at 83.5% with zero request errors.
+  # NVIDIA hardware with a published end-to-end run on that branch: TP4 + EP
+  # on one NVL4 tray, FP8 KV cache, block size 256, DSpark k=3, full
+  # 1000-sample OCRBench at 83.5% with zero request errors.
+  # Atlas A5 8-card mixed serving of the native FP4+FP8 Vision-Exp checkpoint
+  # (DP4+EP, TP=1, DSpark k=3). 950PR verified 2026-09-10 on vLLM Ascend;
+  # 950DT uses the same command (4 of 8 NPUs). See the hardware note for the
+  # required hash-router bias fix.
   default_hardware: gb200
   hardware:
     gb200: verified
+    ascend_950dt_8x: verified
+    ascend_950pr_8x: verified
 
 model:
   model_id: "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp"
@@ -34,7 +40,7 @@ model:
     # checkpoint: released vLLM routes it to the text-only
     # DeepseekV4ForCausalLM, which then fails on the vision/aligner tensors.
     docker:
-      note: "Use the dedicated DeepSeek-V4-Flash-Vision image until support lands in the standard vLLM image."
+      note: "NVIDIA: use the dedicated DeepSeek-V4-Flash-Vision image until support lands in the standard vLLM image. Ascend 950PR/950DT: pin quay.io/ascend/vllm-ascend:v0.23.0-a5 and overlay vllm-project/vllm-ascend#16259."
     pip: false
   architecture: moe
   parameter_count: "285B"
@@ -61,6 +67,13 @@ features:
       - "deepseek_v4"
       - "--reasoning-config"
       - '{"reasoning_parser":"deepseek_v4","reasoning_start_str":"","reasoning_end_str":""}'
+    # Empty start/end strings make the Ascend chat path emit content=null
+    # for a full completion. Keep the parser, drop the override.
+    hardware_overrides:
+      npu:
+        args:
+          - "--reasoning-parser"
+          - "deepseek_v4"
   # Single method, so the boolean form (not `modes`): the checkpoint's fused
   # DSpark module is the only drafter with a published run on this branch. Left
   # OUT of opt_in_features on purpose — the verified GB200 configuration had
@@ -72,6 +85,14 @@ features:
     args:
       - "--speculative-config"
       - '{"method":"dspark","model":"deepseek-ai/DeepSeek-V4-Flash-Vision-Exp","num_speculative_tokens":3,"draft_sample_method":"probabilistic","enable_adaptive_verification":true}'
+    # vLLM Ascend does not implement probabilistic draft sampling or adaptive
+    # verification. k=3 matches the checkpoint's n_predict; the draft stays
+    # eager while the target keeps FULL_DECODE_ONLY.
+    hardware_overrides:
+      npu:
+        args:
+          - "--speculative-config"
+          - '{"method":"dspark","num_speculative_tokens":3,"enforce_eager":true}'
 
 variants:
   default:
@@ -80,6 +101,18 @@ variants:
     # underestimates: sized from the real checkpoint (167.8 GB x 1.2).
     vram_minimum_gb: 202
     description: "Native FP4+FP8 mixed checkpoint (MoE experts FP4, attention/norm/router FP8) with a BF16 vision tower, aligner, and the fused DSpark draft module."
+    hardware_overrides:
+      # Exact-GPU pin: computeDockerMeta has no Huawei brand, so the model-level
+      # docker_image string only affects NVIDIA. Hide pip — official wheels
+      # have no NPU kernels.
+      ascend_950pr_8x:
+        docker_image: "quay.io/ascend/vllm-ascend:v0.23.0-a5"
+        install:
+          pip: false
+      ascend_950dt_8x:
+        docker_image: "quay.io/ascend/vllm-ascend:v0.23.0-a5"
+        install:
+          pip: false
 
 compatible_strategies:
   - single_node_tp
@@ -90,6 +123,74 @@ compatible_strategies:
 
 # TP + EP is the verified layout (TP4 + EP on one GB200 NVL4 tray).
 default_strategy: single_node_tep
+
+# Atlas A5 mixed serving is DP+EP only. The native checkpoint has 64
+# attention heads; 950's FP8 DSA operator accepts local num_heads_q of
+# 64 or 128, so TP must stay 1. TEP/TP and intra-node PD are not offered.
+strategy_hardware:
+  single_node_tp:
+    npu: unsupported
+  single_node_tep:
+    npu: unsupported
+  multi_node_tep:
+    npu: unsupported
+  multi_node_dep:
+    npu: unsupported
+
+# Shared by 950DT 8x (8×96 GB) and 950PR 8x (8×128 GB). Mixed serving uses
+# 4 of the 8 NPUs (DP4+EP, TP=1). HCCL_BUFFSIZE=1024 is required for MC2
+# dispatch. last-wins shadows the DEP builder's --data-parallel-size 8
+# and the recipe-level --block-size 256 / --kv-cache-dtype fp8.
+hardware_overrides:
+  npu:
+    extra_args:
+      - "--data-parallel-size"
+      - "4"
+      - "--block-size"
+      - "128"
+      - "--kv-cache-dtype"
+      - "auto"
+      - "--tokenizer-mode"
+      - "deepseek_v4"
+      - "--safetensors-load-strategy"
+      - "prefetch"
+      - "--async-scheduling"
+      - "--max-model-len"
+      - "8192"
+      - "--max-num-seqs"
+      - "16"
+      - "--max-num-batched-tokens"
+      - "2048"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--api-server-count"
+      - "1"
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--additional-config"
+      - '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "enable_shared_expert_dp": true}'
+    extra_env:
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      OMP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "10"
+      HCCL_BUFFSIZE: "1024"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      TASK_QUEUE_ENABLE: "1"
+      ASCEND_RT_VISIBLE_DEVICES: "0,1,2,3"
+
+hardware_notes:
+  ascend_950dt_8x:
+    title: "vLLM Ascend A5 image required"
+    body: "Mixed serving on one 8-card 950DT node uses 4 of 8 NPUs (DP4+EP, TP=1). Same command as 950PR. Pin quay.io/ascend/vllm-ascend:v0.23.0-a5 — the NVIDIA pip wheel cannot run here. Set HCCL_BUFFSIZE=1024 before launch. Native Flash-Vision checkpoints need the hash-router bias skip in vllm-project/vllm-ascend#16259 — without it load_weights aborts on model.layers.0.mlp.gate.e_score_correction_bias."
+    link:
+      label: "Ascend 950DT 8x mixed"
+      href: "#huawei-ascend-950dt-8x"
+  ascend_950pr_8x:
+    title: "vLLM Ascend A5 image required"
+    body: "Mixed serving on one 8-card 950PR node uses 4 of 8 NPUs (DP4+EP, TP=1). Same command as 950DT. Pin quay.io/ascend/vllm-ascend:v0.23.0-a5 and set HCCL_BUFFSIZE=1024 before launch. Native Flash-Vision checkpoints need the hash-router bias skip in vllm-project/vllm-ascend#16259 — without it load_weights aborts on model.layers.0.mlp.gate.e_score_correction_bias."
+    link:
+      label: "Ascend 950PR 8x mixed"
+      href: "#huawei-ascend-950pr-8x"
 
 guide: |
   ## Overview
@@ -115,11 +216,14 @@ guide: |
   wheel routes this checkpoint to the text-only class and fails on the vision tensors.
 
   - **Weights:** ~168 GB on disk (48 shards). Budget ~202 GB of VRAM before KV cache.
-  - **Hardware:** NVIDIA only — the ROCm and XPU builds have no vision implementation.
-  - **Tokenizer / chat template:** nothing to pass. The repo ships no Jinja template
-    (prompt encoding lives in `encoding/`); vLLM resolves `--tokenizer-mode` to
-    `deepseek_v4` automatically, which is what turns OpenAI content blocks into
-    `<｜deepseek_image｜>` placeholders.
+  - **Hardware:** NVIDIA GB200 is the published OCRBench run. Atlas A5
+    (950PR / 950DT, 8-card) runs the same native checkpoint via vLLM Ascend
+    (DP4+EP, TP=1). The ROCm and XPU builds have no vision implementation.
+  - **Tokenizer / chat template:** nothing extra to pass on NVIDIA. The repo
+    ships no Jinja template (prompt encoding lives in `encoding/`); vLLM
+    resolves `--tokenizer-mode` to `deepseek_v4` automatically, which is what
+    turns OpenAI content blocks into `<｜deepseek_image｜>` placeholders. On
+    Ascend the generated command sets `--tokenizer-mode deepseek_v4` explicitly.
 
   ## Launching the server
 
@@ -163,6 +267,60 @@ guide: |
   `--attention_config.use_fp4_indexer_cache` / `--moe-backend deep_gemm_mega_moe` tweaks
   the text recipe applies are deliberately not set here: the verified vision run did not
   use them.
+
+  ### Huawei Ascend 950PR 8x
+
+  Mixed serving on one 8-card Atlas A5 node uses **4 of 8 NPUs** (DP4+EP,
+  TP=1). The native checkpoint has 64 attention heads; 950's FP8 DSA operator
+  only accepts a local `num_heads_q` of 64 or 128, so TP cannot be 2/4/8.
+  **950DT 8x uses the same command.** Pin
+  `quay.io/ascend/vllm-ascend:v0.23.0-a5` and overlay
+  [vllm-ascend#16259](https://github.com/vllm-project/vllm-ascend/pull/16259)
+  so hash-router layers skip the unused `e_score_correction_bias`. Do not
+  pass `--quantization ascend` — the mixed FP8/FP4 scheme is read from the
+  checkpoint. Leave `--reasoning-config` off; an empty start/end string
+  swallows the chat response.
+
+  ```bash
+  export OMP_PROC_BIND=false
+  export OMP_NUM_THREADS=10
+  export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
+  export ASCEND_RT_VISIBLE_DEVICES="0,1,2,3"
+  export HCCL_BUFFSIZE=1024
+  export HCCL_OP_EXPANSION_MODE="AIV"
+  export TASK_QUEUE_ENABLE=1
+
+  vllm serve deepseek-ai/DeepSeek-V4-Flash-Vision-Exp \
+    --enable-expert-parallel \
+    --data-parallel-size 4 \
+    --block-size 128 \
+    --kv-cache-dtype auto \
+    --tokenizer-mode deepseek_v4 \
+    --safetensors-load-strategy prefetch \
+    --async-scheduling \
+    --max-model-len 8192 \
+    --max-num-seqs 16 \
+    --max-num-batched-tokens 2048 \
+    --gpu-memory-utilization 0.9 \
+    --api-server-count 1 \
+    --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+    --additional-config '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "enable_shared_expert_dp": true}' \
+    --tool-call-parser deepseek_v4 \
+    --enable-auto-tool-choice \
+    --reasoning-parser deepseek_v4 \
+    --speculative-config '{"method":"dspark","num_speculative_tokens":3,"enforce_eager":true}'
+  ```
+
+  `--max-model-len 8192` is the verified bound. Raise it only after checking
+  free HBM — the checkpoint advertises 1M tokens, which will not fit on 4
+  NPUs. DSpark stays at `num_speculative_tokens: 3` so it is divisible by
+  the checkpoint's `n_predict`.
+
+  ### Huawei Ascend 950DT 8x
+
+  Same DP4+EP command as [950PR 8x](#huawei-ascend-950pr-8x). 950DT is
+  8×96 GB; the recipe still uses 4 of 8 NPUs so both A5 SKUs share one
+  command. Do not switch to TP>1.
 
   ## Reasoning modes
 
@@ -271,9 +429,10 @@ guide: |
 
   - **Pre-release.** Flags and defaults can change before #54566 lands; re-check before
     deploying, and keep the image pinned.
-  - **NVIDIA only.** ROCm and XPU raise `NotImplementedError` at model construction.
-  - **GB200 is the only hardware with a published vision run.** Every other pill is the
-    repo's fail-open default, not a tested claim.
+  - **ROCm and XPU** raise `NotImplementedError` at model construction.
+  - **Published vision runs:** GB200 (OCRBench 83.5%) and Atlas A5 950PR/950DT
+    (DP4+EP, TP=1). Every other pill is the repo's fail-open default, not a
+    tested claim. A5 needs vllm-ascend#16259.
   - **PD disaggregation is not offered**, and the CPU/filesystem KV-offload pills stay
     off — neither has a verified run to record. The Mooncake KV-store pills follow the
     repo's fail-open default and are offered, but untested here.
@@ -283,5 +442,6 @@ guide: |
 
   - [Model card](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp)
   - [vLLM support PR #54566](https://github.com/vllm-project/vllm/pull/54566)
+  - [vLLM Ascend hash-router bias fix #16259](https://github.com/vllm-project/vllm-ascend/pull/16259)
   - [DeepSeek-V4-Flash recipe](/deepseek-ai/DeepSeek-V4-Flash) — the text-only sibling
   - [DeepSpec (DSpark)](https://github.com/deepseek-ai/DeepSpec)

--- a/models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.yaml
+++ b/models/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.yaml
@@ -187,15 +187,9 @@ hardware_notes:
   ascend_950dt_8x:
     title: "vLLM Ascend A5 image required"
     body: "Mixed serving on one 8-card 950DT node uses 4 of 8 NPUs (DP4+EP, TP=1). Same command as 950PR. Pin quay.io/ascend/vllm-ascend:v0.23.0-a5 — the NVIDIA pip wheel cannot run here. Set HCCL_BUFFSIZE=1024 before launch. Native Flash-Vision checkpoints need the hash-router bias skip in vllm-project/vllm-ascend#16259 — without it load_weights aborts on model.layers.0.mlp.gate.e_score_correction_bias."
-    link:
-      label: "Ascend 950DT 8x mixed"
-      href: "#huawei-ascend-950dt-8x"
   ascend_950pr_8x:
     title: "vLLM Ascend A5 image required"
     body: "Mixed serving on one 8-card 950PR node uses 4 of 8 NPUs (DP4+EP, TP=1). Same command as 950DT. Pin quay.io/ascend/vllm-ascend:v0.23.0-a5 and set HCCL_BUFFSIZE=1024 before launch. Native Flash-Vision checkpoints need the hash-router bias skip in vllm-project/vllm-ascend#16259 — without it load_weights aborts on model.layers.0.mlp.gate.e_score_correction_bias."
-    link:
-      label: "Ascend 950PR 8x mixed"
-      href: "#huawei-ascend-950pr-8x"
 
 guide: |
   ## Overview
@@ -221,14 +215,11 @@ guide: |
   wheel routes this checkpoint to the text-only class and fails on the vision tensors.
 
   - **Weights:** ~168 GB on disk (48 shards). Budget ~202 GB of VRAM before KV cache.
-  - **Hardware:** NVIDIA GB200 is the published OCRBench run. Atlas A5
-    (950PR / 950DT, 8-card) runs the same native checkpoint via vLLM Ascend
-    (DP4+EP, TP=1). The ROCm and XPU builds have no vision implementation.
-  - **Tokenizer / chat template:** nothing extra to pass on NVIDIA. The repo
-    ships no Jinja template (prompt encoding lives in `encoding/`); vLLM
-    resolves `--tokenizer-mode` to `deepseek_v4` automatically, which is what
-    turns OpenAI content blocks into `<｜deepseek_image｜>` placeholders. On
-    Ascend the generated command sets `--tokenizer-mode deepseek_v4` explicitly.
+  - **Hardware:** NVIDIA only — the ROCm and XPU builds have no vision implementation.
+  - **Tokenizer / chat template:** nothing to pass. The repo ships no Jinja template
+    (prompt encoding lives in `encoding/`); vLLM resolves `--tokenizer-mode` to
+    `deepseek_v4` automatically, which is what turns OpenAI content blocks into
+    `<｜deepseek_image｜>` placeholders.
 
   ## Launching the server
 
@@ -272,59 +263,6 @@ guide: |
   `--attention_config.use_fp4_indexer_cache` / `--moe-backend deep_gemm_mega_moe` tweaks
   the text recipe applies are deliberately not set here: the verified vision run did not
   use them.
-
-  ### Huawei Ascend 950PR 8x
-
-  Mixed serving on one 8-card Atlas A5 node uses **4 of 8 NPUs** (DP4+EP,
-  TP=1). The native checkpoint has 64 attention heads; 950's FP8 DSA operator
-  only accepts a local `num_heads_q` of 64 or 128, so TP cannot be 2/4/8.
-  **950DT 8x uses the same command.** Pin
-  `quay.io/ascend/vllm-ascend:v0.23.0-a5` and overlay
-  [vllm-ascend#16259](https://github.com/vllm-project/vllm-ascend/pull/16259)
-  so hash-router layers skip the unused `e_score_correction_bias`. Do not
-  pass `--quantization ascend` — the mixed FP8/FP4 scheme is read from the
-  checkpoint. Leave `--reasoning-config` off; an empty start/end string
-  swallows the chat response.
-
-  ```bash
-  export OMP_PROC_BIND=false
-  export OMP_NUM_THREADS=10
-  export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
-  export ASCEND_RT_VISIBLE_DEVICES="0,1,2,3"
-  export HCCL_BUFFSIZE=1024
-  export HCCL_OP_EXPANSION_MODE="AIV"
-  export TASK_QUEUE_ENABLE=1
-
-  vllm serve deepseek-ai/DeepSeek-V4-Flash-Vision-Exp \
-    --enable-expert-parallel \
-    --data-parallel-size 4 \
-    --block-size 128 \
-    --kv-cache-dtype auto \
-    --tokenizer-mode deepseek_v4 \
-    --safetensors-load-strategy prefetch \
-    --async-scheduling \
-    --max-model-len 8192 \
-    --max-num-seqs 16 \
-    --max-num-batched-tokens 2048 \
-    --gpu-memory-utilization 0.9 \
-    --api-server-count 1 \
-    --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "enable_shared_expert_dp": true}' \
-    --tool-call-parser deepseek_v4 \
-    --enable-auto-tool-choice \
-    --reasoning-parser deepseek_v4
-  ```
-
-  `--max-model-len 8192` is the verified bound. Raise it only after checking
-  free HBM — the checkpoint advertises 1M tokens, which will not fit on 4
-  NPUs. Do not pass `--speculative-config`: MTP and DSpark are not supported
-  on 950 for this checkpoint yet.
-
-  ### Huawei Ascend 950DT 8x
-
-  Same DP4+EP command as [950PR 8x](#huawei-ascend-950pr-8x). 950DT is
-  8×96 GB; the recipe still uses 4 of 8 NPUs so both A5 SKUs share one
-  command. Do not switch to TP>1.
 
   ## Reasoning modes
 
@@ -433,10 +371,9 @@ guide: |
 
   - **Pre-release.** Flags and defaults can change before #54566 lands; re-check before
     deploying, and keep the image pinned.
-  - **ROCm and XPU** raise `NotImplementedError` at model construction.
-  - **Published vision runs:** GB200 (OCRBench 83.5%) and Atlas A5 950PR/950DT
-    (DP4+EP, TP=1). Every other pill is the repo's fail-open default, not a
-    tested claim. A5 needs vllm-ascend#16259.
+  - **NVIDIA only.** ROCm and XPU raise `NotImplementedError` at model construction.
+  - **GB200 is the only hardware with a published vision run.** Every other pill is the
+    repo's fail-open default, not a tested claim.
   - **PD disaggregation is not offered**, and the CPU/filesystem KV-offload pills stay
     off — neither has a verified run to record. The Mooncake KV-store pills follow the
     repo's fail-open default and are offered, but untested here.
@@ -446,6 +383,5 @@ guide: |
 
   - [Model card](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp)
   - [vLLM support PR #54566](https://github.com/vllm-project/vllm/pull/54566)
-  - [vLLM Ascend hash-router bias fix #16259](https://github.com/vllm-project/vllm-ascend/pull/16259)
   - [DeepSeek-V4-Flash recipe](/deepseek-ai/DeepSeek-V4-Flash) — the text-only sibling
   - [DeepSpec (DSpark)](https://github.com/deepseek-ai/DeepSpec)


### PR DESCRIPTION
## What this PR does

Adds Atlas A5 `ascend_950pr_8x` and `ascend_950dt_8x` to the DeepSeek-V4-Flash-Vision-Exp recipe. Both SKUs use the same mixed-serving command: **DP4+EP, TP=1** on 4 of 8 NPUs.

The native checkpoint has 64 attention heads. 950's FP8 DSA operator only accepts a local `num_heads_q` of 64 or 128, so TP cannot be 2/4/8. 950DT (8x96 GB) and 950PR (8x128 GB) therefore share one command.

NPU-only deltas vs the existing GB200 path:

- Pin `quay.io/ascend/vllm-ascend:v0.23.0-a5` and hide the pip tab
- DSpark `k=3` with `enforce_eager` (no probabilistic / adaptive verification)
- Drop the empty `reasoning-config` start/end override (it swallows chat `content` on Ascend)
- `FULL_DECODE_ONLY`, `HCCL_BUFFSIZE=1024`, `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3`

Needs [vllm-ascend#16259](https://github.com/vllm-project/vllm-ascend/pull/16259) so hash-router layers skip the unused `e_score_correction_bias`.

The GB200 TEP command is unchanged.

## How was this tested

- YAML parses; hardware ids match `taxonomy.yaml`
- 950PR DP4+EP launch of the native Flash-Vision checkpoint on vLLM Ascend
- 950DT is offered on the same A5 command (same as the Flash recipe)