### PR TITLE
[ROCm] Enable breakable CUDA graphs for DeepSeek-V4.1-Flash

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
@@ -100,6 +100,10 @@ hardware_overrides:
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
+      # DeepseekV41ForCausalLM does not support torch.compile. The ROCm sparse
+      # SWA backend only reports UNIFORM_BATCH, so default FULL_AND_PIECEWISE
+      # cannot start unless breakable CUDA graphs are on.
+      VLLM_USE_BREAKABLE_CUDAGRAPH: "1"
 
 strategy_overrides:
   single_node_tp:
@@ -252,6 +256,7 @@ guide: |
     `VLLM_USE_RUST_FRONTEND=1`. If you encounter any compatibility issues, remove
     this environment variable to use the Python frontend.
   - Expect a long first load: `VLLM_ENGINE_READY_TIMEOUT_S=3600` is set for that reason.
+  - On AMD, the generated command sets `VLLM_USE_BREAKABLE_CUDAGRAPH=1`. DeepSeek-V4.1-Flash does not support `torch.compile`, and the ROCm sparse SWA backend only supports uniform-batch CUDA graphs. Without breakable CUDA graphs, default `FULL_AND_PIECEWISE` dies at capture.
 
   ## Verifying
 


### PR DESCRIPTION
## Summary
- The published AMD recipe dies at CUDA graph capture on gfx950 with `DeepseekV41ForCausalLM: piecewise CUDA graphs (cudagraph_mode=FULL_AND_PIECEWISE) unavailable`.
- `DeepseekV41ForCausalLM` does not support `torch.compile`. The ROCm sparse SWA backend only reports `AttentionCGSupport.UNIFORM_BATCH`, so default `FULL_AND_PIECEWISE` cannot start unless breakable CUDA graphs are on.
- I served the ECR pin `public.ecr.aws/q9t5s3a7/vllm-release-repo:79a7108d9aea27ddab99ce1779290d300b17fc23-rocm` on MI355X TP4 with `VLLM_USE_BREAKABLE_CUDAGRAPH=1`. Chat `17*19` returned `323`. Counting 1 to 40 produced 80 decode tokens with no segfault.

## Test plan
- [ ] Generate the MI350X/MI355X command from this YAML and confirm it exports `VLLM_USE_BREAKABLE_CUDAGRAPH=1`
- [ ] Serve DeepSeek-V4.1-Flash TP4 on gfx950 with that command and send the recipe `17*19` curl


Made with [Cursor](https://cursor.com)