### PR TITLE
[DeepSeek] V4.1-Flash: AMD DSpark without adaptive verification

### DIFF
--- a/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
@@ -57,17 +57,18 @@ features:
       - "--reasoning-parser"
       - "deepseek_v41"
   spec_decoding:
-    description: "DSpark multi-token drafting, 5 tokens per round (the trained block size). On NVIDIA, adaptive verification scores each (request, position) slot and only high-scoring slots are verified, up to a startup-profiled compute budget. On AMD, DeepseekV41IndexerBackend does not consume device query lengths, so the generated command sets enable_adaptive_verification:false and verifies the full 5-token block."
+    description: "DSpark multi-token drafting, 5 tokens per round (the trained block size). On NVIDIA, adaptive verification scores each (request, position) slot and only high-scoring slots are verified, up to a startup-profiled compute budget. On AMD, vLLM currently refuses that flag because DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch() is False, so the generated command sets enable_adaptive_verification:false and verifies the full 5-token block."
     args:
       - "--speculative-config"
       - '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
     hardware_overrides:
-      # Adaptive verification writes query_start_loc on device. The ROCm
-      # indexer builds decode metadata from CPU query lengths, so the
-      # published true flag dies during determine_available_memory with
+      # Adaptive verification writes query_start_loc on device. On ROCm,
       # DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()
-      # False. Features emit last in resolveCommand, so this replacement
-      # must live here rather than in hardware_overrides.amd.extra_args.
+      # is False, so maybe_create_adaptive_verification_manager raises
+      # during initialize_kv_cache after the weights load. Features emit
+      # last in resolveCommand, so this replacement must live here rather
+      # than in hardware_overrides.amd.extra_args. vllm-project/vllm#56620
+      # is the engine-side follow-up.
       amd:
         args:
           - "--speculative-config"
@@ -241,10 +242,11 @@ guide: |
   DSpark is the only speculative method for this checkpoint; V4.1 dropped the MTP module
   that V3 and V4 trained alongside the backbone. **Speculative decoding** enables a 5-token
   block. On NVIDIA it also turns on adaptive verification (see the feature description).
-  On AMD the indexer backend cannot consume the device query lengths that adaptive
-  verification writes, so the generated command sets `enable_adaptive_verification:false`
-  and verifies the full block. Acceptance depends on
-  the workload, so measure it on your own traffic before sizing a deployment around it.
+  On AMD, vLLM currently refuses adaptive verification because
+  `DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()` is False, so the
+  generated command sets `enable_adaptive_verification:false` and verifies the full
+  block. Acceptance depends on the workload, so measure it on your own traffic before
+  sizing a deployment around it.
   The drafter's experts add roughly 14B parameters to the load.
 
   ## Serving text-only
@@ -300,7 +302,7 @@ guide: |
     to Python if you encounter unsupported features or compatibility issues.
   - Expect a long first load: `VLLM_ENGINE_READY_TIMEOUT_S=3600` is set for that reason.
   - On AMD, the generated command sets `VLLM_USE_BREAKABLE_CUDAGRAPH=1`. DeepSeek-V4.1-Flash does not support `torch.compile`, and the ROCm sparse SWA backend only supports uniform-batch CUDA graphs. Without breakable CUDA graphs, default `FULL_AND_PIECEWISE` dies at capture.
-  - On AMD, ticking **Speculative decoding** also sets `enable_adaptive_verification:false`. The ROCm AITER indexer does not support the device query-length mismatch that adaptive verification needs. DSpark still drafts 5 tokens per round.
+  - On AMD, ticking **Speculative decoding** also sets `enable_adaptive_verification:false`. vLLM currently refuses the true flag because `DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()` is False. DSpark still drafts 5 tokens per round.
 
   ## Verifying
 

--- a/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
@@ -57,18 +57,22 @@ features:
       - "--reasoning-parser"
       - "deepseek_v41"
   spec_decoding:
