### PR TITLE
[ROCm] DeepSeek-V3/R1 with DP attention + TP experts & vllm-router

### DIFF
--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -206,8 +206,8 @@ guide: |
     a conversation to the rank that already holds its prefix, so the larger
     aggregate cache actually gets hit. `round_robin` scatters turns of the same
     conversation across ranks and throws the prefix away.
-  - Start the router first; `--worker-startup-timeout-secs 1800` covers the
-    engine's weight load.
+  - Start the engine first, then the router; `--worker-startup-timeout-secs 1800`
+    covers the engine's weight load either way.
   - Send client traffic to the router on port 8000, never to 8100 directly.
 
   ### 4xB200 (FP4)

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "DeepSeek"
   description: "DeepSeek-R1 is a 671B-parameter MoE reasoning model built on the DeepSeek-V3 architecture, trained with large-scale reinforcement learning for strong chain-of-thought capabilities."
   date_added: 2025-08-01
-  date_updated: 2026-04-17
+  date_updated: 2026-09-10
   difficulty: intermediate
   tasks:
     - text
@@ -18,6 +18,7 @@ meta:
     gb200: verified
     mi300x: verified
     mi325x: verified
+    mi350x: verified
     mi355x: verified
 
 model:
@@ -73,6 +74,7 @@ compatible_strategies:
   - single_node_tp
   - single_node_tep
   - single_node_dep
+  - single_node_dpa_tp
   - multi_node_tp
   - multi_node_tp_pp
   - multi_node_dep
@@ -84,10 +86,11 @@ hardware_overrides:
     extra_args: []
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
-      VLLM_ROCM_USE_AITER_MOE: "1"
-      SAFETENSORS_FAST_GPU: "1"
 
-strategy_overrides: {}
+strategy_overrides:
+  single_node_dpa_tp:
+    extra_env:
+      VLLM_ENGINE_READY_TIMEOUT_S: "1800"
 
 guide: |
   ## Overview
@@ -133,9 +136,7 @@ guide: |
 
   Tensor Parallel + Expert Parallel (TP8+EP) — ROCm:
   ```bash
-  export SAFETENSORS_FAST_GPU=1
   export VLLM_ROCM_USE_AITER=1
-  export VLLM_ROCM_USE_AITER_MOE=1
 
   vllm serve deepseek-ai/DeepSeek-R1 \
     --trust-remote-code \
@@ -150,6 +151,64 @@ guide: |
     --data-parallel-size 8 \
     --enable-expert-parallel
   ```
+
+  ### 8xMI355X — DP Attention + TP Experts (DPA+TP)
+
+  Validated on MI350X / MI355X. Pick the **DP Attention + TP Experts** strategy
+  above to generate both commands.
+
+  Where TP8+EP runs one attention replica across a single tensor-parallel group,
+  DPA+TP gives each GPU its own attention replica and private KV cache while the
+  MoE expert weights stay sharded across all eight GPUs. Leaving
+  `--enable-expert-parallel` **off** is what does the sharding: with EP disabled
+  vLLM folds the data-parallel ranks into the MoE tensor-parallel group
+  (`moe_tp = dp × tp`), so the experts are split rather than replicated per rank.
+  The result is roughly 8x the aggregate KV-cache capacity of a single TP8
+  replica, which is what makes long multi-turn chat sessions stay resident
+  instead of being evicted and re-prefilled on every turn. R1's long
+  chain-of-thought outputs make those sessions large, so the extra capacity
+  matters more here than on V3.
+
+  The tradeoff is per-request latency: each replica runs at TP1, so a single
+  request gets one GPU's worth of attention compute. Use TP8+EP when
+  time-to-first-token on an idle server matters more than cache residency.
+
+  Engine (all eight ranks in one process, listening on 8100):
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ENGINE_READY_TIMEOUT_S=1800
+
+  vllm serve deepseek-ai/DeepSeek-R1 \
+    --trust-remote-code \
+    --port 8100 \
+    --data-parallel-size 8 \
+    --tensor-parallel-size 1
+  ```
+
+  Router (client-facing on 8000, spreads requests across the eight DP ranks):
+  ```bash
+  uv pip install vllm-router
+
+  vllm-router \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --policy consistent_hash \
+    --intra-node-data-parallel-size 8 \
+    --worker-urls http://localhost:8100 \
+    --worker-startup-timeout-secs 1800
+  ```
+
+  Notes:
+
+  - `--intra-node-data-parallel-size` must match the engine's
+    `--data-parallel-size`. A mismatch silently under-uses ranks.
+  - `consistent_hash` is the policy that makes this worthwhile for chat: it pins
+    a conversation to the rank that already holds its prefix, so the larger
+    aggregate cache actually gets hit. `round_robin` scatters turns of the same
+    conversation across ranks and throws the prefix away.
+  - Start the router first; `--worker-startup-timeout-secs 1800` covers the
+    engine's weight load.
+  - Send client traffic to the router on port 8000, never to 8100 directly.
 
   ### 4xB200 (FP4)
 
@@ -221,3 +280,4 @@ guide: |
   - [DeepSeek-R1-0528 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-R1-0528)
   - [NVIDIA DeepSeek-R1-FP4](https://huggingface.co/nvidia/DeepSeek-R1-FP4)
   - [vLLM Expert Parallelism docs](https://docs.vllm.ai/en/latest/serving/expert_parallel_deployment.html)
+  - [vLLM Data Parallel deployment docs](https://docs.vllm.ai/en/latest/serving/data_parallel_deployment.html)

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -152,26 +152,12 @@ guide: |
     --enable-expert-parallel
   ```
 
