### PR TITLE
Fix Kimi-K3 GB200 minimum for multi-node TP

### DIFF
--- a/models/moonshotai/Kimi-K3.yaml
+++ b/models/moonshotai/Kimi-K3.yaml
@@ -216,6 +216,10 @@ strategy_min_gpus:
   multi_node_tp_pp: 16
   multi_node_dep: 16
   h100: 32
+  # GB200 pure TP needs 16 GPUs across four NVL4 trays.
+  # https://vllm-project.github.io/2026/07/27/k3.html#performance-optimizations
+  gb200:
+    multi_node_tp: 16
   ascend_910c: 64
 
 


### PR DESCRIPTION
Kimi-K3 on GB200 defaulted to two NVL4 trays, or eight GPUs, for multi-node TP. The [K3 guide](https://vllm-project.github.io/2026/07/27/k3.html#performance-optimizations) requires at least 16 GB200 GPUs.

Set `strategy_min_gpus.gb200.multi_node_tp` to 16. The page and JSON API now use four trays with `--tensor-parallel-size 16 --nnodes 4`.

Fixes #934.

Validation:

- `node scripts/build-recipes-api.mjs` passed. Its variant-name warnings also occurred on the base branch.
- Checked the generated commands: TP16, four nodes, and ranks 0–3. The two Mooncake wrappers inherit this minimum; 67 other K3 API files stayed the same.
- Checked the local page: a two-node GB200 URL changes to four nodes. GB300 still allows two nodes and TP8.

No GPU run was performed.