-    description: "DSpark multi-token drafting, 5 tokens per round (the trained block size). On NVIDIA, adaptive verification scores each (request, position) slot and only high-scoring slots are verified, up to a startup-profiled compute budget. On AMD, vLLM currently refuses that flag because DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch() is False, so the generated command sets enable_adaptive_verification:false and verifies the full 5-token block."
+    description: "DSpark multi-token drafting, 5 tokens per round (the trained block size). On NVIDIA, adaptive verification scores each (request, position) slot and only high-scoring slots are verified, up to a startup-profiled compute budget. On AMD, vLLM currently refuses that flag, so the generated command sets enable_adaptive_verification:false and verifies the full 5-token block. Remove the AMD override only after a serve with the true flag actually starts on ROCm."
     args:
       - "--speculative-config"
       - '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
     hardware_overrides:
-      # Adaptive verification writes query_start_loc on device. On ROCm,
-      # DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()
-      # is False, so maybe_create_adaptive_verification_manager raises
-      # during initialize_kv_cache after the weights load. Features emit
-      # last in resolveCommand, so this replacement must live here rather
-      # than in hardware_overrides.amd.extra_args. vllm-project/vllm#56620
-      # is the engine-side follow-up.
+      # Adaptive verification writes query_start_loc on device and captures
+      # varlen decode CUDA graphs. maybe_create_adaptive_verification_manager
+      # therefore requires both supports_device_cpu_query_lens_mismatch()
+      # and AttentionCGSupport.ALWAYS on every target attention builder.
+      # On ROCm, DeepseekV41IndexerBackend fails the first check because
+      # the helpers it inherits are CUDA plus DeepGEMM only. Forcing that
+      # helper True still dies: DeepseekV41ROCMAiterSparseSWABackend reports
+      # UNIFORM_BATCH. Features emit last in resolveCommand, so this
+      # replacement must live here rather than in
+      # hardware_overrides.amd.extra_args. Remove this override only when
+      # a vLLM serve with enable_adaptive_verification:true starts on AMD.
       amd:
         args:
           - "--speculative-config"
@@ -239,13 +243,16 @@ guide: |
 
   ## Speculative decoding
 
-  DSpark is the only speculative method for this checkpoint; V4.1 dropped the MTP module
+  DSpark is the only speculative method for this checkpoint. V4.1 dropped the MTP module
   that V3 and V4 trained alongside the backbone. **Speculative decoding** enables a 5-token
   block. On NVIDIA it also turns on adaptive verification (see the feature description).
-  On AMD, vLLM currently refuses adaptive verification because
-  `DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()` is False, so the
-  generated command sets `enable_adaptive_verification:false` and verifies the full
-  block. Acceptance depends on the workload, so measure it on your own traffic before
+  On AMD, vLLM currently refuses adaptive verification. The generated command sets
+  `enable_adaptive_verification:false` and verifies the full block. Two checks in
+  `maybe_create_adaptive_verification_manager` fail on ROCm: the indexer helper
+  `supports_device_cpu_query_lens_mismatch()` is False, and
+  `DeepseekV41ROCMAiterSparseSWABackend` reports `AttentionCGSupport.UNIFORM_BATCH`
+  rather than `ALWAYS`. Remove the AMD override only after a serve with the true flag
+  starts. Acceptance depends on the workload, so measure it on your own traffic before
   sizing a deployment around it.
   The drafter's experts add roughly 14B parameters to the load.
 
@@ -302,7 +309,7 @@ guide: |
     to Python if you encounter unsupported features or compatibility issues.
   - Expect a long first load: `VLLM_ENGINE_READY_TIMEOUT_S=3600` is set for that reason.
   - On AMD, the generated command sets `VLLM_USE_BREAKABLE_CUDAGRAPH=1`. DeepSeek-V4.1-Flash does not support `torch.compile`, and the ROCm sparse SWA backend only supports uniform-batch CUDA graphs. Without breakable CUDA graphs, default `FULL_AND_PIECEWISE` dies at capture.