-  ### 8xMI355X — DP Attention + Tensor Parallel (DPA+TP)
+  ### 8xMI350X / 8xMI355X (DPA+TP)
 
-  Validated on MI350X / MI355X. Pick the **DP Attention + Tensor Parallel** strategy
-  above to generate both commands.
-
-  Where TP8+EP runs one attention replica across a single tensor-parallel group,
-  DPA+TP gives each GPU its own attention replica and private KV cache while the
-  MoE expert weights stay sharded across all eight GPUs. Leaving
-  `--enable-expert-parallel` **off** is what does the sharding: with EP disabled
-  vLLM folds the data-parallel ranks into the MoE tensor-parallel group
-  (`moe_tp = dp × tp`), so the experts are split rather than replicated per rank.
-  The result is roughly 8x the aggregate KV-cache capacity of a single TP8
-  replica, which is what makes long multi-turn chat sessions stay resident
-  instead of being evicted and re-prefilled on every turn. R1's long
-  chain-of-thought outputs make those sessions large, so the extra capacity
-  matters more here than on V3.
-
-  The tradeoff is per-request latency: each replica runs at TP1, so a single
-  request gets one GPU's worth of attention compute. Use TP8+EP when
-  time-to-first-token on an idle server matters more than cache residency.
+  Each GPU runs its own attention replica with a private KV cache, while the MoE
+  experts stay tensor-sharded across all eight GPUs. Aggregate KV-cache
+  capacity is roughly 8x that of a single TP8 replica, useful for workloads 
+  benefiting from larger KV capacities. 
 
   Engine (all eight ranks in one process, listening on 8100):
   ```bash

--- a/models/deepseek-ai/DeepSeek-R1.yaml
+++ b/models/deepseek-ai/DeepSeek-R1.yaml
@@ -152,9 +152,9 @@ guide: |
     --enable-expert-parallel
   ```
 
-  ### 8xMI355X — DP Attention + TP Experts (DPA+TP)
+  ### 8xMI355X — DP Attention + Tensor Parallel (DPA+TP)
 
-  Validated on MI350X / MI355X. Pick the **DP Attention + TP Experts** strategy
+  Validated on MI350X / MI355X. Pick the **DP Attention + Tensor Parallel** strategy
   above to generate both commands.
 
   Where TP8+EP runs one attention replica across a single tensor-parallel group,

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -150,25 +150,12 @@ guide: |
     --enable-expert-parallel
   ```
 
-  ### 8xMI355X — DP Attention + Tensor Parallel (DPA+TP)
+  ### 8xMI350X / 8xMI355X (DPA+TP)
 
-  Validated on MI350X / MI355X with `deepseek-ai/DeepSeek-V3-0324` (select the
-  **V3 0324** variant above). Pick the **DP Attention + Tensor Parallel** strategy to
-  generate both commands.
-
-  Where TP8+EP replicates the KV cache decisions across one tensor-parallel
-  group, DPA+TP gives each GPU its own attention replica and private KV cache
-  while the MoE expert weights stay sharded across all eight GPUs. Leaving
-  `--enable-expert-parallel` **off** is what does the sharding: with EP disabled
-  vLLM folds the data-parallel ranks into the MoE tensor-parallel group
-  (`moe_tp = dp × tp`), so the experts are split rather than replicated per
-  rank. The result is roughly 8x the aggregate KV-cache capacity of a single TP8
-  replica, which is what makes long multi-turn chat sessions stay resident
-  instead of being evicted and re-prefilled on every turn.
-
-  The tradeoff is per-request latency: each replica runs at TP1, so a single
-  request gets one GPU's worth of attention compute. Use TP8+EP when
-  time-to-first-token on an idle server matters more than cache residency.
+  Each GPU runs its own attention replica with a private KV cache, while the MoE
+  experts stay tensor-sharded across all eight GPUs. Aggregate KV-cache
+  capacity is roughly 8x that of a single TP8 replica, useful for workloads 
+  benefiting from larger KV capacities. 
 
   Engine (all eight ranks in one process, listening on 8100):
   ```bash

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -150,10 +150,10 @@ guide: |
     --enable-expert-parallel
   ```
 
-  ### 8xMI355X — DP Attention + TP Experts (DPA+TP)
+  ### 8xMI355X — DP Attention + Tensor Parallel (DPA+TP)
 
   Validated on MI350X / MI355X with `deepseek-ai/DeepSeek-V3-0324` (select the
-  **V3 0324** variant above). Pick the **DP Attention + TP Experts** strategy to
+  **V3 0324** variant above). Pick the **DP Attention + Tensor Parallel** strategy to
   generate both commands.
 
   Where TP8+EP replicates the KV cache decisions across one tensor-parallel

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "DeepSeek"
   description: "DeepSeek-V3 is a 671B-parameter Mixture-of-Experts model with native FP8 weights and strong reasoning, coding, and math capabilities."
   date_added: 2025-08-01
-  date_updated: 2026-04-17
+  date_updated: 2026-09-10
   difficulty: intermediate
   tasks:
     - text
@@ -18,6 +18,7 @@ meta:
     gb200: verified
     mi300x: verified
     mi325x: verified
+    mi350x: verified
     mi355x: verified
 
 model:
@@ -55,6 +56,11 @@ variants:
     precision: fp8
     vram_minimum_gb: 805
     description: "Native FP8 weights on 8xH200 (recommended)"
+  v3_0324:
+    model_id: "deepseek-ai/DeepSeek-V3-0324"
+    precision: fp8
+    vram_minimum_gb: 805
+    description: "March 2025 DeepSeek-V3 refresh (DeepSeek-V3-0324)"
   fp4:
     model_id: "nvidia/DeepSeek-V3-FP4"
     precision: fp4
@@ -65,6 +71,7 @@ compatible_strategies:
   - single_node_tp
   - single_node_tep
   - single_node_dep
+  - single_node_dpa_tp
   - multi_node_tp
   - multi_node_tp_pp
   - multi_node_dep
@@ -76,19 +83,21 @@ hardware_overrides:
     extra_args: []
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
-      VLLM_ROCM_USE_AITER_MOE: "1"
-      SAFETENSORS_FAST_GPU: "1"
 
-strategy_overrides: {}
+strategy_overrides:
+  single_node_dpa_tp:
+    extra_env:
+      VLLM_ENGINE_READY_TIMEOUT_S: "1800"
 
 guide: |
   ## Overview
 
   DeepSeek-V3 is a 671B-parameter Mixture-of-Experts model (37B activated per token)
   shipped with native FP8 weights. It shares its architecture with DeepSeek-R1, so the
-  same launch recipes apply to both models. For Blackwell GPUs, NVIDIA publishes an FP4
-  quantized variant (`nvidia/DeepSeek-V3-FP4` / `nvidia/DeepSeek-R1-FP4`) that runs on
-  fewer GPUs.
+  same launch recipes apply to both models. DeepSeek publishes a refreshed checkpoint as
+  [`DeepSeek-V3-0324`](https://huggingface.co/deepseek-ai/DeepSeek-V3-0324), available
+  here as the **V3 0324** variant. For Blackwell GPUs, NVIDIA publishes an FP4 quantized
+  variant (`nvidia/DeepSeek-V3-FP4` / `nvidia/DeepSeek-R1-FP4`) that runs on fewer GPUs.
 
   ## Prerequisites
 
@@ -125,9 +134,7 @@ guide: |
 
   Tensor Parallel + Expert Parallel (TP8+EP) — ROCm:
   ```bash
