### PR TITLE
[Xeon] Add missing Docker commands to CPU recipes

### DIFF
--- a/models/Google/diffusiongemma-26B-A4B-it.yaml
+++ b/models/Google/diffusiongemma-26B-A4B-it.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Google"
   description: "Google's DiffusionGemma — a block-diffusion language model built on Gemma 4's MoE backbone (26B total / 4B active). Generates tokens via iterative denoising over a fixed-length canvas rather than left-to-right autoregressive decoding, enabling higher throughput with parallel block generation."
   date_added: 2026-06-11
-  date_updated: 2026-06-10
+  date_updated: 2026-09-12
   difficulty: advanced
   tasks:
     - multimodal
@@ -155,22 +155,23 @@ guide: |
           --host 0.0.0.0 --port 8000
   ```
 
-  ### Intel Xeon 6 (CPU, BF16, 4× NUMA nodes)
+  ### Intel Xeon 6 (CPU, BF16)
 
   DiffusionGemma runs on Intel Xeon 6 CPUs using vLLM's CPU backend with AMX BF16 acceleration.
-  Use `--tensor-parallel-size` equal to the number of NUMA nodes available (typically 2–4 on a dual/quad-socket server).
+  The generated example uses TP=1. Adjust `--tensor-parallel-size` based on the
+  detected NUMA topology and deployment requirements.
 
   ```bash
-  docker run -itd --name diffusiongemma-cpu \
-      --network host \
-      --shm-size 16g \
-      -v ~/.cache/huggingface:/root/.cache/huggingface \
-      vllm/vllm-openai-cpu:latest-x86_64 \
-          --model google/diffusiongemma-26B-A4B-it \
-          --dtype bfloat16 \
-          --tensor-parallel-size 4 \
-          --max-num-seqs 4 \
-          --host 0.0.0.0 --port 8000
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 google/diffusiongemma-26B-A4B-it \
+    --max-num-seqs 4 \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser gemma4 \
+    --chat-template examples/tool_chat_template_gemma4.jinja \
+    --reasoning-parser gemma4
   ```
 
 

--- a/models/Google/gemma-4-26B-A4B-it.yaml
+++ b/models/Google/gemma-4-26B-A4B-it.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Google"
   description: "Google's Gemma 4 MoE multimodal model (26B total / 4B active) with 128 fine-grained experts, top-8 routing, thinking mode, and tool-use protocol."
   date_added: 2026-04-02
-  date_updated: 2026-09-02
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - multimodal
@@ -394,14 +394,15 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `google/gemma-4-26B-A4B-it`:
 
   ```bash
-  docker run -itd --name gemma4-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model google/gemma-4-26B-A4B-it \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 google/gemma-4-26B-A4B-it \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser gemma4 \
+    --chat-template examples/tool_chat_template_gemma4.jinja \
+    --reasoning-parser gemma4
   ```
 
   For additional Intel Xeon 6 deployment details, see the Intel Software Catalog entries for [Gemma 4 26B-A4B IT](https://aiswcatalog.intel.com/models/google-gemma-4-26b-a4b-it).

--- a/models/Google/gemma-4-E2B-it.yaml
+++ b/models/Google/gemma-4-E2B-it.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Google"
   description: "Google's compact Gemma 4 multimodal model (effective 2B) with native text, image, and audio, plus thinking mode and tool-use protocol."
   date_added: 2026-04-02
-  date_updated: 2026-08-18
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - multimodal
@@ -225,14 +225,15 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `google/gemma-4-E2B-it`:
 
   ```bash
-  docker run -itd --name gemma4-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model google/gemma-4-E2B-it \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 google/gemma-4-E2B-it \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser gemma4 \
+    --chat-template examples/tool_chat_template_gemma4.jinja \
+    --reasoning-parser gemma4
   ```
 
 

--- a/models/Google/gemma-4-E4B-it.yaml
+++ b/models/Google/gemma-4-E4B-it.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Google"
   description: "Google's compact Gemma 4 multimodal model (effective 4B) with native text, image, and audio, plus thinking mode and tool-use protocol."
   date_added: 2026-04-02
-  date_updated: 2026-08-18
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - multimodal
@@ -224,14 +224,15 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `google/gemma-4-E4B-it`:
 
   ```bash