-  - On AMD, ticking **Speculative decoding** also sets `enable_adaptive_verification:false`. vLLM currently refuses the true flag because `DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()` is False. DSpark still drafts 5 tokens per round.
+  - On AMD, ticking **Speculative decoding** also sets `enable_adaptive_verification:false`. vLLM currently refuses the true flag: `DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()` is False, and `DeepseekV41ROCMAiterSparseSWABackend` reports `UNIFORM_BATCH` rather than `ALWAYS`. DSpark still drafts 5 tokens per round.
 
   ## Verifying
 

--- a/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
+++ b/models/deepseek-ai/DeepSeek-V4.1-Flash.yaml
@@ -5,7 +5,7 @@ meta:
   provider: "DeepSeek"
   description: "DeepSeek V4.1 Flash vision-language MoE (552B backbone; 8B active per prompt token, 16B per output token) combining sliding-window plus compressed sparse attention with a two-level indexer, engram n-gram memory, hyper-connections, and a DSpark multi-token draft head."
   date_added: 2026-09-09
-  date_updated: 2026-09-11
+  date_updated: 2026-09-12
   difficulty: advanced
   tasks:
     - text
@@ -57,10 +57,21 @@ features:
       - "--reasoning-parser"
       - "deepseek_v41"
   spec_decoding:
-    description: "DSpark multi-token drafting, 5 tokens per round (the trained block size), with adaptive verification: the draft's confidence head scores each (request, position) slot and only high-scoring slots are verified, up to a startup-profiled compute budget. Higher throughput than static verification."
+    description: "DSpark multi-token drafting, 5 tokens per round (the trained block size). On NVIDIA, adaptive verification scores each (request, position) slot and only high-scoring slots are verified, up to a startup-profiled compute budget. On AMD, DeepseekV41IndexerBackend does not consume device query lengths, so the generated command sets enable_adaptive_verification:false and verifies the full 5-token block."
     args:
       - "--speculative-config"
       - '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
+    hardware_overrides:
+      # Adaptive verification writes query_start_loc on device. The ROCm
+      # indexer builds decode metadata from CPU query lengths, so the
+      # published true flag dies during determine_available_memory with
+      # DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()
+      # False. Features emit last in resolveCommand, so this replacement
+      # must live here rather than in hardware_overrides.amd.extra_args.
+      amd:
+        args:
+          - "--speculative-config"
+          - '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":false}'
   text_only:
     description: "Skip loading the vision encoder for text-only workloads — frees VRAM for KV cache. Mutually exclusive with encoder_parallel."
     args:
@@ -229,7 +240,10 @@ guide: |
 
   DSpark is the only speculative method for this checkpoint; V4.1 dropped the MTP module
   that V3 and V4 trained alongside the backbone. **Speculative decoding** enables a 5-token
-  block with adaptive verification (see the feature description). Acceptance depends on
+  block. On NVIDIA it also turns on adaptive verification (see the feature description).
+  On AMD the indexer backend cannot consume the device query lengths that adaptive
+  verification writes, so the generated command sets `enable_adaptive_verification:false`
+  and verifies the full block. Acceptance depends on
   the workload, so measure it on your own traffic before sizing a deployment around it.
   The drafter's experts add roughly 14B parameters to the load.
 
@@ -286,6 +300,7 @@ guide: |
     to Python if you encounter unsupported features or compatibility issues.
   - Expect a long first load: `VLLM_ENGINE_READY_TIMEOUT_S=3600` is set for that reason.
   - On AMD, the generated command sets `VLLM_USE_BREAKABLE_CUDAGRAPH=1`. DeepSeek-V4.1-Flash does not support `torch.compile`, and the ROCm sparse SWA backend only supports uniform-batch CUDA graphs. Without breakable CUDA graphs, default `FULL_AND_PIECEWISE` dies at capture.
