### PR TITLE
[DeepSeek] V4.1-Flash: point the AMD image at a ROCm nightly and select the CK a8w4 MoE experts

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
@@ -98,11 +98,24 @@ hardware_overrides:
     extra_args:
       - "--gpu-memory-utilization"
       - "0.9"
+      # Plain "aiter" rather than "aiter_triton_mxfp4_bf16": the specific name
+      # maps to one entry and pins the Triton W4A16 kernel (_moe_gemm_a16w4),
+      # while the plain name opens vLLM's full priority list, whose head is the
+      # Composable Kernel backend, giving the a8w4 experts
+      # (mfma_moe1_silu_mul_afp8_wfp4_bf16 / mfma_moe2_afp8_wfp4_bf16). CK
+      # quantizes activations to FP8 internally, despite the BF16 backend name
+      # and this checkpoint declaring activation_scheme=dynamic with no
+      # input_scale tensors.
       - "--moe-backend"
-      - "aiter_triton_mxfp4_bf16"
+      - "aiter"
     extra_env:
       VLLM_ROCM_USE_AITER: "1"
       VLLM_ROCM_USE_AITER_MOE: "1"
+      # aiter.ops.triton warns on every call that Gluon is unavailable and it
+      # is falling back to Triton. Gluon supports only gfx1250, so on gfx950
+      # that is a fixed property rather than a condition worth reporting, and
+      # it was 98% of the lines in a server log (411k of 417k, 30 MiB of 32).
+      AITER_TRITON_LOG_LEVEL: "ERROR"
       # DeepseekV41ForCausalLM does not support torch.compile. The ROCm sparse
       # SWA backend only reports UNIFORM_BATCH, so default FULL_AND_PIECEWISE
       # cannot start unless breakable CUDA graphs are on.
@@ -291,6 +304,7 @@ guide: |
     to Python if you encounter unsupported features or compatibility issues.
   - Expect a long first load: `VLLM_ENGINE_READY_TIMEOUT_S=3600` is set for that reason.
   - On AMD, the generated command sets `VLLM_USE_BREAKABLE_CUDAGRAPH=1`. DeepSeek-V4.1-Flash does not support `torch.compile`, and the ROCm sparse SWA backend only supports uniform-batch CUDA graphs. Without breakable CUDA graphs, default `FULL_AND_PIECEWISE` dies at capture.
+  - On AMD, the generated command passes `--moe-backend aiter` rather than naming a kernel. Naming `aiter_triton_mxfp4_bf16` pins the Triton W4A16 kernel; the plain name lets vLLM select the Composable Kernel a8w4 experts, which measured 4–9% faster per decode step at 131k context on MI355X (larger gains at higher concurrency) with gsm8k strict-match unchanged.
 
   ## Verifying
 

--- a/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
@@ -5,7 +5,7 @@ meta:
   provider: "DeepSeek"
   description: "DeepSeek V4.1 Flash vision-language MoE (552B backbone; 8B active per prompt token, 16B per output token) combining sliding-window plus compressed sparse attention with a two-level indexer, engram n-gram memory, hyper-connections, and a DSpark multi-token draft head."
   date_added: 2026-09-09
-  date_updated: 2026-09-11
+  date_updated: 2026-09-12
   difficulty: advanced
   tasks:
     - text
@@ -27,7 +27,10 @@ model:
   default_frontend: rust
   docker_image:
     nvidia: "vllm/vllm-openai:deepseekv41-flash-0909"
-    amd: "vllm/vllm-openai-rocm:deepseekv41-flash-0909"
+    # AMD tracks a ROCm nightly rather than the 0909 release tag: that tag
+    # predates vllm-project/vllm#56503, which moves the mHC delayed pre block
+    # off the eager Torch reference and onto AITER.
+    amd: "vllm/vllm-openai-rocm:nightly-eed1f3d0c6043bd494424a22443ee198dd56f657"
   architecture: moe
   parameter_count: "552B"
   active_parameters: "8-16B"
@@ -281,7 +284,9 @@ guide: |
   ## Prerequisites
 
   - The `vllm/vllm-openai:deepseekv41-flash-0909` image (vLLM 0.30.0+). No pip wheel serves