-  docker run -itd --name gemma4-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model google/gemma-4-E4B-it \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 google/gemma-4-E4B-it \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser gemma4 \
+    --chat-template examples/tool_chat_template_gemma4.jinja \
+    --reasoning-parser gemma4
   ```
 
   For additional Intel Xeon 6 deployment details, see the Intel Software Catalog entries for [Gemma 4 E4B IT](https://aiswcatalog.intel.com/models/google-gemma-4-e4b-it).

--- a/models/Qwen/QwQ-32B.yaml
+++ b/models/Qwen/QwQ-32B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen's 32B dense reasoning model, validated for Intel Xeon 6 CPU execution."
   date_added: 2026-08-17
-  date_updated: 2026-09-10
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - text
@@ -99,7 +99,9 @@ guide: |
 
   For Intel and AMD x86 CPUs, follow the
   [CPU pre-built wheels](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/#pre-built-wheels)
-  installation instructions, or use:
+  installation instructions.
+
+  ### Docker (Intel Xeon 6 CPUs)
 
   ```bash
   docker pull vllm/vllm-openai-cpu:latest-x86_64
@@ -108,7 +110,24 @@ guide: |
   ## Intel Xeon 6
 
   ```bash
-  vllm serve Qwen/QwQ-32B
+  vllm serve Qwen/QwQ-32B \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser hermes \
+    --reasoning-parser deepseek_r1
+  ```
+
+  Docker (the image entrypoint is `vllm serve`):
+
+  ```bash
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/QwQ-32B \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser hermes \
+    --reasoning-parser deepseek_r1
   ```
 
   W8A8 INT8:
@@ -117,17 +136,8 @@ guide: |
   vllm serve RedHatAI/QwQ-32B-quantized.w8a8
   ```
 
-  Choose tensor parallelism based on system topology; the recipe does not
-  prescribe a fixed TP/DP layout or topology-specific CPU binding.
-
-  For reasoning-content extraction and automatic tool choice:
-
-  ```bash
-  vllm serve Qwen/QwQ-32B \
-    --reasoning-parser deepseek_r1 \
-    --enable-auto-tool-choice \
-    --tool-call-parser hermes
-  ```
+  The example uses TP=1. Adjust tensor parallelism based on system topology;
+  topology-specific CPU binding is intentionally not hard-coded.
 
   ## Runtime and Platform Tuning
 

--- a/models/Qwen/Qwen2.5-VL-7B-Instruct.yaml
+++ b/models/Qwen/Qwen2.5-VL-7B-Instruct.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen2.5-VL dense vision-language model (7B) for image and video understanding — fits on a single TPU v6e chip, one GPU, or Intel Xeon 6 CPU."
   date_added: 2025-08-22
-  date_updated: 2026-08-17
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - multimodal
@@ -121,14 +121,12 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name qwen25-vl-7b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model Qwen/Qwen2.5-VL-7B-Instruct \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen2.5-VL-7B-Instruct \
+    --tensor-parallel-size 1 \
+    --mm-encoder-tp-mode data
   ```
 
   #### Runtime and Platform Tuning

--- a/models/Qwen/Qwen3-1.7B.yaml
+++ b/models/Qwen/Qwen3-1.7B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen3 1.7B dense model with hybrid thinking/non-thinking modes, validated for BF16 serving on Intel Xeon 6."
   date_added: 2026-08-14
-  date_updated: 2026-08-14
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -98,16 +98,16 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name qwen3-1-7b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model Qwen/Qwen3-1.7B \
-      --max-num-batched-tokens 16384 \
-      --gpu-memory-utilization 0.8 \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen3-1.7B \
+    --tensor-parallel-size 1 \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser hermes \
+    --reasoning-parser qwen3
   ```
 
   ## Client Usage

--- a/models/Qwen/Qwen3-14B.yaml
+++ b/models/Qwen/Qwen3-14B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen3 14B dense model with hybrid thinking/non-thinking modes, validated for Intel Xeon 6 CPU serving."
   date_added: 2026-08-17
-  date_updated: 2026-09-10
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - text
@@ -118,14 +118,13 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name qwen3-14b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model Qwen/Qwen3-14B \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen3-14B \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser hermes
   ```
 
   ## Configuration Notes