+  - On AMD, ticking **Speculative decoding** also sets `enable_adaptive_verification:false`. The ROCm AITER indexer does not support the device query-length mismatch that adaptive verification needs. DSpark still drafts 5 tokens per round.
 
   ## Verifying
 


### PR DESCRIPTION
## Summary

The published Speculative decoding tick cannot start DeepSeek-V4.1-Flash on AMD. `maybe_create_adaptive_verification_manager` raises during `initialize_kv_cache` after the weights load. There are two checks, not one.

The published DSpark JSON hits the first check:

```
ValueError: Adaptive verification trims verification requests on device, which the DeepseekV41IndexerBackend attention backend does not support. Pass enable_adaptive_verification=false in the speculative config, or use a backend that does.
```

`DeepseekV41IndexerBackend.supports_device_cpu_query_lens_mismatch()` is False on ROCm. The helpers it inherits (`_supports_varlen_paged_mqa_logits` and `_supports_flattened_device_query_lens` in `vllm/v1/attention/backends/mla/indexer.py`) are CUDA plus DeepGEMM only. HIP `rocm_aiter_sparse_attn_indexer` already consumes flattened `decode_metadata` (`decode_lens` / `seq_lens` / `block_table`). The engine still refuses to start because that capability helper is False.

Forcing the flatten helper True is not enough. The second check then raises:

```
ValueError: Adaptive verification captures varlen decode cudagraphs, so every target attention builder must report AttentionCGSupport.ALWAYS, but DeepseekV41ROCMAiterSparseSWABackend reports AttentionCGSupport.UNIFORM_BATCH.
```

That is `adaptive_verification.py:492`. Do not flip the SWA builder to `ALWAYS` without varlen decode graph support.

## What this PR does

- Keeps NVIDIA DSpark at `enable_adaptive_verification:true`.
- Replaces the AMD feature args with the same DSpark JSON except `enable_adaptive_verification:false`. DSpark still drafts 5 tokens per round.
- Puts that replacement on `features.spec_decoding.hardware_overrides.amd`. Features emit last in `resolveCommand`, so a second `--speculative-config` in `hardware_overrides.amd.extra_args` would lose to the feature's `true` value.
- Documents both gates in the YAML comment. Remove this override only after a serve with `enable_adaptive_verification:true` actually starts on AMD.

This is independent of vllm-project/recipes#962 (AMD image pin to a ROCm nightly that contains vllm-project/vllm#56503). That pin is still the right move. Merge this immediately after #962 so recipes.vllm.ai does not generate an AMD DSpark command that cannot start. Do not fold this into #962 expecting a later indexer helper PR to remove it.

## Validation

- YAML loads. NVIDIA `gb200` / `h200` / `gb300` still resolve to `enable_adaptive_verification:true`. AMD `mi355x` / `mi350x` resolve to `false` via `hardwareKeyedValue` brand `amd`.
- Hub nightly `vllm/vllm-openai-rocm:nightly` at `eed1f3d0c` (`sha256:960228cfcb5de9f4cd22d28998d1125be62b546c3d220a884f570343e99ffcee`) on MI355X TP4 with the published DSpark JSON (`true`) hit the first `ValueError` after 48/48 shards.
- The same digest, same node, same flags except `enable_adaptive_verification:false` reached `Application startup complete`. The recipe `17*19` curl returned `323` both with `chat_template_kwargs.thinking: false` and with the published recipe curl (thinking on, answer still `323`).

## Test plan

- [x] Generate the MI350X/MI355X command with Speculative decoding ticked and confirm `--speculative-config` contains `enable_adaptive_verification:false`
- [x] Generate the GB200 command with the same tick and confirm it still contains `true`
- [x] Serve DeepSeek-V4.1-Flash TP4 on gfx950 with the AMD command and send the recipe `17*19` curl