### PR TITLE
Update K2-Horizon context length arguments

### DIFF
--- a/models/IFM/K2-Horizon-3.7B.yaml
+++ b/models/IFM/K2-Horizon-3.7B.yaml
@@ -17,7 +17,7 @@ model:
   parameter_count: "5.06B"
   active_parameters: "5.06B"
   context_length: 524288
-  base_args: ["--trust-remote-code", "--dtype", "bfloat16", "--max-model-len", "131072"]
+  base_args: ["--trust-remote-code", "--dtype", "bfloat16"]
   base_env: {}
 features:
   reasoning:
@@ -52,7 +52,6 @@ guide: |
   vllm serve IFM/K2-Horizon-3.7B \
     --trust-remote-code \
     --dtype bfloat16 \
-    --max-model-len 131072 \
     --reasoning-parser k2_horizon \
     --enable-auto-tool-choice \
     --tool-call-parser k2_horizon

--- a/models/IFM/K2-Horizon-32B.yaml
+++ b/models/IFM/K2-Horizon-32B.yaml
@@ -17,7 +17,7 @@ model:
   parameter_count: "34.78B"
   active_parameters: "34.78B"
   context_length: 524288
-  base_args: ["--trust-remote-code", "--dtype", "bfloat16", "--max-model-len", "131072"]
+  base_args: ["--trust-remote-code", "--dtype", "bfloat16"]
   base_env: {}
 features:
   reasoning:
@@ -57,7 +57,6 @@ guide: |
     --tensor-parallel-size 2 \
     --trust-remote-code \
     --dtype bfloat16 \
-    --max-model-len 131072 \
     --reasoning-parser k2_horizon \
     --enable-auto-tool-choice \
     --tool-call-parser k2_horizon

--- a/models/IFM/K2-Horizon-375B-A23B.yaml
+++ b/models/IFM/K2-Horizon-375B-A23B.yaml
@@ -22,7 +22,7 @@ model:
   # path too, which deliberately runs pure TP (see strategy_hardware). The TEP
   # strategies emit it themselves; multi_node_tp_pp does not, so it carries its
   # own copy in strategy_overrides below.
-  base_args: ["--trust-remote-code", "--dtype", "bfloat16", "--max-model-len", "131072"]
+  base_args: ["--trust-remote-code", "--dtype", "bfloat16"]
   base_env: {}
 features:
   reasoning:
@@ -88,7 +88,6 @@ guide: |
     --tensor-parallel-size 8 \
     --trust-remote-code \
     --dtype bfloat16 \
-    --max-model-len 131072 \
     --enable-expert-parallel \
     --reasoning-parser k2_horizon \
     --enable-auto-tool-choice \

--- a/models/IFM/K2-Horizon-7B.yaml
+++ b/models/IFM/K2-Horizon-7B.yaml
@@ -17,7 +17,7 @@ model:
   parameter_count: "9B"
   active_parameters: "9B"
   context_length: 524288
-  base_args: ["--trust-remote-code", "--dtype", "bfloat16", "--max-model-len", "131072"]
+  base_args: ["--trust-remote-code", "--dtype", "bfloat16"]
   base_env: {}
 features:
   reasoning:
@@ -53,7 +53,6 @@ guide: |
   vllm serve IFM/K2-Horizon-7B \
     --trust-remote-code \
     --dtype bfloat16 \
-    --max-model-len 131072 \
     --reasoning-parser k2_horizon \
     --enable-auto-tool-choice \
     --tool-call-parser k2_horizon

--- a/models/IFM/K2-Horizon-MoVA-36B-A4B.yaml
+++ b/models/IFM/K2-Horizon-MoVA-36B-A4B.yaml
@@ -17,7 +17,7 @@ model:
   parameter_count: "37.44B"
   active_parameters: "5.95B"
   context_length: 524288
-  base_args: ["--trust-remote-code", "--dtype", "bfloat16", "--max-model-len", "131072", "--enable-expert-parallel"]
+  base_args: ["--trust-remote-code", "--dtype", "bfloat16", "--enable-expert-parallel"]
   base_env: {}
 features:
   reasoning:
@@ -59,7 +59,6 @@ guide: |
     --tensor-parallel-size 2 \
     --trust-remote-code \
     --dtype bfloat16 \
-    --max-model-len 131072 \
     --enable-expert-parallel \
     --reasoning-parser k2_horizon \
     --enable-auto-tool-choice \


### PR DESCRIPTION
Removes `--max-model-len 131072` from base arguments and launch examples for all K2-Horizon models except 0.9B to prevent possible confusion about their supported context lengths.