--- a/models/Qwen/Qwen3-30B-A3B.yaml
+++ b/models/Qwen/Qwen3-30B-A3B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen3 MoE model with 30.5B total and 3.3B active parameters, validated for BF16 serving on Intel Xeon 6."
   date_added: 2026-08-14
-  date_updated: 2026-09-10
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - text
@@ -106,16 +106,16 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name qwen3-30b-a3b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model Qwen/Qwen3-30B-A3B \
-      --max-num-batched-tokens 16384 \
-      --gpu-memory-utilization 0.8 \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen3-30B-A3B \
+    --tensor-parallel-size 1 \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser hermes \
+    --reasoning-parser qwen3
   ```
 
   ## Client Usage

--- a/models/Qwen/Qwen3-4B.yaml
+++ b/models/Qwen/Qwen3-4B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen3 4B dense model with hybrid thinking/non-thinking modes — fits on a single TPU v6e chip, one GPU or one Xeon 6 NUMA node."
   date_added: 2025-10-15
-  date_updated: 2026-09-10
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -128,14 +128,14 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `Qwen/Qwen3-4B`:
 
   ```bash
-  docker run -itd --name qwen4b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model Qwen/Qwen3-4B \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen3-4B \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser hermes \
+    --reasoning-parser qwen3
   ```
 
 

--- a/models/Qwen/Qwen3-8B.yaml
+++ b/models/Qwen/Qwen3-8B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen3 8.2B dense model with hybrid thinking/non-thinking modes, validated for BF16 serving on Intel Xeon 6."
   date_added: 2026-08-14
-  date_updated: 2026-09-10
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -107,16 +107,16 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name qwen3-8b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model Qwen/Qwen3-8B \
-      --max-num-batched-tokens 16384 \
-      --gpu-memory-utilization 0.8 \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen3-8B \
+    --tensor-parallel-size 1 \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.8 \
+    --enable-auto-tool-choice \
+    --tool-call-parser hermes \
+    --reasoning-parser qwen3
   ```
 
   ## Client Usage

--- a/models/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
+++ b/models/Qwen/Qwen3-VL-30B-A3B-Instruct.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen3-VL MoE vision-language model with 30B total / 3B active parameters, supporting image, video, and text workloads."
   date_added: 2026-08-17
