### PR TITLE
[ROCm][Kimi-K3] Switch SiTUv2 MoE toggle to VLLM_ROCM_USE_AITER_MOE_SITUV2

### DIFF
--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -273,7 +273,6 @@ hardware_overrides:
       VLLM_ROCM_USE_AITER: "1"
       SAFETENSORS_FAST_GPU: "1"
       VLLM_ROCM_USE_AITER_MOE_SITUV2: "1"
-      AITER_BF16_FP8_MOE_BOUND: "0"
       VLLM_USE_BREAKABLE_CUDAGRAPH: "0" # REQUIRED on ROCm: the build auto-enables =1
     extra_args:
       - "--load-format"

--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Moonshot AI"
   description: "Pre-release 2.8T-parameter native multimodal MoE with Kimi Delta Attention, Gated MLA, Attention Residuals, and a 1M-token context window"
   date_added: 2026-07-27
-  date_updated: 2026-08-27
+  date_updated: 2026-09-10
   difficulty: hard
   tasks:
     - multimodal
@@ -272,7 +272,7 @@ hardware_overrides:
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       SAFETENSORS_FAST_GPU: "1"
-      VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: "1"
+      VLLM_ROCM_USE_AITER_MOE_SITUV2: "1"
       AITER_BF16_FP8_MOE_BOUND: "0"
       VLLM_USE_BREAKABLE_CUDAGRAPH: "0" # REQUIRED on ROCm: the build auto-enables =1
     extra_args:
@@ -441,7 +441,7 @@ guide: |
   - **MoE backend**: Recommend to use `deep_gemm_mega_moe` for DEP deployments with cross-node NVLink e.g. GB200 and GB300. Note that DeepGEMM MegaMoE is not compatible with cross-node RDMA.
   - **Model Runner v2 and Rust Frontend**: `VLLM_USE_V2_MODEL_RUNNER=1` and `VLLM_USE_RUST_FRONTEND=1`: Model Runner v2 and Rust Frontend fully supports this model and can be enabled if needed.
   - **Tool calling**: K3 occasionally emit a tool-call format its own parser doesn't expect. Suggest to run do schema validation and retry.
-  - **AMD (MI355X / MI350X, CDNA4 gfx950)**: set AITER_SITUV2_A8W4 to 0 along with AITER master flag to use aiter a16w4 MoE path. Set it to 1 to use aiter a8w4 MoE path.
+  - **AMD (MI355X / MI350X, CDNA4 gfx950)**: `VLLM_ROCM_USE_AITER_MOE_SITUV2=1` (set above) enables AITER's SiTUv2 a4w4 FlyDSL MoE path (vllm-project/vllm#53940). Unset it or set `0` for the default a16w4 path. Do not set `AITER_SITUV2_A8W4=1`; AITER checks that flag first and it would override a4w4. Older vLLM builds still accept the deprecated alias `VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4`.
   - **max-model-len**: Adjust max-model-len for different benchmark scenarios for best performance.
   - **RDMA**: If RDMA is enabled, set `UCX_TLS="rc,cuda_copy"` to make sure KV Cache transfer goes through RDMA.
   - **MNNVL environments** (GB200/GB300 NVL): recommend adding `NCCL_MNNVL_ENABLE=1`, `NCCL_CUMEM_ENABLE=1`, and `NCCL_NVLS_ENABLE=1`.


### PR DESCRIPTION
## Summary
- Rename the AMD extra_env flag in `models/moonshotai/Kimi-K3.yaml` from `VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4` to `VLLM_ROCM_USE_AITER_MOE_SITUV2`, matching [vllm-project/vllm#53940](https://github.com/vllm-project/vllm/pull/53940).
- Update the AMD notes: this recipe path is SiTUv2 a4w4 FlyDSL, not a8w4. Do not set `AITER_SITUV2_A8W4=1` (AITER checks it first and it would override a4w4). The old vLLM env name remains a deprecated alias until older nightlies go away.

## Test plan
- [ ] Confirm `gh search code --repo vllm-project/recipes SITUV2_A8W4` is empty after merge
- [ ] On recipes.vllm.ai Kimi-K3 + MI355X, generated extra_env includes `VLLM_ROCM_USE_AITER_MOE_SITUV2=1` and not `_A8W4`
- [ ] After vLLM #53940, serve with this recipe env and confirm a4w4 FlyDSL (`afp4_wfp4`, not `afp8` / `_gui_`)


Made with [Cursor](https://cursor.com)