-  export SAFETENSORS_FAST_GPU=1
   export VLLM_ROCM_USE_AITER=1
-  export VLLM_ROCM_USE_AITER_MOE=1
 
   vllm serve deepseek-ai/DeepSeek-V3 \
     --trust-remote-code \
@@ -142,6 +149,63 @@ guide: |
     --data-parallel-size 8 \
     --enable-expert-parallel
   ```
+
+  ### 8xMI355X — DP Attention + TP Experts (DPA+TP)
+
+  Validated on MI350X / MI355X with `deepseek-ai/DeepSeek-V3-0324` (select the
+  **V3 0324** variant above). Pick the **DP Attention + TP Experts** strategy to
+  generate both commands.
+
+  Where TP8+EP replicates the KV cache decisions across one tensor-parallel
+  group, DPA+TP gives each GPU its own attention replica and private KV cache
+  while the MoE expert weights stay sharded across all eight GPUs. Leaving
+  `--enable-expert-parallel` **off** is what does the sharding: with EP disabled
+  vLLM folds the data-parallel ranks into the MoE tensor-parallel group
+  (`moe_tp = dp × tp`), so the experts are split rather than replicated per
+  rank. The result is roughly 8x the aggregate KV-cache capacity of a single TP8
+  replica, which is what makes long multi-turn chat sessions stay resident
+  instead of being evicted and re-prefilled on every turn.
+
+  The tradeoff is per-request latency: each replica runs at TP1, so a single
+  request gets one GPU's worth of attention compute. Use TP8+EP when
+  time-to-first-token on an idle server matters more than cache residency.
+
+  Engine (all eight ranks in one process, listening on 8100):
+  ```bash
+  export VLLM_ROCM_USE_AITER=1
+  export VLLM_ENGINE_READY_TIMEOUT_S=1800
+
+  vllm serve deepseek-ai/DeepSeek-V3-0324 \
+    --trust-remote-code \
+    --port 8100 \
+    --data-parallel-size 8 \
+    --tensor-parallel-size 1
+  ```
+
+  Router (client-facing on 8000, spreads requests across the eight DP ranks):
+  ```bash
+  uv pip install vllm-router
+
+  vllm-router \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --policy consistent_hash \
+    --intra-node-data-parallel-size 8 \
+    --worker-urls http://localhost:8100 \
+    --worker-startup-timeout-secs 1800
+  ```
+
+  Notes:
+
+  - `--intra-node-data-parallel-size` must match the engine's
+    `--data-parallel-size`. A mismatch silently under-uses ranks.
+  - `consistent_hash` is the policy that makes this worthwhile for chat: it pins
+    a conversation to the rank that already holds its prefix, so the larger
+    aggregate cache actually gets hit. `round_robin` scatters turns of the same
+    conversation across ranks and throws the prefix away.
+  - Start the router first; `--worker-startup-timeout-secs 1800` covers the
+    engine's weight load.
+  - Send client traffic to the router on port 8000, never to 8100 directly.
 
   ### 4xB200 (FP4)
 
@@ -197,5 +261,7 @@ guide: |
   ## References
 
   - [DeepSeek-V3 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-V3)
+  - [DeepSeek-V3-0324 on Hugging Face](https://huggingface.co/deepseek-ai/DeepSeek-V3-0324)
   - [NVIDIA DeepSeek-V3-FP4](https://huggingface.co/nvidia/DeepSeek-V3-FP4)
   - [vLLM Expert Parallelism docs](https://docs.vllm.ai/en/latest/serving/expert_parallel_deployment.html)
+  - [vLLM Data Parallel deployment docs](https://docs.vllm.ai/en/latest/serving/data_parallel_deployment.html)

--- a/models/deepseek-ai/DeepSeek-V3.yaml
+++ b/models/deepseek-ai/DeepSeek-V3.yaml
@@ -203,8 +203,8 @@ guide: |
     a conversation to the rank that already holds its prefix, so the larger
     aggregate cache actually gets hit. `round_robin` scatters turns of the same
     conversation across ranks and throws the prefix away.
-  - Start the router first; `--worker-startup-timeout-secs 1800` covers the
-    engine's weight load.
+  - Start the engine first, then the router; `--worker-startup-timeout-secs 1800`
+    covers the engine's weight load either way.
   - Send client traffic to the router on port 8000, never to 8100 directly.
 
   ### 4xB200 (FP4)

--- a/scripts/build-recipes-api.mjs
+++ b/scripts/build-recipes-api.mjs
@@ -26,6 +26,7 @@ import {
   fitsSingleNode,
   isHardwareScalable,
   isKvStoreBrandSupported,
+  strategyAllowsKvOffload,
   pickFittingVariant,
   pdFitsSingleNode,
   resolveCommand,
@@ -301,7 +302,7 @@ function validateHardwareKeys(recipe, sourceFile, taxonomy, strategies) {
 
 // Wrap a rendered (command, argv) pair in `docker run`. Returns
 // { docker_command, docker_argv } so each form has its docker counterpart.
-function dockerize(command, argv, env, dockerMeta, port = 8000) {
+function dockerize(command, argv, env, dockerMeta, port = null) {
   return {
     docker_command: buildDockerRun({
       command, env, image: dockerMeta.image, gpuFlags: dockerMeta.gpuFlags, port,
@@ -579,6 +580,7 @@ function buildVariantRendering(recipe, variantKey, hwId, strategies, taxonomy) {
     const ok = (id) => {
       const d = strategies[id]?.deploy_type;
       if (!strategies[id] || d === "pd_cluster" || d === "kv_store_lb") return false;
+      if (!strategyAllowsKvOffload(strategies[id])) return false;
       return nc > 1 ? d === "multi_node" : d !== "multi_node";
     };
     const rec = recommendStrategy(recipe, hwProfile, nc);

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -3136,9 +3136,12 @@ function SingleCommandBlock({ command, env, companions, verifyCmd, benchCmd, sta
   // a feature's `companion:` or the active kv_offload option's, e.g.
   // LMCache's `lmcache server`). When any are active the block grows a
   // PD-style tab bar in LAUNCH ORDER — companions sit LEFT of vLLM Serve
-  // because they must be running before it starts. With none, the classic
-  // single-command layout renders untouched.
+  // because they must be running before it starts, unless one marks itself
+  // `after` (a router that fronts the engine it proxies). With none, the
+  // classic single-command layout renders untouched.
   const hasCompanions = Array.isArray(companions) && companions.length > 0;
+  const preCompanions = hasCompanions ? companions.filter((c) => !c.after) : [];
+  const postCompanions = hasCompanions ? companions.filter((c) => c.after) : [];
   // Falls back to the vLLM view when the selected companion's source was
   // toggled off (stale tab state).
   const activeCompanion = hasCompanions && tab !== "vllm"
@@ -3148,7 +3151,7 @@ function SingleCommandBlock({ command, env, companions, verifyCmd, benchCmd, sta
   // leftmost tab so the launch sequence reads left to right from step 1.
   const companionIds = hasCompanions ? companions.map((c) => c.feature).join(",") : "";
   useEffect(() => {
-    setTab(hasCompanions ? companions[0].feature : "vllm");
+    setTab(preCompanions.length ? preCompanions[0].feature : "vllm");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [companionIds]);
   // Companions are host-side helper binaries (not `vllm serve`), so they get
@@ -3182,7 +3185,11 @@ function SingleCommandBlock({ command, env, companions, verifyCmd, benchCmd, sta
           </div>
           <div className="flex items-center justify-between px-4 pt-2 gap-3">
             <CommandTabs
-              tabs={[...companions.map((c) => ({ id: c.feature, label: c.label })), { id: "vllm", label: "vLLM Serve" }].map((t, i) => ({ ...t, step: i + 1 }))}
+              tabs={[
+                ...preCompanions.map((c) => ({ id: c.feature, label: c.label })),
+                { id: "vllm", label: "vLLM Serve" },
+                ...postCompanions.map((c) => ({ id: c.feature, label: c.label })),
+              ].map((t, i) => ({ ...t, step: i + 1 }))}
               current={activeCompanion ? activeCompanion.feature : "vllm"}
               onSelect={setTab}
             />

--- a/src/components/recipes/CommandBuilder.jsx
+++ b/src/components/recipes/CommandBuilder.jsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { Copy, Check, Terminal, Gauge, Sparkles, ChevronDown, Package, Info, Zap, Globe, Wrench, Brain, ExternalLink } from "lucide-react";
 import { HuggingFaceIcon } from "@/components/icons/PlatformLogos";
-import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, isVariantHardwareSupported, fitsSingleNode, isHardwareScalable, isKvStoreBrandSupported, variantRunsOnHardware, pickFittingVariant, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun, resolveOmniCommand, pdPoolModes, defaultModeFor, isModeSupported, isModeAllowedForVariant, resolveModeKey, isFeatureAllowedForStrategy, isKvOffloadAllowedForStrategy, isKvOffloadSupportedForRecipe, isKvOffloadBrandSupported, MAX_NODES, nodesForStrategy, isStrategyReachable, isStrategySupportedOnHardware, effectiveCompatibleStrategies } from "@/lib/command-synthesis";
+import { resolveCommand, recommendStrategy, isPrecisionCompatible, isHardwareSupported, isVariantHardwareSupported, fitsSingleNode, isHardwareScalable, isKvStoreBrandSupported, variantRunsOnHardware, pickFittingVariant, pickDefaultHardware, resolveSingleNodeTp, computeDockerMeta, buildDockerRun, resolveOmniCommand, pdPoolModes, defaultModeFor, isModeSupported, isModeAllowedForVariant, resolveModeKey, isFeatureAllowedForStrategy, isKvOffloadAllowedForStrategy, isKvOffloadSupportedForRecipe, isKvOffloadBrandSupported, strategyAllowsKvOffload, MAX_NODES, nodesForStrategy, isStrategyReachable, isStrategySupportedOnHardware, effectiveCompatibleStrategies } from "@/lib/command-synthesis";
 import { resolveOmniTasks, resolveOmniTaskForHardware } from "@/lib/omni-tasks";
 import { TooltipProvider, InfoTip } from "@/components/ui/tooltip";
 import { detectPlaceholdersAll, substitute, substituteEnv, loadEndpoints, saveEndpoint, clearEndpoints } from "@/lib/cluster-endpoints";
@@ -946,6 +946,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
   // by the recipe. Same helpers as synthesis, so a disabled pill and an
   // empty command can't disagree.
   const kvOffloadOptions = taxonomy.kv_offload || {};
+  const kvOffloadAllowedByStrategy = strategyAllowsKvOffload(strategies[activeServingStrategy]);
   // Intel XPU: no KV-offload layer is validated on this backend, so gate every
   // option off (and force the effective selection to Off further down).
   const kvOffloadDisabledByHw = hwProfile?.generation === "xpu";
@@ -970,6 +971,9 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
     if (!isKvOffloadBrandSupported(opt, hwProfile)) {
       return `${name} needs a CUDA, ROCm or XPU device — not available on ${hwProfile.brand ? `${hwProfile.brand} ` : ""}${hwProfile.display_name || hwId} backends.`;
     }
+    if (!kvOffloadAllowedByStrategy) {
+      return `${name} isn't offered under ${strategies[activeServingStrategy]?.display_name || activeServingStrategy}, which manages its own KV layout across the DP ranks.`;
+    }
     return activeServingStrategy === "pd_cluster"
       ? `${name} can't compose with PD cluster, which owns --kv-transfer-config. (Mooncake composes with PD instead.)`
       : `${name} works with: ${(opt?.strategies || []).map((s) => strategies[s]?.display_name || s).join(", ")}.`;