-  date_updated: 2026-08-17
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - multimodal
@@ -84,7 +84,9 @@ guide: |
 
   For Intel and AMD x86 CPUs, follow the
   [CPU pre-built wheels](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/#pre-built-wheels)
-  installation instructions, or use:
+  installation instructions.
+
+  ### Docker (Intel Xeon 6 CPUs)
 
   ```bash
   docker pull vllm/vllm-openai-cpu:latest-x86_64
@@ -93,11 +95,24 @@ guide: |
   ## Intel Xeon 6
 
   ```bash
-  vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct
+  vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+    --tensor-parallel-size 1 \
+    --mm-encoder-tp-mode data
   ```
 
-  Choose tensor parallelism based on system topology; TP/DP and NUMA binding
-  are intentionally not hard-coded in the recipe.
+  Docker (the image entrypoint is `vllm serve`):
+
+  ```bash
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen3-VL-30B-A3B-Instruct \
+    --tensor-parallel-size 1 \
+    --mm-encoder-tp-mode data
+  ```
+
+  The example uses TP=1. Adjust TP/DP based on system topology; NUMA binding is
+  intentionally not hard-coded in the recipe.
 
   ## Configuration Notes
 

--- a/models/Qwen/Qwen3.5-35B-A3B.yaml
+++ b/models/Qwen/Qwen3.5-35B-A3B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Compact Qwen3.5 multimodal MoE (35B total / 3B active) with gated delta networks, 256 experts, and 262K context"
   date_added: 2026-04-22
-  date_updated: 2026-09-10
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - multimodal
@@ -164,14 +164,16 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `Qwen/Qwen3.5-35B-A3B`:
 
   ```bash
-  docker run -itd --name qwen35b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model Qwen/Qwen3.5-35B-A3B \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen3.5-35B-A3B \
+    --trust-remote-code \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser qwen3 \
+    --mm-encoder-tp-mode data
   ```
 
   ### MTP speculative decoding

--- a/models/Qwen/Qwen3.5-4B.yaml
+++ b/models/Qwen/Qwen3.5-4B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Qwen"
   description: "Qwen3.5 compact dense multimodal model (4B) — fits on 16 GB consumer GPUs with full 262K context or one Xeon 6 NUMA node or Intel Arc Pro B60/B70"
   date_added: 2026-04-22
-  date_updated: 2026-09-10
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - multimodal
@@ -123,14 +123,15 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `Qwen/Qwen3.5-4B`:
 
   ```bash
-  docker run -itd --name qwen4b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model Qwen/Qwen3.5-4B \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 Qwen/Qwen3.5-4B \
+    --trust-remote-code \
+    --tensor-parallel-size 1 \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser qwen3
   ```
 
   ### Docker (Intel XPU B60 / B70)

--- a/models/meta-llama/Llama-3.1-8B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.1-8B-Instruct.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Meta"
   description: "Meta's Llama 3.1 8B dense instruction-tuned language model with 128K context"
   date_added: 2025-10-15
-  date_updated: 2026-08-18
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -175,14 +175,11 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `meta-llama/Llama-3.1-8B-Instruct`:
 
   ```bash
-  docker run -itd --name llama3-8b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model meta-llama/Llama-3.1-8B-Instruct \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 meta-llama/Llama-3.1-8B-Instruct \
+    --tensor-parallel-size 2
   ```
 
   The validation TP/DP layout and host-specific CPU placement are intentionally

--- a/models/meta-llama/Llama-3.1-8B.yaml
+++ b/models/meta-llama/Llama-3.1-8B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Meta"
   description: "Meta Llama 3.1 8B dense base language model with a CPU-validated Red Hat AI W8A8 variant."
   date_added: 2026-08-19
-  date_updated: 2026-08-19
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -89,14 +89,11 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name llama31-8b-w8a8-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model RedHatAI/Meta-Llama-3.1-8B-quantized.w8a8 \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 RedHatAI/Meta-Llama-3.1-8B-quantized.w8a8 \
+    --tensor-parallel-size 2
   ```
 
   ## Runtime and Platform Tuning

--- a/models/meta-llama/Llama-3.2-1B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.2-1B-Instruct.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Meta"
   description: "Meta Llama 3.2 1B Instruct with CPU-validated Red Hat AI W8A8 and AMead10 AWQ variants."
   date_added: 2026-08-18
-  date_updated: 2026-08-18
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -94,7 +94,23 @@ guide: |
 
   ## Intel Xeon 6
 
-  TP/DP and host-specific CPU binding are intentionally not hard-coded.
+  ```bash
+  vllm serve meta-llama/Llama-3.2-1B-Instruct \
+    --tensor-parallel-size 1
+  ```
+
+  Docker (the image entrypoint is `vllm serve`):
+
+  ```bash
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 meta-llama/Llama-3.2-1B-Instruct \
+    --tensor-parallel-size 1
+  ```
+
+  The example uses TP=1. Adjust TP/DP for the deployment topology;
+  host-specific CPU binding is intentionally not hard-coded.
 
   ## Runtime and Platform Tuning
 

--- a/models/meta-llama/Llama-3.2-1B.yaml
+++ b/models/meta-llama/Llama-3.2-1B.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Meta"
   description: "Meta Llama 3.2 1.23B dense pretrained language model with 128K context, validated for BF16 serving on Intel Xeon 6."
   date_added: 2026-08-18
-  date_updated: 2026-08-18
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -99,14 +99,11 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name llama32-1b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model meta-llama/Llama-3.2-1B \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 meta-llama/Llama-3.2-1B \
+    --tensor-parallel-size 1
   ```
 
   ## Client Usage

--- a/models/meta-llama/Llama-3.2-3B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.2-3B-Instruct.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Meta"
   description: "Meta Llama 3.2 3.21B dense instruction-tuned language model with 128K context, validated for BF16 serving on Intel Xeon 6."
   date_added: 2026-08-18
-  date_updated: 2026-08-18
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -116,14 +116,11 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name llama32-3b-instruct-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model meta-llama/Llama-3.2-3B-Instruct \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 meta-llama/Llama-3.2-3B-Instruct \
+    --tensor-parallel-size 1
   ```
 
   ## Client Usage

--- a/models/meta-llama/Llama-3.3-70B-Instruct.yaml
+++ b/models/meta-llama/Llama-3.3-70B-Instruct.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Meta"
   description: "Llama 3.3 70B dense model with NVIDIA FP8/FP4 quantized variants for Hopper and Blackwell GPUs"
   date_added: 2025-08-06
-  date_updated: 2026-08-18
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -164,14 +164,11 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `meta-llama/Llama-3.3-70B-Instruct`:
 
   ```bash
-  docker run -itd --name llama3-70b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model meta-llama/Llama-3.3-70B-Instruct \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 meta-llama/Llama-3.3-70B-Instruct \
+    --tensor-parallel-size 8
   ```
 
   TP/DP remain user/deployment choices rather than recipe defaults.

--- a/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
+++ b/models/meta-llama/Llama-4-Scout-17B-16E-Instruct.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Meta"
   description: "Llama 4 Scout 17B-16E MoE model with NVIDIA FP8/FP4 variants, fits on a single GPU with quantization"
   date_added: 2025-08-06
-  date_updated: 2026-08-18
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -161,15 +161,12 @@ guide: |
   Launch the x86 CPU vLLM Docker container for `meta-llama/Llama-4-Scout-17B-16E-Instruct`:
 
   ```bash
-  docker run -itd --name llama4-17b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model meta-llama/Llama-4-Scout-17B-16E-Instruct \
-      --max-model-len 8192 \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 meta-llama/Llama-4-Scout-17B-16E-Instruct \
+    --tensor-parallel-size 4 \
+    --max-model-len 8192
   ```
 
   `--max-model-len 8192` is retained because it is the model-specific row argument

--- a/models/microsoft/Phi-4-multimodal-instruct.yaml
+++ b/models/microsoft/Phi-4-multimodal-instruct.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Microsoft"
   description: "Microsoft Phi-4 multimodal model supporting text, image, and audio inputs with text outputs."
   date_added: 2026-08-19
-  date_updated: 2026-08-19
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - multimodal
@@ -63,10 +63,23 @@ guide: |
 
   ```bash
   vllm serve microsoft/Phi-4-multimodal-instruct \
-    --trust-remote-code  ```
+    --trust-remote-code \
+    --tensor-parallel-size 1
+  ```
 
-  TP/DP values and host-specific CPU placement remain deployment choices and
-  are not hard-coded into the portable recipe.
+  Docker (the image entrypoint is `vllm serve`):
+
+  ```bash
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 microsoft/Phi-4-multimodal-instruct \
+    --trust-remote-code \
+    --tensor-parallel-size 1
+  ```
+
+  The example uses TP=1. Adjust TP/DP for the deployment topology;
+  host-specific CPU placement is intentionally not hard-coded.
 
   ## Runtime and Platform Tuning
 

--- a/models/microsoft/Phi-4-reasoning.yaml
+++ b/models/microsoft/Phi-4-reasoning.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Microsoft"
   description: "Microsoft Phi-4 14B dense reasoning model with 32K context."
   date_added: 2026-08-19
-  date_updated: 2026-08-19
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - text
@@ -60,10 +60,22 @@ guide: |
   ## Intel Xeon 6
 
   ```bash
-  vllm serve microsoft/Phi-4-reasoning  ```
+  vllm serve microsoft/Phi-4-reasoning \
+    --tensor-parallel-size 1
+  ```
 
-  TP/DP values and host-specific CPU placement remain deployment choices and
-  are not hard-coded into the portable recipe.
+  Docker (the image entrypoint is `vllm serve`):
+
+  ```bash
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 microsoft/Phi-4-reasoning \
+    --tensor-parallel-size 1
+  ```
+
+  The example uses TP=1. Adjust TP/DP for the deployment topology;
+  host-specific CPU placement is intentionally not hard-coded.
 
   ## Runtime and Platform Tuning
 

--- a/models/openai/gpt-oss-20b.yaml
+++ b/models/openai/gpt-oss-20b.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "OpenAI"
   description: "OpenAI's gpt-oss-20b — 21B-total / 3.6B-active MoE reasoning model with native MXFP4 quant; supports GPU, XPU, and Xeon 6 CPU serving"
   date_added: 2025-08-05
-  date_updated: 2026-05-08
+  date_updated: 2026-09-12
   difficulty: beginner
   tasks:
     - text
@@ -154,16 +154,15 @@ guide: |
   Docker:
 
   ```bash
-  docker run -itd --name gpt-oss-20b-cpu \
-    --network host \
-    --shm-size 16g \
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
-    vllm/vllm-openai-cpu:latest-x86_64 \
-      --model openai/gpt-oss-20b \
-      --max-num-batched-tokens 16384 \
-      --gpu-memory-utilization 0.8 \
-      --host 0.0.0.0 \
-      --port 8000
+    vllm/vllm-openai-cpu:latest-x86_64 openai/gpt-oss-20b \
+    --tensor-parallel-size 1 \
+    --max-num-batched-tokens 16384 \
+    --gpu-memory-utilization 0.8 \
+    --tool-call-parser openai \
+    --enable-auto-tool-choice
   ```
 
   Blackwell (B200) with FlashInfer MXFP4+MXFP8 MoE:

--- a/models/openai/whisper-large-v3.yaml
+++ b/models/openai/whisper-large-v3.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "OpenAI"
   description: "Whisper Large v3 speech recognition model, validated for Intel Xeon 6 CPU serving."
   date_added: 2026-08-19
-  date_updated: 2026-08-19
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - multimodal
@@ -62,10 +62,21 @@ guide: |
   ## Intel Xeon 6
 
   ```bash
-  vllm serve openai/whisper-large-v3  ```
+  vllm serve openai/whisper-large-v3 \
+    --tensor-parallel-size 1
+  ```
 
-  TP/DP is deployment/topology tuning and is not hard-coded into the portable
-  recipe.
+  Docker (the image entrypoint is `vllm serve`):
+
+  ```bash
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 openai/whisper-large-v3 \
+    --tensor-parallel-size 1
+  ```
+
+  The example uses TP=1. Adjust TP/DP for the deployment topology.
 
   ## Runtime and Platform Tuning
 

--- a/models/zai-org/glm-4-9b-hf.yaml
+++ b/models/zai-org/glm-4-9b-hf.yaml
@@ -4,7 +4,7 @@ meta:
   provider: "Z.ai"
   description: "GLM-4 9B dense base language model with 8K context."
   date_added: 2026-08-19
-  date_updated: 2026-08-19
+  date_updated: 2026-09-12
   difficulty: intermediate
   tasks:
     - text
@@ -62,10 +62,22 @@ guide: |
   ## Intel Xeon 6
 
   ```bash
-  vllm serve zai-org/glm-4-9b-hf  ```
+  vllm serve zai-org/glm-4-9b-hf \
+    --tensor-parallel-size 1
+  ```
 
-  TP/DP values and host-specific CPU placement remain deployment choices and
-  are not hard-coded into the portable recipe.
+  Docker (the image entrypoint is `vllm serve`):
+
+  ```bash
+  docker run --shm-size=16g \
+    --privileged --ipc=host -p 8000:8000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-openai-cpu:latest-x86_64 zai-org/glm-4-9b-hf \
+    --tensor-parallel-size 1
+  ```
+
+  The example uses TP=1. Adjust TP/DP for the deployment topology;
+  host-specific CPU placement is intentionally not hard-coded.
 
   ## Runtime and Platform Tuning
 


### PR DESCRIPTION
## Summary

Add missing Intel Xeon CPU Docker deployment examples for:

* `Qwen/QwQ-32B`
* `Qwen/Qwen3-VL-30B-A3B-Instruct`
* `meta-llama/Llama-3.2-1B-Instruct`
* `microsoft/Phi-4-reasoning`
* `microsoft/Phi-4-multimodal-instruct`
* `zai-org/glm-4-9b-hf`
* `openai/whisper-large-v3`

Also:

* Fix malformed Markdown code fences in the Phi-4, GLM-4, and Whisper recipes.
* Separate Docker instructions incorrectly placed under pip sections.
* Add the missing `vllm serve` example for Llama 3.2 1B Instruct.
* Preserve `--trust-remote-code` for Phi-4 Multimodal.

TP/DP and host-specific CPU binding remain deployment choices.

## Testing