-    this architecture, so the Install block only offers Docker.
+    this architecture, so the Install block only offers Docker. On AMD, use the
+    `vllm/vllm-openai-rocm:nightly-eed1f3d0...` image instead — it carries the AITER
+    mHC path from vllm-project/vllm#56503, which the 0909 tag predates.
   - The Rust OpenAI frontend is selected by default in the command builder. Switch
     to Python if you encounter unsupported features or compatibility issues.
   - Expect a long first load: `VLLM_ENGINE_READY_TIMEOUT_S=3600` is set for that reason.


### PR DESCRIPTION
## Summary

Two **AMD-only** changes for DeepSeek-V4.1-Flash. NVIDIA is unchanged.

```diff
   docker_image:
     nvidia: "vllm/vllm-openai:deepseekv41-flash-0909"
-    amd: "vllm/vllm-openai-rocm:deepseekv41-flash-0909"
+    amd: "vllm/vllm-openai-rocm:nightly-eed1f3d0c6043bd494424a22443ee198dd56f657"

   hardware_overrides:
     amd:
       extra_args:
         - "--moe-backend"
-        - "aiter_triton_mxfp4_bf16"
+        - "aiter"
```

## Why the nightly image

The `deepseekv41-flash-0909` tag predates vllm-project/vllm#56503, which moves the mHC
delayed pre block off the eager Torch reference and onto AITER. Without it, MI355X runs
the hyper-connection seams as unfused eager Torch ops.

| | |
|---|---|
| tag | `vllm/vllm-openai-rocm:nightly-eed1f3d0c6043bd494424a22443ee198dd56f657` |
| digest | `sha256:960228cfcb5de9f4cd22d28998d1125be62b546c3d220a884f570343e99ffcee` |
| published | 2026-09-12T05:27:48Z |
| vLLM commit | `eed1f3d0c6043bd494424a22443ee198dd56f657` |

`eed1f3d` is 11 commits ahead of, and 0 behind, #56503's merge commit, so the change is
included.

## Why plain `aiter` rather than a named kernel

`aiter_triton_mxfp4_bf16` maps to exactly one entry, the Triton W4A16 kernel, so decode
ran `_moe_gemm_a16w4`. Plain `aiter` opens vLLM's full priority list, whose head is the
Composable Kernel backend, and the experts become the a8w4 family:

```
mfma_moe1_silu_mul_afp8_wfp4_bf16_t32x128x256_pm1_async_gui_v33.kd
mfma_moe2_afp8_wfp4_bf16_cshuffle_t32x128x128_vscale_fix3_fp4opt_v1_pm1.kd
```

Two things make this non-obvious, so the flag carries a comment: the backend is named
`..._BF16`, and this checkpoint declares `activation_scheme: dynamic` with no
`input_scale` tensors. CK quantizes activations to FP8 internally regardless.

Decode traces on MI355X TP4 at 131k context:

| concurrency | MoE GEMM (ms/step) | whole step |
|---|---|---|
| 1 | 2.72 → 2.30 | −4.2% |
| 4 | 4.91 → 4.27 | −5.3% |
| 16 | 9.06 → 7.18 | −8.7% |

gsm8k strict-match is unchanged at 0.9719.

## Log level

`AITER_TRITON_LOG_LEVEL=ERROR` is added to the AMD env. Every warning `aiter.ops.triton`
emits is about Gluon availability, and Gluon supports only gfx1250 — on gfx950 that is a
fixed property rather than a condition worth reporting. It accounted for 98% of the lines
in a server log (411k of 417k lines, 30 MiB of 32 MiB) with no throughput effect.

## Validation

`scripts/build-recipes-api.mjs` could not be run — the host has Node but no npm/pnpm, so
`js-yaml` is unavailable. The file was validated by parsing it with PyYAML instead,
confirming that it loads, that both `docker_image` entries resolve, that the AMD override
resolves to `--gpu-memory-utilization 0.9 --moe-backend aiter`, and that the edits inside
the `guide: |` literal block preserve the block's indentation. No schema keys were added
or removed.

Runtime on MI355X TP4 with DSpark drafting 5 tokens: the CK path serves correctly on this
nightly, and single-user decode measures **265 tok/s p50 interactivity against 259 tok/s**
for the Triton kernel on the same box and image. Broader concurrency validation is tracked
downstream.