@@ -992,6 +996,7 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
       : kvOffloadOptions[kvOffload]
       ? (kvOptAllowed(kvOffload) ? kvOffload : "")
       : compatibleKvStoreStrategies.includes(kvOffload) && hwScalable
+          && kvOffloadAllowedByStrategy
           && isKvStoreBrandSupported(hwProfile) && isKvStoreSupported(kvOffload)
         ? kvOffload
         : "";
@@ -2427,10 +2432,13 @@ export function CommandBuilder({ recipe, strategies, taxonomy }) {
                   // extra store process).
                   const supported = compatibleKvStoreStrategies.filter((s) => isKvStoreSupported(s));
                   const brandOk = isKvStoreBrandSupported(hwProfile);
-                  const selectable = !isXpuHardware && hwScalable && brandOk && supported.length > 0;
+                  const selectable = !isXpuHardware && hwScalable && brandOk
+                    && kvOffloadAllowedByStrategy && supported.length > 0;
                   const defaultId = supported[0];
                   const disabledTitle = isXpuHardware
                     ? "Mooncake isn't validated on Intel XPU — serve directly with the Docker image."
+                    : !kvOffloadAllowedByStrategy
+                    ? `${strategies[activeServingStrategy]?.display_name || activeServingStrategy} already fronts its ranks with its own router, which a Mooncake deployment would replace. Pick another strategy to layer Mooncake on.`
                     : !brandOk
                     ? `Mooncake's transfer engine ships CUDA and ROCm builds only — not available on ${hwProfile.brand || ""} ${hwProfile.display_name || hwId} backends.`
                     : !hwScalable

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -378,6 +378,15 @@ export function isFeatureAllowedForStrategy(feature, strategyName) {
 }
 
 /**
+ * Strategy-level opt-out from the whole KV Offload row (`kv_offload: false` in
+ * strategies/*.yaml): set it when a strategy already fronts its own ranks with
+ * a router that a Mooncake shell would replace.
+ */
+export function strategyAllowsKvOffload(strategy) {
+  return strategy?.kv_offload !== false;
+}
+
+/**
  * Whether a composing KV-offload option (taxonomy.kv_offload.*) may run under
  * a strategy. Two layers: pd_cluster / kv_store_lb are excluded for EVERY
  * option (both own --kv-transfer-config; last-wins dedupe would corrupt it),
@@ -386,6 +395,7 @@ export function isFeatureAllowedForStrategy(feature, strategyName) {
  */
 export function isKvOffloadAllowedForStrategy(option, strategyName, strategy) {
   if (!option) return false;
+  if (!strategyAllowsKvOffload(strategy)) return false;
   if (strategy?.deploy_type === "pd_cluster" || strategy?.deploy_type === "kv_store_lb") return false;
   const allow = option.strategies;
   return !Array.isArray(allow) || allow.length === 0 || allow.includes(strategyName);
@@ -781,10 +791,19 @@ function localModelMount(modelId) {
     : [];
 }
 
+// Port to publish, read off the command's own `--port` so a strategy that
+// serves behind a router (on 8100) stays reachable from the host.
+function servedPort(tokens, fallback = 8000) {
+  const i = tokens.lastIndexOf("--port");
+  const v = i >= 0 ? Number(tokens[i + 1]) : NaN;
+  return Number.isInteger(v) && v > 0 ? v : fallback;
+}
+
 // Wrap a `vllm serve MODEL <args>` command in `docker run`. The vllm/vllm-openai
 // image's entrypoint is `vllm serve`, so we pass MODEL and the trailing args as
 // CMD. Env vars become `-e KEY=VAL` inside the container.
-export function buildDockerRun({ command, env, image, gpuFlags, port = 8000, isNpu = false }) {
+export function buildDockerRun({ command, env, image, gpuFlags, port = null, isNpu = false }) {
+  const pubPort = port ?? servedPort(command.split(/\s+/));
   const envFlags = Object.entries(env || {})
     .map(([k, v]) => `-e ${k}=${v}`)
     .join(" \\\n  ");
@@ -807,7 +826,7 @@ export function buildDockerRun({ command, env, image, gpuFlags, port = 8000, isN
   // under `--net=host` and hid the required `--shm-size` on 950PR.
   const runtimeFlags = isNpu
     ? "--privileged --net=host --shm-size=16g"
-    : `--privileged --ipc=host -p ${port}:${port}`;
+    : `--privileged --ipc=host -p ${pubPort}:${pubPort}`;
   const base = `${prereq}docker run ${gpuFlags} \\
   ${runtimeFlags} \\
   -v ~/.cache/huggingface:/root/.cache/huggingface \\${mountFlags ? `\n  ${mountFlags} \\` : ""}${envFlags ? `\n  ${envFlags} \\` : ""}`;
@@ -818,7 +837,8 @@ export function buildDockerRun({ command, env, image, gpuFlags, port = 8000, isN
 // argv companion to buildDockerRun. `argv` here is the inner command's argv —
 // `["vllm", "serve", "<model>", ...flags]` from formatArgv. Returns the full
 // docker-run argv ready to spawn without a shell.
-export function buildDockerArgv({ argv, env, meta, port = 8000 }) {
+export function buildDockerArgv({ argv, env, meta, port = null }) {
+  const pubPort = port ?? servedPort(argv);
   const envFlags = [];
   for (const [k, v] of Object.entries(env || {})) {
     envFlags.push("-e", `${k}=${v}`);
@@ -832,7 +852,7 @@ export function buildDockerArgv({ argv, env, meta, port = 8000 }) {
   }
   const runtimeFlags = meta.isNpu
     ? ["--privileged", "--net=host", "--shm-size", "16g"]
-    : ["--privileged", "--ipc=host", "-p", `${port}:${port}`];
+    : ["--privileged", "--ipc=host", "-p", `${pubPort}:${pubPort}`];
   const base = [
     "docker", "run",
     ...dockerGpuArgv(meta),
@@ -891,6 +911,24 @@ function dedupeArgs(args) {
       out.push(u.flag);
       if (u.value !== undefined) out.push(u.value);
     }
+  }
+  return out;
+}
+
+// Drop every occurrence of `flags` (and any value following one) from an arg
+// list. Backs a strategy's `remove_args`, the only way to unset a boolean flag
+// a recipe declares globally: dedupeArgs is last-wins, so it can override a
+// value but never remove a bare switch.
+function stripArgs(args, flags) {
+  const drop = new Set(flags);
+  const out = [];
+  for (let i = 0; i < args.length; i++) {
+    if (!drop.has(args[i])) {
+      out.push(args[i]);
+      continue;
+    }
+    const next = args[i + 1];
+    if (next !== undefined && !(typeof next === "string" && next.startsWith("-"))) i++;
   }
   return out;
 }
@@ -1096,6 +1134,13 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
     }
 
     // 3. Strategy args + parallel size (grouped together so -tp/-dp sits next to -ep etc.)
+    //    Stripping `remove_args` here leaves anything emitted later free to
+    //    put the flag back under the usual last-wins rule.
+    if (strategy.remove_args?.length) {
+      const kept = stripArgs(args, strategy.remove_args);
+      args.length = 0;
+      args.push(...kept);
+    }
     if (strategy.deploy_type !== "pd_cluster") {
       if (strategy.vllm_args) args.push(...strategy.vllm_args);
     } else if (roleOverride && strategy[roleOverride]?.vllm_args) {
@@ -1271,6 +1316,11 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
           if (nodeIdx > 0) args.push("--headless");
         }
       }
+    } else if (strategy.parallelism === "dpa_tp") {
+      // One attention replica with a private KV cache per GPU; the experts
+      // shard across the ranks because `remove_args` drops EP.
+      args.push("--data-parallel-size", String(gpuCount));
+      args.push("--tensor-parallel-size", "1");
     } else {
       // Single-node TP / TEP / DEP. `singleNodeTp` equals `gpuCount` for
       // everything except single_node_tp with a recipe-declared
@@ -1805,9 +1855,10 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
 
   const singleArgs = buildArgs(null, null);
   // Companion processes — helpers that must run alongside `vllm serve` on the
-  // same node, rendered as PD-style tabs next to the serve command. Two
+  // same node, rendered as PD-style tabs next to the serve command. Three
   // sources, same gating as their args so a companion never leaks onto an
   // excluded strategy:
+  //   - the strategy itself (single_node_dpa_tp's vllm-router)
   //   - enabled features declaring `companion: { label, description?, command }`
   //   - the active composing KV-offload option (e.g. LMCache's MP server)
   const companions = (enabledFeatures || []).flatMap((f) => {
@@ -1830,6 +1881,22 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
         kvOpt.install ? `Requires: ${kvOpt.install}` : "",
       ].filter(Boolean).join(" "),
       command: String(kvOpt.companion.command).trimEnd(),
+    });
+  }
+  // The strategy's own companion leads the launch sequence: the router has to
+  // be reachable before clients arrive. `{dp_size}` resolves against the same
+  // gpuCount the DP flag was emitted with.
+  if (strategy.companion?.command && deployType === "single_node") {
+    companions.unshift({
+      feature: `strategy:${strategyName}`,
+      label: strategy.companion.label || strategyName,
+      description: [
+        strategy.companion.description || "",
+        strategy.companion.install ? `Requires: ${strategy.companion.install}` : "",
+      ].filter(Boolean).join(" ").trim(),
+      command: String(strategy.companion.command)
+        .replace(/\{dp_size\}/g, String(gpuCount))
+        .trimEnd(),
     });
   }
   return {

--- a/src/lib/command-synthesis.js
+++ b/src/lib/command-synthesis.js
@@ -794,9 +794,15 @@ function localModelMount(modelId) {
 // Port to publish, read off the command's own `--port` so a strategy that
 // serves behind a router (on 8100) stays reachable from the host.
 function servedPort(tokens, fallback = 8000) {
-  const i = tokens.lastIndexOf("--port");
-  const v = i >= 0 ? Number(tokens[i + 1]) : NaN;
-  return Number.isInteger(v) && v > 0 ? v : fallback;
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const t = tokens[i];
+    if (typeof t !== "string") continue;
+    const raw = t === "--port" ? tokens[i + 1] : t.startsWith("--port=") ? t.slice(7) : null;
+    if (raw == null) continue;
+    const v = Number(raw);
+    if (Number.isInteger(v) && v > 0) return v;
+  }
+  return fallback;
 }
 
 // Wrap a `vllm serve MODEL <args>` command in `docker run`. The vllm/vllm-openai
@@ -1858,9 +1864,9 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
   // same node, rendered as PD-style tabs next to the serve command. Three
   // sources, same gating as their args so a companion never leaks onto an
   // excluded strategy:
-  //   - the strategy itself (single_node_dpa_tp's vllm-router)
   //   - enabled features declaring `companion: { label, description?, command }`
   //   - the active composing KV-offload option (e.g. LMCache's MP server)
+  //   - the strategy itself (single_node_dpa_tp's vllm-router)
   const companions = (enabledFeatures || []).flatMap((f) => {
     const feat = recipe.features?.[f];
     if (!feat?.companion?.command) return [];
@@ -1883,19 +1889,20 @@ export function resolveCommand(recipe, variantKey, strategyName, hwProfileId, en
       command: String(kvOpt.companion.command).trimEnd(),
     });
   }
-  // The strategy's own companion leads the launch sequence: the router has to
-  // be reachable before clients arrive. `{dp_size}` resolves against the same
-  // gpuCount the DP flag was emitted with.
+  // `{dp_size}` resolves against the same gpuCount the DP flag was emitted
+  // with, `{port}` against the port the engine actually serves on.
   if (strategy.companion?.command && deployType === "single_node") {
-    companions.unshift({
+    companions.push({
       feature: `strategy:${strategyName}`,
       label: strategy.companion.label || strategyName,
+      after: strategy.companion.start === "after",
       description: [
         strategy.companion.description || "",
         strategy.companion.install ? `Requires: ${strategy.companion.install}` : "",
       ].filter(Boolean).join(" ").trim(),
       command: String(strategy.companion.command)
         .replace(/\{dp_size\}/g, String(gpuCount))
+        .replace(/\{port\}/g, String(servedPort(singleArgs)))
         .trimEnd(),
     });
   }

--- a/strategies/single_node_dpa_tp.yaml
+++ b/strategies/single_node_dpa_tp.yaml
@@ -1,0 +1,50 @@
+name: single_node_dpa_tp
+deploy_type: single_node
+display_name: "DP Attention + TP Experts"
+orientation: throughput
+description: >
+  Single-node data-parallel attention with tensor-sharded experts
+  (DPA+TP). Every GPU runs its own attention replica with a private
+  KV cache, while the MoE expert weights are tensor-sharded across all
+  local GPUs instead of replicated per replica: expert parallelism is
+  deliberately off, so vLLM folds the DP ranks into the MoE
+  tensor-parallel group. Aggregate KV cache capacity scales with the
+  GPU count, so long multi-turn conversations stay resident instead of
+  being evicted and re-prefilled. A vllm-router in front spreads
+  requests across the DP ranks. For MoE models only.
+
+hardware_match:
+  min_gpus: 2
+  max_gpus: 8
+  multi_node: false
+  architecture: moe
+
+parallelism: dpa_tp
+
+remove_args:
+  - "--enable-expert-parallel"
+
+vllm_args:
+  - "--port"
+  - "8100"
+
+parallel_flag: "--data-parallel-size"
+
+kv_offload: false
+
+companion:
+  label: "vLLM Router"
+  description: >-
+    Routes client requests across the DP ranks of the single engine
+    process. --intra-node-data-parallel-size must match the engine's
+    --data-parallel-size; consistent_hash keeps a conversation pinned to
+    the rank that already holds its prefix.
+  install: "uv pip install vllm-router"
+  command: |
+    vllm-router \
+      --host 0.0.0.0 \
+      --port 8000 \
+      --policy consistent_hash \
+      --intra-node-data-parallel-size {dp_size} \
+      --worker-urls http://localhost:8100 \
+      --worker-startup-timeout-secs 1800

--- a/strategies/single_node_dpa_tp.yaml
+++ b/strategies/single_node_dpa_tp.yaml
@@ -1,17 +1,16 @@
 name: single_node_dpa_tp
 deploy_type: single_node
-display_name: "DP Attention + TP Experts"
+display_name: "DP Attention + Tensor Parallel"
 orientation: throughput
 description: >
   Single-node data-parallel attention with tensor-sharded experts
   (DPA+TP). Every GPU runs its own attention replica with a private
   KV cache, while the MoE expert weights are tensor-sharded across all
-  local GPUs instead of replicated per replica: expert parallelism is
-  deliberately off, so vLLM folds the DP ranks into the MoE
-  tensor-parallel group. Aggregate KV cache capacity scales with the
-  GPU count, so long multi-turn conversations stay resident instead of
-  being evicted and re-prefilled. A vllm-router in front spreads
-  requests across the DP ranks. For MoE models only.
+  local GPUs instead of replicated per replica. Aggregate KV cache
+  capacity scales with the GPU count, so long multi-turn conversations
+  stay resident instead of being evicted and re-prefilled. A
+  vllm-router in front spreads requests across the DP ranks. For MoE
+  models only.
 
 hardware_match:
   min_gpus: 2

--- a/strategies/single_node_dpa_tp.yaml
+++ b/strategies/single_node_dpa_tp.yaml
@@ -40,11 +40,12 @@ companion:
     --data-parallel-size; consistent_hash keeps a conversation pinned to
     the rank that already holds its prefix.
   install: "uv pip install vllm-router"
+  start: after
   command: |
     vllm-router \
       --host 0.0.0.0 \
       --port 8000 \
       --policy consistent_hash \
       --intra-node-data-parallel-size {dp_size} \
-      --worker-urls http://localhost:8100 \
+      --worker-urls http://localhost:{port} \
       --worker-startup-timeout-secs 1800


### PR DESCRIPTION
Adds DP attention + TP-sharded experts (DPA+TP) as a first-class serving strategy, for DSv3 and R1.

This is different from the existing DP+EP recipe, because 
- it uses DP routing using vllm-router, crucial for good perf and prefix reuse
- TP experts to avoid rank imbalance

vllm:
<img width="1966" height="1749" alt="image" src="https://github.com/user-attachments/assets/07a22fe4-8667-4b0b-8299-8723177bb07f" />

Router:
<img width="1906" height="1654" alt="image" src="https://github.com/user-attachments/assets/a1665c3e-5119-4da0-889b-485c8b1a26b2" />
